### PR TITLE
Only `SetTail` for Accepted Blocks

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -955,6 +955,8 @@ func (bc *BlockChain) WriteCanonicalFromCurrentBlock() error {
 			log.Crit("Failed to update chain indexes and markers", "err", err)
 		}
 		bc.chainmu.Unlock()
+		totalUpdates += currentSize
+		log.Info("canonical chain update", "totalUpdates", totalUpdates)
 	}
 
 	return nil

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -83,14 +83,15 @@ var (
 )
 
 const (
-	bodyCacheLimit      = 256
-	blockCacheLimit     = 256
-	receiptsCacheLimit  = 32
-	txLookupCacheLimit  = 1024
-	maxFutureBlocks     = 256
-	maxTimeFutureBlocks = 30
-	badBlockLimit       = 10
-	TriesInMemory       = 128
+	bodyCacheLimit       = 256
+	blockCacheLimit      = 256
+	receiptsCacheLimit   = 32
+	txLookupCacheLimit   = 1024
+	maxFutureBlocks      = 256
+	maxTimeFutureBlocks  = 30
+	badBlockLimit        = 10
+	TriesInMemory        = 128
+	repairBlockBatchSize = 10
 
 	// BlockChainVersion ensures that an incompatible database forces a resync from scratch.
 	//
@@ -855,6 +856,108 @@ func (bc *BlockChain) GetBlockByNumber(number uint64) *types.Block {
 		return nil
 	}
 	return bc.GetBlock(hash, number)
+}
+
+func (bc *BlockChain) ValidateCanonicalChain() error {
+	current := bc.CurrentBlock()
+	for current.Hash() != bc.genesisBlock.Hash() {
+		blkByHash := bc.GetBlockByHash(current.Hash())
+		if blkByHash == nil {
+			return fmt.Errorf("couldn't find block by hash %s at height %d", current.Hash().String(), current.Number())
+		}
+		if blkByHash.Hash() != current.Hash() {
+			return fmt.Errorf("blockByHash returned a block with an unepected hash: %s, expected: %s", blkByHash.Hash().String(), current.Hash().String())
+		}
+		blkByNumber := bc.GetBlockByNumber(current.Number().Uint64())
+		if blkByNumber == nil {
+			return fmt.Errorf("couldn't find block by number at height %d", current.Number())
+		}
+		if blkByNumber.Hash() != current.Hash() {
+			return fmt.Errorf("blockByNumber returned a block with unexpected hash: %s, expected: %s", blkByNumber.Hash().String(), current.Hash().String())
+		}
+
+		// Ensure that all of the transactions have been stored correctly in the canonical
+		// chain
+		txs := current.Body().Transactions
+		for txIndex, tx := range txs {
+			txLookup := bc.GetTransactionLookup(tx.Hash())
+			if txLookup == nil {
+				return fmt.Errorf("failed to find transaction %s", tx.Hash())
+			}
+			if txLookup.BlockHash != current.Hash() {
+				return fmt.Errorf("tx lookup returned with incorrect block hash: %s, expected: %s", txLookup.BlockHash.String(), current.Hash().String())
+			}
+			if txLookup.BlockIndex != current.Number().Uint64() {
+				return fmt.Errorf("tx lookup returned with incorrect block index: %d, expected: %d", txLookup.BlockIndex, current.Number().Uint64())
+			}
+			if txLookup.Index != uint64(txIndex) {
+				return fmt.Errorf("tx lookup returned with incorrect transaction index: %d, expected: %d", txLookup.Index, txIndex)
+			}
+		}
+
+		current = bc.GetBlockByHash(current.ParentHash())
+	}
+
+	return nil
+}
+
+// WriteCanonicalFromCurrentBlock writes the canonical chain from the
+// current block to the genesis.
+// WriteCanonicalFromCurrentBlock only grabs the lock as necessary to
+// write batches to disk, such that it can be run in a goroutine.
+func (bc *BlockChain) WriteCanonicalFromCurrentBlock() error {
+	current := bc.CurrentBlock()
+
+	currentSize := 0
+	totalUpdates := 0
+	batch := bc.db.NewBatch()
+	log.Info("writing canonical chain from current block", "hash", current.Hash().String(), "number", current.NumberU64())
+
+	for current.Hash() != bc.genesisBlock.Hash() {
+		blkNumber := current.NumberU64()
+		canonicalBlk := bc.GetBlockByNumber(blkNumber)
+		if canonicalBlk == nil {
+			return fmt.Errorf("failed to get block by number at height: %d", blkNumber)
+		}
+		if canonicalBlk.Hash() == current.Hash() {
+			parent := bc.GetBlockByHash(current.ParentHash())
+			if parent == nil {
+				return fmt.Errorf("failed to get parent of block %s, with parent hash %s", current.Hash().String(), current.ParentHash().String())
+			}
+			current = parent
+			continue
+		}
+
+		// If the canonical blockhash at [blkNumber] is incorrect
+		// repair it here.
+		rawdb.WriteCanonicalHash(batch, current.Hash(), current.NumberU64())
+		rawdb.WriteTxLookupEntriesByBlock(batch, current)
+		currentSize += 1
+		if currentSize >= repairBlockBatchSize {
+			bc.chainmu.Lock()
+			// Flush the whole batch into the disk, exit the node if failed
+			if err := batch.Write(); err != nil {
+				bc.chainmu.Unlock()
+				return fmt.Errorf("failed to write batch with size %d at current block height %d: %s", currentSize, current.NumberU64(), err)
+			}
+			bc.chainmu.Unlock()
+			totalUpdates += currentSize
+			currentSize = 0
+			log.Info("canonical chain update", "currentBlock", current.NumberU64(), "totalUpdates", totalUpdates)
+		}
+	}
+
+	if currentSize > 0 {
+		bc.chainmu.Lock()
+		// Flush the whole batch into the disk, exit the node if failed
+		if err := batch.Write(); err != nil {
+			bc.chainmu.Unlock()
+			log.Crit("Failed to update chain indexes and markers", "err", err)
+		}
+		bc.chainmu.Unlock()
+	}
+
+	return nil
 }
 
 // GetReceiptsByHash retrieves the receipts for all transactions in a given block.

