### PR TITLE
Remove IP filter

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -386,8 +386,8 @@ func (vm *VM) CreateHandlers() map[string]*commonEng.HTTPHandler {
 	handler.RegisterName("admin", &admin.Performance{})
 
 	return map[string]*commonEng.HTTPHandler{
-		"/rpc": &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: newIPFilter(handler)},
-		"/ws":  &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: newIPFilter(handler.WebsocketHandler([]string{"*"}))},
+		"/rpc": &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: handler},
+		"/ws":  &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: handler.WebsocketHandler([]string{"*"})},
 	}
 }
 
@@ -396,8 +396,8 @@ func (vm *VM) CreateStaticHandlers() map[string]*commonEng.HTTPHandler {
 	handler := rpc.NewServer()
 	handler.RegisterName("static", &StaticService{})
 	return map[string]*commonEng.HTTPHandler{
-		"/rpc": &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: newIPFilter(handler)},
-		"/ws":  &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: newIPFilter(handler.WebsocketHandler([]string{"*"}))},
+		"/rpc": &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: handler},
+		"/ws":  &commonEng.HTTPHandler{LockOptions: commonEng.NoLock, Handler: handler.WebsocketHandler([]string{"*"})},
 	}
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -10,8 +10,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"net"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -356,23 +354,6 @@ func (vm *VM) LastAccepted() ids.ID {
 	defer vm.metalock.Unlock()
 
 	return vm.lastAccepted.ID()
-}
-
-type ipFilter struct {
-	handler http.Handler
-}
-
-func (ipf ipFilter) ServeHTTP(writer http.ResponseWriter, request *http.Request) {
-	if ips, _, err := net.SplitHostPort(request.RemoteAddr); err == nil && ips == "127.0.0.1" {
-		ipf.handler.ServeHTTP(writer, request)
-		return
-	}
-	writer.WriteHeader(404)
-	writer.Write([]byte("404 page not found\r\n"))
-}
-
-func newIPFilter(handler http.Handler) http.Handler {
-	return ipFilter{handler}
 }
 
 // CreateHandlers makes new http handlers that can handle API calls


### PR DESCRIPTION
The IP filter was added to prevent calls from non-localhost, but gecko has its own access controls: including a flag to control the interface to bind to which defaults to the local interface, and soon an access token system.

@Determinant has confirmed that this is okay to remove given that the API is only available on the local interface by default already.