### PR TITLE
Add optional config for max blocks per getLogs request

### DIFF
--- a/coreth.go
+++ b/coreth.go
@@ -45,7 +45,7 @@ type ETHChain struct {
 }
 
 // NewETHChain creates an Ethereum blockchain with the given configs.
-func NewETHChain(config *eth.Config, nodecfg *node.Config, etherBase *common.Address, chainDB ethdb.Database) *ETHChain {
+func NewETHChain(config *eth.Config, nodecfg *node.Config, etherBase *common.Address, chainDB ethdb.Database, settings eth.Settings) *ETHChain {
 	if config == nil {
 		config = &eth.DefaultConfig
 	}
@@ -63,7 +63,7 @@ func NewETHChain(config *eth.Config, nodecfg *node.Config, etherBase *common.Add
 	cb := new(dummy.ConsensusCallbacks)
 	mcb := new(miner.MinerCallbacks)
 	bcb := new(eth.BackendCallbacks)
-	backend, _ := eth.New(node, config, cb, mcb, bcb, chainDB)
+	backend, _ := eth.New(node, config, cb, mcb, bcb, chainDB, settings)
 	chain := &ETHChain{backend: backend, cb: cb, mcb: mcb, bcb: bcb}
 	if etherBase == nil {
 		etherBase = &BlackholeAddr

--- a/examples/block/main.go
+++ b/examples/block/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"math/big"
+
 	"github.com/ava-labs/coreth"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/types"
@@ -15,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/rlp"
-	"math/big"
 )
 
 func checkError(err error) {
@@ -64,7 +65,7 @@ func main() {
 	config.Miner.ManualMining = true
 	config.Miner.DisableUncle = true
 
-	chain := coreth.NewETHChain(&config, nil, nil, nil)
+	chain := coreth.NewETHChain(&config, nil, nil, nil, eth.DefaultSettings)
 	buff := new(bytes.Buffer)
 	blk := chain.GetGenesisBlock()
 	err := blk.EncodeRLPEth(buff)

--- a/examples/chain/main.go
+++ b/examples/chain/main.go
@@ -6,6 +6,9 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
+	"math/big"
+	"sync"
+
 	"github.com/ava-labs/coreth"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/types"
@@ -15,8 +18,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"math/big"
-	"sync"
 )
 
 func checkError(err error) {
@@ -49,7 +50,7 @@ func NewTestChain(name string, config *eth.Config,
 		hasBlock:   make(map[common.Hash]struct{}),
 		blocks:     make([]common.Hash, 0),
 		blkCount:   0,
-		chain:      coreth.NewETHChain(config, nil, nil, nil),
+		chain:      coreth.NewETHChain(config, nil, nil, nil, eth.DefaultSettings),
 		outBlockCh: outBlockCh,
 	}
 	tc.insertBlock(tc.chain.GetGenesisBlock())

--- a/examples/counter/main.go
+++ b/examples/counter/main.go
@@ -8,6 +8,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"go/build"
+	"math/big"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+	"time"
+
 	"github.com/ava-labs/coreth"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/types"
@@ -17,13 +25,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/compiler"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
-	"go/build"
-	"math/big"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"syscall"
-	"time"
 )
 
 func checkError(err error) {
@@ -96,7 +97,7 @@ func main() {
 	gasPrice := big.NewInt(1000000000)
 
 	blockCount := 0
-	chain := coreth.NewETHChain(&config, nil, nil, nil)
+	chain := coreth.NewETHChain(&config, nil, nil, nil, eth.DefaultSettings)
 	newTxPoolHeadChan := make(chan core.NewTxPoolHeadEvent, 1)
 	log.Info(chain.GetGenesisBlock().Hash().Hex())
 	firstBlock := false

--- a/examples/multicoin/main.go
+++ b/examples/multicoin/main.go
@@ -8,6 +8,15 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"go/build"
+	"math/big"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
 	"github.com/ava-labs/coreth"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/types"
@@ -21,14 +30,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"go/build"
-	"math/big"
-	"os"
-	"os/signal"
-	"path/filepath"
-	"strings"
-	"syscall"
-	"time"
 )
 
 func checkError(err error) {
@@ -109,7 +110,7 @@ func main() {
 	gasPrice := big.NewInt(1000000000)
 
 	blockCount := 0
-	chain := coreth.NewETHChain(&config, nil, nil, nil)
+	chain := coreth.NewETHChain(&config, nil, nil, nil, eth.DefaultSettings)
 	newTxPoolHeadChan := make(chan core.NewTxPoolHeadEvent, 1)
 	log.Info(chain.GetGenesisBlock().Hash().Hex())
 

--- a/examples/payments/main.go
+++ b/examples/payments/main.go
@@ -6,6 +6,8 @@ package main
 import (
 	"crypto/rand"
 	"fmt"
+	"math/big"
+
 	"github.com/ava-labs/coreth"
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/types"
@@ -14,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/log"
-	"math/big"
 )
 
 func checkError(err error) {
@@ -70,7 +71,7 @@ func main() {
 	bob, err := coreth.NewKey(rand.Reader)
 	checkError(err)
 
-	chain := coreth.NewETHChain(&config, nil, nil, nil)
+	chain := coreth.NewETHChain(&config, nil, nil, nil, eth.DefaultSettings)
 	showBalance := func() {
 		state, err := chain.CurrentState()
 		checkError(err)

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -3,6 +3,8 @@
 
 package evm
 
+import "github.com/ava-labs/coreth/eth"
+
 // CommandLineConfig ...
 type CommandLineConfig struct {
 	// Coreth APIs
@@ -21,7 +23,8 @@ type CommandLineConfig struct {
 	DebugAPIEnabled    bool `json:"debug-api-enabled"`
 	Web3APIEnabled     bool `json:"web3-api-enabled"`
 
-	APIMaxDuration int64 `json:"api-max-duration"`
+	APIMaxDuration      int64 `json:"api-max-duration"`
+	MaxBlocksPerRequest int64 `json:"api-max-blocks-per-request"`
 
 	ParsingError error
 }
@@ -44,4 +47,8 @@ func (c CommandLineConfig) EthAPIs() []string {
 	}
 
 	return ethAPIs
+}
+
+func (c CommandLineConfig) EthBackendSettings() eth.Settings {
+	return eth.Settings{MaxBlocksPerRequest: c.MaxBlocksPerRequest}
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -297,7 +297,7 @@ func (vm *VM) Initialize(
 		panic(err)
 	}
 	nodecfg := node.Config{NoUSB: true}
-	chain := coreth.NewETHChain(&config, &nodecfg, nil, vm.chaindb)
+	chain := coreth.NewETHChain(&config, &nodecfg, nil, vm.chaindb, vm.CLIConfig.EthBackendSettings())
 	vm.chain = chain
 	vm.networkID = config.NetworkId
 	chain.SetOnHeaderNew(func(header *types.Header) {

--- a/plugin/params.go
+++ b/plugin/params.go
@@ -31,9 +31,10 @@ func init() {
 		cliConfig.TxPoolAPIEnabled = true
 		cliConfig.NetAPIEnabled = true
 		cliConfig.Web3APIEnabled = true
-		cliConfig.RPCGasCap = 2500000000 // 25000000 x 100
-		cliConfig.RPCTxFeeCap = 100      // 100 AVAX
-		cliConfig.APIMaxDuration = 0     // default to no maximum
+		cliConfig.RPCGasCap = 2500000000  // 25000000 x 100
+		cliConfig.RPCTxFeeCap = 100       // 100 AVAX
+		cliConfig.APIMaxDuration = 0      // Default to no maximum API Call duration
+		cliConfig.MaxBlocksPerRequest = 0 // Default to no maximum on the number of blocks per getLogs request
 	} else {
 		// TODO only overwrite values that were explicitly set
 		cliConfig.ParsingError = json.Unmarshal([]byte(*config), &cliConfig)


### PR DESCRIPTION
This PR creates an optional cap to set on the max number of blocks a GetLogs request will attempt to fetch.