--- a/core/tx_pool.go
+++ b/core/tx_pool.go
@@ -18,6 +18,7 @@ package core
 
 import (
 	"errors"
+	"fmt"
 	"math"
 	"math/big"
 	"sort"
@@ -554,8 +555,8 @@ func (pool *TxPool) validateTx(tx *types.Transaction, local bool) error {
 	}
 	// Transactor should have enough funds to cover the costs
 	// cost == V + GP * GL
-	if pool.currentState.GetBalance(from).Cmp(tx.Cost()) < 0 {
-		return ErrInsufficientFunds
+	if balance := pool.currentState.GetBalance(from); balance.Cmp(tx.Cost()) < 0 {
+		return fmt.Errorf("insufficient funds for gas * price + value, balance: %d, cost: %d", balance, tx.Cost())
 	}
 	// Ensure the transaction has more gas than the basic tx fee.
 	intrGas, err := IntrinsicGas(tx.Data(), tx.To() == nil, true, pool.istanbul)

--- a/coreth.go
+++ b/coreth.go
@@ -171,6 +171,24 @@ func (self *ETHChain) GetBlockByHash(hash common.Hash) *types.Block {
 	return self.backend.BlockChain().GetBlockByHash(hash)
 }
 
+// Retrives a block from the database by number.
+func (self *ETHChain) GetBlockByNumber(num uint64) *types.Block {
+	return self.backend.BlockChain().GetBlockByNumber(num)
+}
+
+// Validate the canonical chain from current block to the genesis.
+// This should only be called as a convenience method in tests, not
+// in production as it traverses the entire chain.
+func (self *ETHChain) ValidateCanonicalChain() error {
+	return self.backend.BlockChain().ValidateCanonicalChain()
+}
+
+// WriteCanonicalFromCurrentBlock writes the canonical chain from the
+// current block to the genesis.
+func (self *ETHChain) WriteCanonicalFromCurrentBlock() error {
+	return self.backend.BlockChain().WriteCanonicalFromCurrentBlock()
+}
+
 // SetTail sets the current head block to the one defined by the hash
 // irrelevant what the chain contents were prior.
 func (self *ETHChain) SetTail(hash common.Hash) error {

--- a/coreth.go
+++ b/coreth.go
@@ -177,6 +177,9 @@ func (self *ETHChain) SetTail(hash common.Hash) error {
 	return self.backend.BlockChain().ManualHead(hash)
 }
 
+// SetPreference sets the block we should treat as the parent
+// when building future blocks. [block] may not yet be finalized
+// when this function is called.
 func (self *ETHChain) SetPreference(block *types.Block) {
 	self.backend.Miner().SetPreference(block)
 }

--- a/coreth.go
+++ b/coreth.go
@@ -178,7 +178,7 @@ func (self *ETHChain) SetTail(hash common.Hash) error {
 }
 
 func (self *ETHChain) SetPreference(block *types.Block) {
-	self.backend.Miner().SetPreferred(block)
+	self.backend.Miner().SetPreference(block)
 }
 
 func (self *ETHChain) GetReceiptsByHash(hash common.Hash) types.Receipts {

--- a/coreth.go
+++ b/coreth.go
@@ -177,6 +177,10 @@ func (self *ETHChain) SetTail(hash common.Hash) error {
 	return self.backend.BlockChain().ManualHead(hash)
 }
 
+func (self *ETHChain) SetPreference(block *types.Block) {
+	self.backend.Miner().SetPreferred(block)
+}
+
 func (self *ETHChain) GetReceiptsByHash(hash common.Hash) types.Receipts {
 	return self.backend.BlockChain().GetReceiptsByHash(hash)
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -140,6 +140,9 @@ func (miner *Miner) GetWorkerMux() *event.TypeMux {
 	return miner.worker.mux
 }
 
+// SetPreference sets the block we should treat as the parent
+// when building future blocks. [block] may not yet be finalized
+// when this function is called.
 func (miner *Miner) SetPreference(block *types.Block) {
 	miner.worker.setPreference(block)
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -141,5 +141,5 @@ func (miner *Miner) GetWorkerMux() *event.TypeMux {
 }
 
 func (miner *Miner) SetPreference(block *types.Block) {
-	miner.worker.SetPreference(block)
+	miner.worker.setPreference(block)
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -140,6 +140,6 @@ func (miner *Miner) GetWorkerMux() *event.TypeMux {
 	return miner.worker.mux
 }
 
-func (miner *Miner) SetPreferred(block *types.Block) {
-	miner.worker.SetPreferred(block)
+func (miner *Miner) SetPreference(block *types.Block) {
+	miner.worker.SetPreference(block)
 }

--- a/miner/miner.go
+++ b/miner/miner.go
@@ -139,3 +139,7 @@ func (miner *Miner) GenBlock() {
 func (miner *Miner) GetWorkerMux() *event.TypeMux {
 	return miner.worker.mux
 }
+
+func (miner *Miner) SetPreferred(block *types.Block) {
+	miner.worker.SetPreferred(block)
+}

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -267,13 +267,6 @@ func (w *worker) setPreference(block *types.Block) {
 	w.preferenceBlock = block
 }
 
-func (w *worker) getPreference() *types.Block {
-	w.mu.Lock()
-	defer w.mu.Unlock()
-
-	return w.preferenceBlock
-}
-
 // setEtherbase sets the etherbase used to initialize the block coinbase field.
 func (w *worker) setEtherbase(addr common.Address) {
 	w.mu.Lock()
@@ -925,7 +918,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 	defer w.mu.RUnlock()
 
 	tstart := time.Now()
-	parent := w.getPreference()
+	parent := w.preferenceBlock
 	if parent == nil {
 		// We should never have a nil preference as it is
 		// always initialized to be the last accepted block

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -199,8 +199,8 @@ type worker struct {
 	disableUncle   bool
 	minerCallbacks *MinerCallbacks
 
-	preferredBlock *types.Block
-	preferredMutex sync.Mutex
+	preferenceBlock *types.Block
+	preferenceMutex sync.Mutex
 }
 
 func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus.Engine, eth Backend, mux *event.TypeMux, isLocalBlock func(*types.Block) bool, init bool, mcb *MinerCallbacks) *worker {
@@ -259,19 +259,18 @@ func newWorker(config *Config, chainConfig *params.ChainConfig, engine consensus
 	return worker
 }
 
-func (w *worker) SetPreferred(block *types.Block) {
-	w.preferredMutex.Lock()
-	defer w.preferredMutex.Unlock()
+func (w *worker) SetPreference(block *types.Block) {
+	w.preferenceMutex.Lock()
+	defer w.preferenceMutex.Unlock()
 
-	w.preferredBlock = block
+	w.preferenceBlock = block
 }
 
-func (w *worker) GetPreferred() *types.Block {
-	w.preferredMutex.Lock()
-	defer w.preferredMutex.Unlock()
+func (w *worker) GetPreference() *types.Block {
+	w.preferenceMutex.Lock()
+	defer w.preferenceMutex.Unlock()
 
-	// TODO: do we need to copy this?
-	return w.preferredBlock
+	return w.preferenceBlock
 }
 
 // setEtherbase sets the etherbase used to initialize the block coinbase field.
@@ -926,7 +925,7 @@ func (w *worker) commitNewWork(interrupt *int32, noempty bool, timestamp int64) 
 
 	tstart := time.Now()
 	// TODO: need to get last preferred
-	parent := w.GetPreferred()
+	parent := w.GetPreference()
 	if parent == nil {
 		log.Error("Preferred parent not set")
 		return

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -513,8 +513,15 @@ func (vm *VM) GetBlock(id ids.ID) (snowman.Block, error) {
 
 // SetPreference sets what the current tail of the chain is
 func (vm *VM) SetPreference(blkID ids.ID) {
-	err := vm.chain.SetTail(common.Hash(blkID))
-	vm.ctx.Log.AssertNoError(err)
+	// TODO: set preference block to build on
+	block := vm.getBlock(blkID)
+	if block == nil {
+		// TODO: probably don
+		return
+	}
+
+	// TODO: convert to eth block
+	vm.chain.SetPreference(block.ethBlock)
 }
 
 // LastAccepted returns the ID of the block that was last accepted
@@ -603,6 +610,8 @@ func (vm *VM) updateStatus(blockID ids.ID, status choices.Status) {
 		if atomic.SwapUint32(&vm.writingMetadata, 1) == 0 {
 			go vm.ctx.Log.RecoverAndPanic(vm.writeBackMetadata)
 		}
+		err := vm.chain.SetTail(common.Hash(blockID))
+		vm.ctx.Log.AssertNoError(err)
 	}
 	vm.blockStatusCache.Put(blockID, status)
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -551,10 +551,7 @@ func (vm *VM) GetBlock(id ids.ID) (snowman.Block, error) {
 // SetPreference sets what the current tail of the chain is
 func (vm *VM) SetPreference(blkID ids.ID) {
 	block := vm.getBlock(blkID)
-	if block == nil {
-		vm.ctx.Log.Error("could not get preference block %s", blkID)
-		return
-	}
+	vm.ctx.Log.AssertTrue(block != nil, "problem setting preferred block, couldn't find blkID %s", blkID)
 
 	vm.chain.SetPreference(block.ethBlock)
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -61,9 +61,10 @@ var (
 	x2cRate = big.NewInt(1000000000)
 )
 
-const (
-	lastAcceptedKey = "snowman_lastAccepted"
-	acceptedPrefix  = "snowman_accepted"
+var (
+	lastAcceptedKey = []byte("snowman_lastAccepted")
+	acceptedPrefix  = []byte("snowman_accepted")
+	repairedKey     = []byte("repaired")
 )
 
 const (
@@ -158,6 +159,7 @@ type VM struct {
 	networkID    uint64
 	genesisHash  common.Hash
 	chain        *coreth.ETHChain
+	db           database.Database
 	chaindb      Database
 	newBlockChan chan *Block
 	// A message is sent on this channel when a new block
@@ -260,13 +262,14 @@ func (vm *VM) Initialize(
 
 	vm.shutdownChan = make(chan struct{}, 1)
 	vm.ctx = ctx
+	vm.db = db
 	vm.chaindb = Database{db}
 	g := new(core.Genesis)
 	if err := json.Unmarshal(b, g); err != nil {
 		return err
 	}
 
-	vm.acceptedDB = prefixdb.New([]byte(acceptedPrefix), db)
+	vm.acceptedDB = prefixdb.New(acceptedPrefix, db)
 
 	vm.chainID = g.Config.ChainID
 	vm.txFee = txFee
@@ -391,7 +394,7 @@ func (vm *VM) Initialize(
 	chain.Start()
 
 	var lastAccepted *types.Block
-	if b, err := vm.chaindb.Get([]byte(lastAcceptedKey)); err == nil {
+	if b, err := vm.chaindb.Get(lastAcceptedKey); err == nil {
 		var hash common.Hash
 		if err = rlp.DecodeBytes(b, &hash); err == nil {
 			if block := chain.GetBlockByHash(hash); block == nil {
@@ -417,6 +420,10 @@ func (vm *VM) Initialize(
 	vm.shutdownWg.Add(1)
 	go vm.ctx.Log.RecoverAndPanic(vm.awaitSubmittedTxs)
 	vm.codec = Codec
+	if err := vm.repairCanonicalChain(); err != nil {
+		return fmt.Errorf("problem during repair canonical chain: %w", err)
+	}
+
 	// The Codec explicitly registers the types it requires from the secp256k1fx
 	// so [vm.baseCodec] is a dummy codec use to fulfill the secp256k1fx VM
 	// interface. The fx will register all of its types, which can be safely
@@ -424,6 +431,35 @@ func (vm *VM) Initialize(
 	vm.baseCodec = linearcodec.NewDefault()
 
 	return vm.fx.Initialize(vm)
+}
+
+// repairCanonicalChain writes the canonical chain index from the last accepted
+// block back to the genesis block to overwrite any corruption that might have
+// occurred.
+// assumes that the genesisHash and [lastAccepted] block have already been set.
+func (vm *VM) repairCanonicalChain() error {
+	// Check if the canonical chain has already been repaired
+	if has, err := vm.db.Has(repairedKey); err != nil {
+		return err
+	} else if has {
+		return nil
+	}
+
+	go func() {
+		start := time.Now()
+		log.Info("starting to repair canonical chain", "startTime", start)
+		err := vm.chain.WriteCanonicalFromCurrentBlock()
+		if err != nil {
+			log.Error("failed to repair canonical chain", "error", err, "timeElapsed", time.Since(start))
+			return
+		}
+		log.Info("finished repairing canonical chain", "timeElapsed", time.Since(start))
+		if err := vm.db.Put(repairedKey, []byte("finished")); err != nil {
+			log.Error("failed to mark flag for canonical chain repaired", "error", err)
+		}
+	}()
+
+	return nil
 }
 
 // Bootstrapping notifies this VM that the consensus engine is performing
@@ -772,7 +808,7 @@ func (vm *VM) writeBackMetadata() {
 		return
 	}
 	log.Debug("writing back metadata")
-	vm.chaindb.Put([]byte(lastAcceptedKey), b)
+	vm.chaindb.Put(lastAcceptedKey, b)
 	atomic.StoreUint32(&vm.writingMetadata, 0)
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -410,6 +410,7 @@ func (vm *VM) Initialize(
 		ethBlock: lastAccepted,
 		vm:       vm,
 	}
+	vm.chain.SetPreference(lastAccepted)
 	vm.genesisHash = chain.GetGenesisBlock().Hash()
 	log.Info(fmt.Sprintf("lastAccepted = %s", vm.lastAccepted.ethBlock.Hash().Hex()))
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -513,14 +513,12 @@ func (vm *VM) GetBlock(id ids.ID) (snowman.Block, error) {
 
 // SetPreference sets what the current tail of the chain is
 func (vm *VM) SetPreference(blkID ids.ID) {
-	// TODO: set preference block to build on
 	block := vm.getBlock(blkID)
 	if block == nil {
-		// TODO: probably don
+		vm.ctx.Log.Error("could not get preference block %s", blkID)
 		return
 	}
 
-	// TODO: convert to eth block
 	vm.chain.SetPreference(block.ethBlock)
 }
 

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -246,6 +246,8 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
 	}
 
+	vm.SetPreference(blk.ID())
+
 	if err := blk.Accept(); err != nil {
 		t.Fatal(err)
 	}
@@ -372,6 +374,8 @@ func TestBuildEthTxBlock(t *testing.T) {
 	if status := blk.Status(); status != choices.Processing {
 		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
 	}
+
+	vm.SetPreference(blk.ID())
 
 	if err := blk.Accept(); err != nil {
 		t.Fatal(err)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
 )
 
 var (
@@ -536,5 +537,274 @@ func TestConflictingImportTxs(t *testing.T) {
 		if err == nil {
 			t.Fatalf("Block verification should have failed in BuildBlock %d due to double spending atomic UTXO", i)
 		}
+	}
+}
+
+// Regression test to ensure that after accepting block A
+// then calling SetPreference on block B (when it becomes preferred)
+// and the head of a longer chain (block D) does not corrupt the
+// canonical chain.
+//  A
+// / \
+// B  C
+//    |
+//    D
+func TestSetPreferenceRace(t *testing.T) {
+	// Create two VMs which will agree on block A and then
+	// build the two distinct preferred chains above
+	issuer1, vm1, _, sharedMemory1 := GenesisVM(t, true)
+	issuer2, vm2, _, sharedMemory2 := GenesisVM(t, true)
+
+	defer func() {
+		if err := vm1.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+		if err := vm2.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	key, err := coreth.NewKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Import 1 AVAX
+	importAmount := uint64(1000000000)
+	utxoID := avax.UTXOID{
+		TxID: ids.ID{
+			0x0f, 0x2f, 0x4f, 0x6f, 0x8e, 0xae, 0xce, 0xee,
+			0x0d, 0x2d, 0x4d, 0x6d, 0x8c, 0xac, 0xcc, 0xec,
+			0x0b, 0x2b, 0x4b, 0x6b, 0x8a, 0xaa, 0xca, 0xea,
+			0x09, 0x29, 0x49, 0x69, 0x88, 0xa8, 0xc8, 0xe8,
+		},
+	}
+
+	utxo := &avax.UTXO{
+		UTXOID: utxoID,
+		Asset:  avax.Asset{ID: vm1.ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: importAmount,
+			OutputOwners: secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{testKeys[0].PublicKey().Address()},
+			},
+		},
+	}
+	utxoBytes, err := vm1.codec.Marshal(codecVersion, utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xChainSharedMemory1 := sharedMemory1.NewSharedMemory(vm1.ctx.XChainID)
+	xChainSharedMemory2 := sharedMemory2.NewSharedMemory(vm2.ctx.XChainID)
+	inputID := utxo.InputID()
+	if err := xChainSharedMemory1.Put(vm1.ctx.ChainID, []*atomic.Element{{
+		Key:   inputID[:],
+		Value: utxoBytes,
+		Traits: [][]byte{
+			testKeys[0].PublicKey().Address().Bytes(),
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := xChainSharedMemory2.Put(vm2.ctx.ChainID, []*atomic.Element{{
+		Key:   inputID[:],
+		Value: utxoBytes,
+		Traits: [][]byte{
+			testKeys[0].PublicKey().Address().Bytes(),
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	importTx, err := vm1.newImportTx(vm1.ctx.XChainID, key.Address, []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm1.issueTx(importTx); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer1
+
+	vm1BlkA, err := vm1.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build block with import transaction: %s", err)
+	}
+
+	if err := vm1BlkA.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM1: %s", err)
+	}
+
+	if status := vm1BlkA.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm1.SetPreference(vm1BlkA.ID())
+
+	vm2BlkA, err := vm2.ParseBlock(vm1BlkA.Bytes())
+	if err != nil {
+		t.Fatalf("Unexpected error parsing block from vm2: %s", err)
+	}
+	if err := vm2BlkA.Verify(); err != nil {
+		t.Fatalf("Block failed verification on VM2: %s", err)
+	}
+	if status := vm2BlkA.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of block on VM2 to be %s, but found %s", choices.Processing, status)
+	}
+	vm2.SetPreference(vm2BlkA.ID())
+
+	if err := vm1BlkA.Accept(); err != nil {
+		t.Fatalf("VM1 failed to accept block: %s", err)
+	}
+	if err := vm2BlkA.Accept(); err != nil {
+		t.Fatalf("VM2 failed to accept block: %s", err)
+	}
+
+	// Create list of 10 successive transactions to build block A on vm1
+	// and to be split into two separate blocks on VM2
+	txs := make([]*types.Transaction, 10)
+	for i := 0; i < 10; i++ {
+		tx := types.NewTransaction(uint64(i), key.Address, big.NewInt(10), 21000, params.MinGasPrice, nil)
+		signedTx, err := types.SignTx(tx, types.NewEIP155Signer(vm1.chainID), key.PrivateKey)
+		if err != nil {
+			t.Fatal(err)
+		}
+		txs[i] = signedTx
+	}
+
+	var (
+		errs []error
+	)
+
+	// Add the remote transactions, build the block, and set VM1's preference for block A
+	errs = vm1.chain.AddRemoteTxs(txs)
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Failed to add transaction to VM1 at index %d: %s", i, err)
+		}
+	}
+
+	<-issuer1
+
+	vm1BlkB, err := vm1.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm1BlkB.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := vm1BlkB.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm1.SetPreference(vm1BlkB.ID())
+
+	// Split the transactions over two blocks, and set VM2's preference to them in sequence
+	// after building each block
+	// Block C
+	errs = vm2.chain.AddRemoteTxs(txs[0:5])
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Failed to add transaction to VM2 at index %d: %s", i, err)
+		}
+	}
+
+	<-issuer2
+	vm2BlkC, err := vm2.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build BlkC on VM2: %s", err)
+	}
+
+	if err := vm2BlkC.Verify(); err != nil {
+		t.Fatalf("BlkC failed verification on VM2: %s", err)
+	}
+
+	if status := vm2BlkC.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block C to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm2.SetPreference(vm2BlkC.ID())
+
+	// Block D
+	errs = vm2.chain.AddRemoteTxs(txs[5:10])
+	for i, err := range errs {
+		if err != nil {
+			t.Fatalf("Failed to add transaction to VM2 at index %d: %s", i, err)
+		}
+	}
+
+	<-issuer2
+	vm2BlkD, err := vm2.BuildBlock()
+	if err != nil {
+		t.Fatalf("Failed to build BlkD on VM2: %s", err)
+	}
+
+	if err := vm2BlkD.Verify(); err != nil {
+		t.Fatalf("BlkD failed verification on VM2: %s", err)
+	}
+
+	if status := vm2BlkD.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block D to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm2.SetPreference(vm2BlkD.ID())
+
+	// VM1 receives blkC and blkD from VM1
+	// and happens to call SetPreference on blkD without ever calling SetPreference
+	// on blkC
+	// Here we parse them in reverse order to simulate receiving a chain from the tip
+	// back to the last accepted block as would typically be the case in the consensus
+	// engine
+	vm1BlkD, err := vm1.ParseBlock(vm2BlkD.Bytes())
+	if err != nil {
+		t.Fatalf("VM1 errored parsing blkD: %s", err)
+	}
+	vm1BlkC, err := vm1.ParseBlock(vm2BlkC.Bytes())
+	if err != nil {
+		t.Fatalf("VM1 errored parsing blkC: %s", err)
+	}
+
+	// The blocks must be verified in order. This invariant is maintained
+	// in the consensus engine.
+	if err := vm1BlkC.Verify(); err != nil {
+		t.Fatalf("VM1 BlkC failed verification: %s", err)
+	}
+	if err := vm1BlkD.Verify(); err != nil {
+		t.Fatalf("VM1 BlkD failed verification: %s", err)
+	}
+
+	// Set VM1's preference to blockD, skipping blockC
+	vm1.SetPreference(vm1BlkD.ID())
+
+	// Accept the longer chain on both VMs and ensure there are no errors
+	// VM1 Accepts the blocks in order
+	if err := vm1BlkC.Accept(); err != nil {
+		t.Fatalf("VM1 BlkC failed on accept: %s", err)
+	}
+	if err := vm1BlkD.Accept(); err != nil {
+		t.Fatalf("VM1 BlkC failed on accept: %s", err)
+	}
+
+	// VM2 Accepts the blocks in order
+	if err := vm2BlkC.Accept(); err != nil {
+		t.Fatalf("VM2 BlkC failed on accept: %s", err)
+	}
+	if err := vm2BlkD.Accept(); err != nil {
+		t.Fatalf("VM2 BlkC failed on accept: %s", err)
+	}
+
+	log.Info("Validating canonical chain")
+	// Verify the Canonical Chain for Both VMs
+	if err := vm2.chain.ValidateCanonicalChain(); err != nil {
+		t.Fatalf("VM2 failed canonical chain verification due to: %s", err)
+	}
+
+	if err := vm1.chain.ValidateCanonicalChain(); err != nil {
+		t.Fatalf("VM1 failed canonical chain verification due to: %s", err)
 	}
 }


### PR DESCRIPTION
This PR alters the `vm` logic to only `SetTail` when a block has been accepted. To avoid creating additional contention on block production, this PR alters the `miner` to build off of the last preferred block (instead of the last block we called `SetTail` on).