### PR TITLE
[Tracer] Handle Empty Contract Deployments

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -195,10 +195,11 @@ func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (
 	// Don't bother with the execution if there's no code.
 	if len(contract.Code) == 0 {
 		if in.cfg.Debug {
-			// Even if we've done nothing, we need to invoke CaptureState here because the
-			// tracer relies on StateDB being populated. If a transaction contains
-			// a lone empty contract deployment and we don't set CaptureState here, the
-			// tracer could panic.
+			// Even if there's nothing to execute, we need to invoke CaptureState here because the
+			// tracer assumes StateDB is populated when GetResult is invoked.
+			//
+			// If a transaction only contains an contract deployment with no code and we don't set CaptureState here, the
+			// tracer will panic if any db-related methods are invoked.
 			in.cfg.Tracer.CaptureState(in.evm, pcCopy, op, gasCopy, cost, mem, stack, returns, in.returnData, contract, in.evm.depth, nil)
 		}
 		return nil, nil

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -211,6 +211,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 	// Push the wrapper for statedb.GetCode
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
 		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
+
 		ptr := ctx.PushFixedBuffer(len(code))
 		copy(makeSlice(ptr, uint(len(code))), code)
 		return 1

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -210,25 +210,7 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetCode
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		var code []byte
-		if dw.db != nil {
-			// When a transaction deploys an empty contract, dw.db will
-			// be nil when querying its code.
-			code = dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
-		}
-
-		// TODO: do we need to check for nil db on other calls here to protect
-		// against other scripts.
-
-		// TODO: make sure for empty contracts, we populate nil here
-
-		// TODO: try again on fresh box -> fixed this
-
-		// TODO: will selfdestruct on contract with no code access
-		// other db?
-
-		// TODO: why does memory stay around when we exit?
-
+		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
 		ptr := ctx.PushFixedBuffer(len(code))
 		copy(makeSlice(ptr, uint(len(code))), code)
 		return 1

--- a/eth/tracers/tracer.go
+++ b/eth/tracers/tracer.go
@@ -210,7 +210,24 @@ func (dw *dbWrapper) pushObject(vm *duktape.Context) {
 
 	// Push the wrapper for statedb.GetCode
 	vm.PushGoFunction(func(ctx *duktape.Context) int {
-		code := dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
+		var code []byte
+		if dw.db != nil {
+			// When a transaction deploys an empty contract, dw.db will
+			// be nil when querying its code.
+			code = dw.db.GetCode(common.BytesToAddress(popSlice(ctx)))
+		}
+
+		// TODO: do we need to check for nil db on other calls here to protect
+		// against other scripts.
+
+		// TODO: make sure for empty contracts, we populate nil here
+
+		// TODO: try again on fresh box -> fixed this
+
+		// TODO: will selfdestruct on contract with no code access
+		// other db?
+
+		// TODO: why does memory stay around when we exit?
 
 		ptr := ctx.PushFixedBuffer(len(code))
 		copy(makeSlice(ptr, uint(len(code))), code)


### PR DESCRIPTION
Related: https://github.com/ava-labs/avalanchego/issues/752

`debug_traceTransaction` will panic when tracing transactions (with this [script](https://github.com/poanetwork/blockscout/blob/master/apps/ethereum_jsonrpc/priv/js/ethereum_jsonrpc/geth/debug_traceTransaction/tracer.js)) that deploy contracts with no code. This was discovered when tracing `0xc0f33007b76c2d8675cdc34e979b94f3aab4778572be0b185115bbd4686f6a17` on `FUJI`.

The root cause of this issue is that the `dbWrapper.db` is not populated in the tracer when a transaction contains a lone contract deployment that has no code. `result` (called at the end of `debug_traceTransaction` assumes this wrapper was populated with `StateDB` at some point.