### PR TITLE
Add nil to newBlockChan if block verification errors

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -295,6 +295,7 @@ func (vm *VM) Initialize(
 			vm:       vm,
 		}
 		if blk.Verify() != nil {
+			vm.newBlockChan <- nil
 			return errInvalidBlock
 		}
 		vm.newBlockChan <- blk


### PR DESCRIPTION
Fixes #16 at base level. Previous PR #17 to fix it prevented invalid transactions from being added to the tx pool, but did not address problem of failing to build a block causing the chain to lock up and block forever on newBlockChan