### PR TITLE
Add mempool for atomic transactions

### DIFF
--- a/plugin/evm/export_tx.go
+++ b/plugin/evm/export_tx.go
@@ -238,7 +238,6 @@ func (vm *VM) newExportTx(
 
 // EVMStateTransfer executes the state update from the atomic export transaction
 func (tx *UnsignedExportTx) EVMStateTransfer(vm *VM, state *state.StateDB) error {
-	addrs := map[[20]byte]uint64{}
 	var balanceDeltas []struct {
 		isAVAX bool
 		amount *big.Int
@@ -276,10 +275,10 @@ func (tx *UnsignedExportTx) EVMStateTransfer(vm *VM, state *state.StateDB) error
 				amount: amount,
 			})
 		}
-		addrs[from.Address] = from.Nonce
 	}
 
 	// Apply the state changes
+	addrs := map[[20]byte]uint64{}
 	for i, from := range tx.Ins {
 		log.Info("crosschain C->X", "addr", from.Address, "amount", from.Amount)
 		d := balanceDeltas[i]

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -1,0 +1,46 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import "github.com/ava-labs/avalanchego/ids"
+
+// Mempool is a simple mempool for atomic transactions
+type Mempool struct {
+	maxSize int
+	txs     map[ids.ID]*Tx
+}
+
+// NewMempool returns a Mempool with [maxSize]
+func NewMempool(maxSize int) *Mempool {
+	return &Mempool{
+		txs:     make(map[ids.ID]*Tx),
+		maxSize: maxSize,
+	}
+}
+
+// Add attempts to add [tx] to the mempool and returns true
+// if [tx] has been added to the mempool.
+func (m *Mempool) Add(tx *Tx) bool {
+	if m.Len() >= m.maxSize {
+		return false
+	}
+	txID := tx.ID()
+	if _, exists := m.txs[txID]; exists {
+		return true
+	}
+	m.txs[txID] = tx
+	return true
+}
+
+// Len returns the number of transactions in the mempool
+func (m *Mempool) Len() int { return len(m.txs) }
+
+// Remove attempts to remove a transaction from the mempool
+func (m *Mempool) Remove() (*Tx, bool) {
+	for txID, tx := range m.txs {
+		delete(m.txs, txID)
+		return tx, true
+	}
+	return nil, false
+}

--- a/plugin/evm/tx.go
+++ b/plugin/evm/tx.go
@@ -74,6 +74,8 @@ type UnsignedAtomicTx interface {
 	// Accept this transaction with the additionally provided state transitions.
 	Accept(ctx *snow.Context, batch database.Batch) error
 
+	// EVMStateTransfer executes the atomic transaction on [state]
+	// if it returns an error it does not change the state.
 	EVMStateTransfer(vm *VM, state *state.StateDB) error
 }
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -336,7 +336,7 @@ func (vm *VM) Initialize(
 		if len(txs) == 0 && len(atomicTxBytes) == 0 {
 			vm.newBlockChan <- nil
 			if lastErr != nil {
-				log.Error("Failed to finalize and assemble block with atomic transaction", "error", err)
+				log.Error("Failed to finalize and assemble block with atomic transaction", "error", lastErr)
 				return nil, lastErr
 			} else {
 				log.Error("Failed to finalzie and assemble block due to no transactions")

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -336,8 +336,10 @@ func (vm *VM) Initialize(
 		if len(txs) == 0 && len(atomicTxBytes) == 0 {
 			vm.newBlockChan <- nil
 			if lastErr != nil {
+				log.Error("Failed to finalize and assemble block with atomic transaction", "error", err)
 				return nil, lastErr
 			} else {
+				log.Error("Failed to finalzie and assemble block due to no transactions")
 				return nil, errEmptyBlock
 			}
 		}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -808,3 +808,117 @@ func TestSetPreferenceRace(t *testing.T) {
 		t.Fatalf("VM1 failed canonical chain verification due to: %s", err)
 	}
 }
+
+func TestReissueAtomicTx(t *testing.T) {
+	issuer, vm, _, sharedMemory := GenesisVM(t, true)
+
+	defer func() {
+		if err := vm.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	genesisBlkID := vm.LastAccepted()
+
+	importAmount := uint64(10000000)
+	utxoID := avax.UTXOID{
+		TxID: ids.ID{
+			0x0f, 0x2f, 0x4f, 0x6f, 0x8e, 0xae, 0xce, 0xee,
+			0x0d, 0x2d, 0x4d, 0x6d, 0x8c, 0xac, 0xcc, 0xec,
+			0x0b, 0x2b, 0x4b, 0x6b, 0x8a, 0xaa, 0xca, 0xea,
+			0x09, 0x29, 0x49, 0x69, 0x88, 0xa8, 0xc8, 0xe8,
+		},
+	}
+
+	utxo := &avax.UTXO{
+		UTXOID: utxoID,
+		Asset:  avax.Asset{ID: vm.ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: importAmount,
+			OutputOwners: secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{testKeys[0].PublicKey().Address()},
+			},
+		},
+	}
+	utxoBytes, err := vm.codec.Marshal(codecVersion, utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xChainSharedMemory := sharedMemory.NewSharedMemory(vm.ctx.XChainID)
+	inputID := utxo.InputID()
+	if err := xChainSharedMemory.Put(vm.ctx.ChainID, []*atomic.Element{{
+		Key:   inputID[:],
+		Value: utxoBytes,
+		Traits: [][]byte{
+			testKeys[0].PublicKey().Address().Bytes(),
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm.issueTx(importTx); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer
+
+	blk, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := blk.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm.SetPreference(blk.ID())
+
+	if err := blk.Reject(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Rejected {
+		t.Fatalf("Expected status of rejected block to be %s, but found %s", choices.Rejected, status)
+	}
+
+	vm.SetPreference(genesisBlkID)
+	<-issuer
+	blk, err = vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := blk.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm.SetPreference(blk.ID())
+
+	if err := blk.Accept(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Accepted {
+		t.Fatalf("Expected status of accepted block to be %s, but found %s", choices.Accepted, status)
+	}
+
+	lastAcceptedID := vm.LastAccepted()
+	if lastAcceptedID != blk.ID() {
+		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
+	}
+}


### PR DESCRIPTION
This PR adds a mempool for atomic transactions. When a block is rejected, if there is an atomic transaction present, it will be re-issued.