### PR TITLE
add block extra data to eth_getBlockByNumber

### DIFF
--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -1161,6 +1161,10 @@ func RPCMarshalBlock(block *types.Block, inclTx bool, fullTx bool) (map[string]i
 	fields := RPCMarshalHeader(block.Header())
 	fields["size"] = hexutil.Uint64(block.Size())
 
+	if len(block.ExtraData()) != 0 {
+		fields["blockExtraData"] = hexutil.Encode(block.ExtraData())
+	}
+
 	if inclTx {
 		formatTx := func(tx *types.Transaction) (interface{}, error) {
 			return tx.Hash(), nil


### PR DESCRIPTION
Adjusts the eth_getBlockByNumber to include 'blockExtraData'...

Exposes [evm atomicTx](https://github.com/ava-labs/coreth/blob/ae4541f42a666fb5ae1c36d6f7423c3d9eb2c875/plugin/evm/vm.go#L188)


`curl -X POST --data "{\"id\":0,\"jsonrpc\":\"2.0\",\"method\":\"eth_getBlockByNumber\",\"params\":[\"latest\",false]}"  -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/rpc`

`{"jsonrpc":"2.0","id":0,"result":{"blockExtraData":"0x000000000000000000057f....","difficulty":"0x1","extraData":"0xd98301...","gasLimit":"0x2dbdfc6","gasUsed":"0x0","hash":"0x550165eb6e539a7c17fbd8f5624655ad7e4ff34d749a683f55b6063906890e46","logsBloom":"0x0000...","miner":"0x0100000000000000000000000000000000000000","mixHash":"0x00...","nonce":"0x0000000000000000","number":"0x2f0","parentHash":"0xca4a1ac1c043af92ca1b9ab46b5350c1b8f66d443f5ef072693a3248f1fede4b","receiptsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","size":"0x392","stateRoot":"0x45d24298fef6c74fe2df832259e14ebcae26d523e2dcff2f100b933dea717236","timestamp":"0x5f7f4c7a","totalDifficulty":"0x2f0","transactions":[],"transactionsRoot":"0x56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421","uncles":[]}}`

