### PR TITLE
Add  atomic tx mempool

### DIFF
--- a/coreth.go
+++ b/coreth.go
@@ -234,9 +234,10 @@ func (self *ETHChain) AttachEthService(handler *rpc.Server, namespaces []string)
 	}
 }
 
-// TODO: use SubscribeNewTxsEvent()
-func (self *ETHChain) GetTxSubmitCh() <-chan struct{} {
-	return self.backend.GetTxSubmitCh()
+func (self *ETHChain) GetTxSubmitCh() <-chan core.NewTxsEvent {
+	newTxsChan := make(chan core.NewTxsEvent)
+	self.backend.TxPool().SubscribeNewTxsEvent(newTxsChan)
+	return newTxsChan
 }
 
 func (self *ETHChain) GetTxPool() *core.TxPool {

--- a/coreth.go
+++ b/coreth.go
@@ -93,10 +93,6 @@ func (self *ETHChain) BlockChain() *core.BlockChain {
 	return self.backend.BlockChain()
 }
 
-func (self *ETHChain) UnlockIndexing() {
-	self.backend.BlockChain().UnlockIndexing()
-}
-
 func (self *ETHChain) VerifyBlock(block *types.Block) bool {
 	txnHash := types.DeriveSha(block.Transactions(), new(trie.Trie))
 	uncleHash := types.CalcUncleHash(block.Uncles())

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -259,10 +259,6 @@ func (b *EthAPIBackend) SendTx(ctx context.Context, signedTx *types.Transaction)
 		return errExpired
 	}
 	err := b.eth.txPool.AddLocal(signedTx)
-	select {
-	case b.eth.txSubmitChan <- struct{}{}:
-	default:
-	}
 	return err
 }
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -118,8 +118,7 @@ type Ethereum struct {
 
 	lock sync.RWMutex // Protects the variadic fields (e.g. gas price and etherbase)
 
-	txSubmitChan chan struct{}
-	bcb          *BackendCallbacks
+	bcb *BackendCallbacks
 
 	settings Settings // Settings for Ethereum API
 }
@@ -182,7 +181,6 @@ func New(stack *node.Node, config *Config,
 		bloomRequests:     make(chan chan *bloombits.Retrieval),
 		bloomIndexer:      NewBloomIndexer(chainDb, params.BloomBitsBlocks, params.BloomConfirms),
 		p2pServer:         stack.Server(),
-		txSubmitChan:      make(chan struct{}, 1),
 		bcb:               bcb,
 		settings:          settings,
 	}
@@ -570,10 +568,6 @@ func (s *Ethereum) StopPart() error {
 	s.chainDb.Close()
 	s.eventMux.Stop()
 	return nil
-}
-
-func (s *Ethereum) GetTxSubmitCh() <-chan struct{} {
-	return s.txSubmitChan
 }
 
 func (s *Ethereum) AcceptedBlock() *types.Block {

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7
-	github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9
+	github.com/ava-labs/avalanchego v1.2.1-0.20210218215124-641d0ad84c8c
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/edsrzf/mmap-go v1.0.0

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.5.7
-	github.com/ava-labs/avalanchego v1.1.4-rc.1.0.20210215143356-b3f8c4101a1a
+	github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.7.1
 	github.com/edsrzf/mmap-go v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -46,8 +46,8 @@ github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9 h1:saJ4SyMYTzpRCXyXYSk97qADmEG5q2ATd27RX1sPpx0=
-github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9/go.mod h1:ws5ncQjbLgsRIGotzy9BR487A8PxJryJNg0+gr91uNc=
+github.com/ava-labs/avalanchego v1.2.1-0.20210218215124-641d0ad84c8c h1:6ef94VoEvQkPGbVrZgujnE5mniWYCGBNfcDwYFAFUyI=
+github.com/ava-labs/avalanchego v1.2.1-0.20210218215124-641d0ad84c8c/go.mod h1:ws5ncQjbLgsRIGotzy9BR487A8PxJryJNg0+gr91uNc=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -48,6 +48,7 @@ github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmV
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/ava-labs/avalanchego v1.1.4-rc.1.0.20210215143356-b3f8c4101a1a h1:ckVYg2UpbqN6qmy71N+ZGpezeSRnukvfUOBOmOXQXF8=
 github.com/ava-labs/avalanchego v1.1.4-rc.1.0.20210215143356-b3f8c4101a1a/go.mod h1:Zm/+dPIz58K53OazgITQ8Lvk6PcesV4w/MdZ+3y1ygA=
+github.com/ava-labs/avalanchego v1.2.0 h1:7Fj/fSfIkyd8pe2wDQqzwUl6wdp06E/UfM2JAZ5E8t4=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/go.sum
+++ b/go.sum
@@ -46,6 +46,7 @@ github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
+github.com/ava-labs/avalanchego v1.2.0 h1:7Fj/fSfIkyd8pe2wDQqzwUl6wdp06E/UfM2JAZ5E8t4=
 github.com/ava-labs/avalanchego v1.2.1-0.20210218215124-641d0ad84c8c h1:6ef94VoEvQkPGbVrZgujnE5mniWYCGBNfcDwYFAFUyI=
 github.com/ava-labs/avalanchego v1.2.1-0.20210218215124-641d0ad84c8c/go.mod h1:ws5ncQjbLgsRIGotzy9BR487A8PxJryJNg0+gr91uNc=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=

--- a/go.sum
+++ b/go.sum
@@ -46,9 +46,8 @@ github.com/aristanetworks/goarista v0.0.0-20170210015632-ea17b1a17847/go.mod h1:
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/ava-labs/avalanchego v1.1.4-rc.1.0.20210215143356-b3f8c4101a1a h1:ckVYg2UpbqN6qmy71N+ZGpezeSRnukvfUOBOmOXQXF8=
-github.com/ava-labs/avalanchego v1.1.4-rc.1.0.20210215143356-b3f8c4101a1a/go.mod h1:Zm/+dPIz58K53OazgITQ8Lvk6PcesV4w/MdZ+3y1ygA=
-github.com/ava-labs/avalanchego v1.2.0 h1:7Fj/fSfIkyd8pe2wDQqzwUl6wdp06E/UfM2JAZ5E8t4=
+github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9 h1:saJ4SyMYTzpRCXyXYSk97qADmEG5q2ATd27RX1sPpx0=
+github.com/ava-labs/avalanchego v1.2.1-0.20210215220558-25a1ea82aaf9/go.mod h1:ws5ncQjbLgsRIGotzy9BR487A8PxJryJNg0+gr91uNc=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
@@ -249,6 +248,7 @@ github.com/julienschmidt/httprouter v1.2.0 h1:TDTW5Yz1mjftljbcKqRcrYhd4XeOoI98t+
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356 h1:I/yrLt2WilKxlQKCM52clh5rGzTKpVctGT1lH4Dc8Jw=
 github.com/karalabe/usb v0.0.0-20190919080040-51dc0efba356/go.mod h1:Od972xHfMJowv7NGVDiWVxk2zxnWgjLlJzE+F4F7AGU=
+github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0/go.mod h1:1NbS8ALrpOvjt0rHPNLyCIeMtbizbir8U//inJ+zuB8=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kkdai/bstream v0.0.0-20161212061736-f391b8402d23/go.mod h1:J+Gs4SYgM6CZQHDETBtE9HaSEkGmuNXF86RwHhHUvq4=

--- a/plugin/evm/client.go
+++ b/plugin/evm/client.go
@@ -46,13 +46,13 @@ func (c *Client) IssueTx(txBytes []byte) (ids.ID, error) {
 }
 
 // GetTxStatus returns the status of [txID]
-// func (c *Client) GetTxStatus(txID ids.ID) (choices.Status, error) {
-// 	res := &GetTxStatusReply{}
-// 	err := c.requester.SendRequest("getTxStatus", &api.JSONTxID{
-// 		TxID: txID,
-// 	}, res)
-// 	return res.Status, err
-// }
+func (c *Client) GetTxStatus(txID ids.ID) (Status, error) {
+	res := &GetTxStatusReply{}
+	err := c.requester.SendRequest("getTxStatus", &api.JSONTxID{
+		TxID: txID,
+	}, res)
+	return res.Status, err
+}
 
 // GetTx returns the byte representation of [txID]
 func (c *Client) GetTx(txID ids.ID) ([]byte, error) {

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -1,0 +1,210 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"sync"
+
+	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/ids"
+)
+
+// Mempool is a simple mempool for atomic transactions
+type Mempool struct {
+	lock sync.Mutex
+	// maxSize is the maximum number of transactions allowed to be kept in mempool
+	maxSize int
+	// currentTx is the transaction about to be added to a block.
+	currentTx *Tx
+	// txs is the set of transactions that need to be issued into new blocks
+	txs map[ids.ID]*Tx
+	// issuedTxs is the set of transactions that have been issued into a new block
+	issuedTxs map[ids.ID]*Tx
+	// discardedTxs is an LRU Cache of recently discarded transactions
+	discardedTxs *cache.LRU
+	// Pending is a channel that signals when the mempool is ready to put an atomic transaction
+	// into a new block
+	Pending chan struct{}
+}
+
+// NewMempool returns a Mempool with [maxSize]
+func NewMempool(maxSize int) *Mempool {
+	return &Mempool{
+		txs:          make(map[ids.ID]*Tx),
+		issuedTxs:    make(map[ids.ID]*Tx),
+		discardedTxs: &cache.LRU{Size: 10},
+		Pending:      make(chan struct{}, 1),
+		maxSize:      maxSize,
+	}
+}
+
+// Len returns the number of transactions in the mempool
+func (m *Mempool) Len() int {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	return m.length()
+}
+
+// assumes the lock is held
+func (m *Mempool) length() int {
+	return len(m.txs) + len(m.issuedTxs)
+}
+
+// Add attempts to add [tx] to the mempool and returns true if the
+// mempool requires a new block to be built.
+func (m *Mempool) AddTx(tx *Tx) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	txID := tx.ID()
+	// If [txID] has already been issued, there is no need to
+	// build a new block.
+	if _, exists := m.issuedTxs[txID]; exists {
+		return nil
+	}
+
+	// Each of the following cases results in there being a
+	// pending transaction, so we add to the channel here.
+	m.addPending()
+
+	if m.length() >= m.maxSize {
+		return errTooManyAtomicTx
+	}
+
+	if _, exists := m.txs[txID]; exists {
+		return nil
+	}
+
+	m.txs[txID] = tx
+	return nil
+}
+
+// NextTx returns a transaction to be issued from the mempool.
+func (m *Mempool) NextTx() (*Tx, bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	for txID, tx := range m.txs {
+		delete(m.txs, txID)
+		m.currentTx = tx
+		// If there are still atomic transactions remaining
+		// ensure there is an item on the pending channel.
+		if len(m.txs) > 0 {
+			m.addPending()
+		}
+		return tx, true
+	}
+
+	return nil, false
+}
+
+// GetTx returns the transaction [txID] if it was issued
+// by this node and returns whether it was dropped and whether
+// it exists.
+func (m *Mempool) GetTx(txID ids.ID) (*Tx, bool, bool) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if tx, ok := m.txs[txID]; ok {
+		return tx, false, true
+	}
+	if tx, ok := m.issuedTxs[txID]; ok {
+		return tx, false, true
+	}
+	if m.currentTx != nil && m.currentTx.ID() == txID {
+		return m.currentTx, false, true
+	}
+	if tx, exists := m.discardedTxs.Get(txID); exists {
+		return tx.(*Tx), true, true
+	}
+
+	return nil, false, false
+}
+
+// IssueCurrentTx marks [currentTx] as issued if there is one
+func (m *Mempool) IssueCurrentTx() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.currentTx != nil {
+		m.issuedTxs[m.currentTx.ID()] = m.currentTx
+		m.currentTx = nil
+	}
+
+	if len(m.txs) > 0 {
+		m.addPending()
+	}
+}
+
+// CancelCurrentTx marks the attempt to issue [currentTx]
+// as being aborted. If this is called after a buildBlock error
+// caused by the atomic transaction, then DiscardCurrentTx should have been called
+// such that this call will have no effect and should not re-issue the invalid tx.
+func (m *Mempool) CancelCurrentTx() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.currentTx != nil {
+		m.txs[m.currentTx.ID()] = m.currentTx
+		m.currentTx = nil
+	}
+
+	// If the VM failed to build a block for any reason
+	// make sure there is an item on the Pending channel if
+	// there are any more transactions to issue.
+	if len(m.txs) > 0 {
+		m.addPending()
+	}
+}
+
+// DiscardCurrentTx marks [currentTx] as invalid and aborts the attempt
+// to issue it since it failed verification.
+func (m *Mempool) DiscardCurrentTx() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.currentTx == nil {
+		return
+	}
+
+	m.discardedTxs.Put(m.currentTx.ID(), m.currentTx)
+	m.currentTx = nil
+}
+
+// RemoveTx removes [txID] from the mempool completely.
+func (m *Mempool) RemoveTx(txID ids.ID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if m.currentTx != nil && m.currentTx.ID() == txID {
+		m.currentTx = nil
+	}
+	delete(m.txs, txID)
+	delete(m.issuedTxs, txID)
+}
+
+// RejectTx marks [txID] as being rejected and attempts to re-issue
+// it if it was previously in the mempool.
+func (m *Mempool) RejectTx(txID ids.ID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	tx, ok := m.issuedTxs[txID]
+	if !ok {
+		return
+	}
+	// If the transaction was issued by the mempool, add it back
+	// to transactions pending issuance.
+	m.txs[txID] = tx
+	m.addPending()
+}
+
+// addPending makes sure that an item is added to the pending channel
+func (m *Mempool) addPending() {
+	select {
+	case m.Pending <- struct{}{}:
+	default:
+	}
+}

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -197,6 +197,7 @@ func (m *Mempool) RemoveTx(txID ids.ID) {
 	}
 	delete(m.txs, txID)
 	delete(m.issuedTxs, txID)
+	m.discardedTxs.Evict(txID)
 }
 
 // RejectTx marks [txID] as being rejected and attempts to re-issue

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -89,7 +89,8 @@ func (api *SnowmanAPI) GetAcceptedFront(ctx context.Context) (*GetAcceptedFrontR
 func (api *SnowmanAPI) IssueBlock(ctx context.Context) error {
 	log.Info("Issuing a new block")
 
-	return api.vm.tryBlockGen()
+	api.vm.signalTxsReady()
+	return nil
 }
 
 // parseAssetID parses an assetID string into an ID

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -445,10 +445,10 @@ func (service *AvaxAPI) GetTxStatus(r *http.Request, args *api.JSONTxID, reply *
 
 	_, status, height, _ := service.vm.getAtomicTx(args.TxID)
 
+	reply.Status = status
 	if status == Accepted {
 		reply.BlockHeight = &height
 	}
-	reply.Status = status
 	return nil
 }
 
@@ -465,9 +465,13 @@ func (service *AvaxAPI) GetTx(r *http.Request, args *api.GetTxArgs, reply *Forma
 		return errNilTxID
 	}
 
-	tx, status, height, found := service.vm.getAtomicTx(args.TxID)
-	if !found {
-		return fmt.Errorf("could not find atomic tx %s", args.TxID)
+	tx, status, height, err := service.vm.getAtomicTx(args.TxID)
+	if err != nil {
+		return err
+	}
+
+	if status == Unknown {
+		return fmt.Errorf("could not find tx %s", args.TxID)
 	}
 
 	txBytes, err := formatting.Encode(args.Encoding, tx.Bytes())

--- a/plugin/evm/status.go
+++ b/plugin/evm/status.go
@@ -5,6 +5,7 @@ package evm
 
 import (
 	"errors"
+	"fmt"
 )
 
 var (
@@ -31,7 +32,7 @@ func (s Status) MarshalJSON() ([]byte, error) {
 	if err := s.Valid(); err != nil {
 		return nil, err
 	}
-	return []byte("\"" + s.String() + "\""), nil
+	return []byte(fmt.Sprintf("%q", s)), nil
 }
 
 // UnmarshalJSON ...

--- a/plugin/evm/status.go
+++ b/plugin/evm/status.go
@@ -1,0 +1,81 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package evm
+
+import (
+	"errors"
+)
+
+var (
+	errUnknownStatus = errors.New("unknown status")
+)
+
+// Status ...
+type Status uint32
+
+// List of possible status values
+// [Unknown] Zero value, means the status is not known
+// [Dropped] means the transaction was in the mempool, but was dropped because it failed verification
+// [Processing] means the transaction is in the mempool
+// [Accepted] means the transaction was accepted
+const (
+	Unknown Status = iota
+	Dropped
+	Processing
+	Accepted
+)
+
+// MarshalJSON ...
+func (s Status) MarshalJSON() ([]byte, error) {
+	if err := s.Valid(); err != nil {
+		return nil, err
+	}
+	return []byte("\"" + s.String() + "\""), nil
+}
+
+// UnmarshalJSON ...
+func (s *Status) UnmarshalJSON(b []byte) error {
+	str := string(b)
+	if str == "null" {
+		return nil
+	}
+	switch str {
+	case "\"Unknown\"":
+		*s = Unknown
+	case "\"Dropped\"":
+		*s = Dropped
+	case "\"Processing\"":
+		*s = Processing
+	case "\"Accepted\"":
+		*s = Accepted
+	default:
+		return errUnknownStatus
+	}
+	return nil
+}
+
+// Valid returns nil if the status is a valid status.
+func (s Status) Valid() error {
+	switch s {
+	case Unknown, Dropped, Processing, Accepted:
+		return nil
+	default:
+		return errUnknownStatus
+	}
+}
+
+func (s Status) String() string {
+	switch s {
+	case Unknown:
+		return "Unknown"
+	case Dropped:
+		return "Dropped"
+	case Processing:
+		return "Processing"
+	case Accepted:
+		return "Accepted"
+	default:
+		return "Invalid status"
+	}
+}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -303,14 +303,14 @@ func TestIssueAtomicTxs(t *testing.T) {
 	}
 
 	// Check that both atomic transactions were indexed as expected.
-	indexedImportTx, status, height, found := vm.getAtomicTx(importTx.ID())
-	assert.True(t, found)
+	indexedImportTx, status, height, err := vm.getAtomicTx(importTx.ID())
+	assert.NoError(t, err)
 	assert.Equal(t, Accepted, status)
 	assert.Equal(t, uint64(1), height, "expected height of indexed import tx to be 1")
 	assert.Equal(t, indexedImportTx.ID(), importTx.ID(), "expected ID of indexed import tx to match original txID")
 
-	indexedExportTx, status, height, found := vm.getAtomicTx(exportTx.ID())
-	assert.True(t, found)
+	indexedExportTx, status, height, err := vm.getAtomicTx(exportTx.ID())
+	assert.NoError(t, err)
 	assert.Equal(t, Accepted, status)
 	assert.Equal(t, uint64(2), height, "expected height of indexed export tx to be 2")
 	assert.Equal(t, indexedExportTx.ID(), exportTx.ID(), "expected ID of indexed import tx to match original txID")
@@ -1233,5 +1233,125 @@ func TestReissueAtomicTx(t *testing.T) {
 	lastAcceptedID := vm.LastAccepted()
 	if lastAcceptedID != blk.ID() {
 		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
+	}
+}
+
+func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {
+	issuer, vm, _, sharedMemory := GenesisVM(t, true)
+
+	defer func() {
+		if err := vm.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	importAmount := uint64(10000000)
+	utxoID := avax.UTXOID{
+		TxID: ids.ID{
+			0x0f, 0x2f, 0x4f, 0x6f, 0x8e, 0xae, 0xce, 0xee,
+			0x0d, 0x2d, 0x4d, 0x6d, 0x8c, 0xac, 0xcc, 0xec,
+			0x0b, 0x2b, 0x4b, 0x6b, 0x8a, 0xaa, 0xca, 0xea,
+			0x09, 0x29, 0x49, 0x69, 0x88, 0xa8, 0xc8, 0xe8,
+		},
+	}
+
+	utxo := &avax.UTXO{
+		UTXOID: utxoID,
+		Asset:  avax.Asset{ID: vm.ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: importAmount,
+			OutputOwners: secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{testKeys[0].PublicKey().Address()},
+			},
+		},
+	}
+	utxoBytes, err := vm.codec.Marshal(codecVersion, utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xChainSharedMemory := sharedMemory.NewSharedMemory(vm.ctx.XChainID)
+	inputID := utxo.InputID()
+	if err := xChainSharedMemory.Put(vm.ctx.ChainID, []*atomic.Element{{
+		Key:   inputID[:],
+		Value: utxoBytes,
+		Traits: [][]byte{
+			testKeys[0].PublicKey().Address().Bytes(),
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm.issueTx(importTx); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer
+
+	blk, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := blk.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm.SetPreference(blk.ID())
+
+	if err := blk.Accept(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Accepted {
+		t.Fatalf("Expected status of accepted block to be %s, but found %s", choices.Accepted, status)
+	}
+
+	lastAcceptedID := vm.LastAccepted()
+	if lastAcceptedID != blk.ID() {
+		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
+	}
+
+	exportTx1, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-vm.txFee-1, vm.ctx.XChainID, testShortIDAddrs[0], []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+	exportTx2, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-vm.txFee-1, vm.ctx.XChainID, testShortIDAddrs[1], []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm.issueTx(exportTx1); err != nil {
+		t.Fatal(err)
+	}
+	<-issuer
+	exportBlk1, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := exportBlk1.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	vm.SetPreference(exportBlk1.ID())
+
+	if err := vm.issueTx(exportTx2); err != nil {
+		t.Fatal(err)
+	}
+	<-issuer
+
+	_, err = vm.BuildBlock()
+	if err == nil {
+		t.Fatal("BuildBlock should have returned an error due to invalid export transaction")
 	}
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -303,15 +303,15 @@ func TestIssueAtomicTxs(t *testing.T) {
 	}
 
 	// Check that both atomic transactions were indexed as expected.
-	indexedImportTx, height, err := vm.getAtomicTx(importTx.ID())
-	assert.NoError(t, err)
-
+	indexedImportTx, status, height, found := vm.getAtomicTx(importTx.ID())
+	assert.True(t, found)
+	assert.Equal(t, Accepted, status)
 	assert.Equal(t, uint64(1), height, "expected height of indexed import tx to be 1")
 	assert.Equal(t, indexedImportTx.ID(), importTx.ID(), "expected ID of indexed import tx to match original txID")
 
-	indexedExportTx, height, err := vm.getAtomicTx(exportTx.ID())
-	assert.NoError(t, err)
-
+	indexedExportTx, status, height, found := vm.getAtomicTx(exportTx.ID())
+	assert.True(t, found)
+	assert.Equal(t, Accepted, status)
 	assert.Equal(t, uint64(2), height, "expected height of indexed export tx to be 2")
 	assert.Equal(t, indexedExportTx.ID(), exportTx.ID(), "expected ID of indexed import tx to match original txID")
 }
@@ -939,13 +939,18 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	importTx0, err := vm.newImportTx(vm.ctx.XChainID, key.Address, []*crypto.PrivateKeySECP256K1R{key0})
+	importTx0A, err := vm.newImportTx(vm.ctx.XChainID, key.Address, []*crypto.PrivateKeySECP256K1R{key0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Create a conflicting transaction
+	importTx0B, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[2], []*crypto.PrivateKeySECP256K1R{key0})
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if err := vm.issueTx(importTx0); err != nil {
-		t.Fatal(err)
+	if err := vm.issueTx(importTx0A); err != nil {
+		t.Fatalf("Failed to issue importTx0A: %s", err)
 	}
 
 	<-issuer
@@ -979,18 +984,18 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 
 	blk1, err := vm.BuildBlock()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to build blk1: %s", err)
 	}
 
 	if err := blk1.Verify(); err != nil {
-		t.Fatal(err)
+		t.Fatalf("blk1 failed verification due to %s", err)
 	}
 
 	vm.SetPreference(blk1.ID())
 
 	importTx1, err := vm.newImportTx(vm.ctx.XChainID, key.Address, []*crypto.PrivateKeySECP256K1R{key1})
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("Failed to issue importTx1 due to: %s", err)
 	}
 
 	if err := vm.issueTx(importTx1); err != nil {
@@ -1010,8 +1015,8 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 
 	vm.SetPreference(blk2.ID())
 
-	if err := vm.issueTx(importTx0); err != nil {
-		t.Fatal(err)
+	if err := vm.issueTx(importTx0B); err != nil {
+		t.Fatalf("Failed to issue importTx0B due to: %s", err)
 	}
 
 	<-issuer
@@ -1113,6 +1118,120 @@ func TestBonusBlocksTxs(t *testing.T) {
 
 	lastAcceptedID := vm.LastAccepted()
 	if lastAcceptedID != evmBlock.ID() {
+		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
+	}
+}
+
+func TestReissueAtomicTx(t *testing.T) {
+	issuer, vm, _, sharedMemory := GenesisVM(t, true)
+
+	defer func() {
+		if err := vm.Shutdown(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	genesisBlkID := vm.LastAccepted()
+
+	importAmount := uint64(10000000)
+	utxoID := avax.UTXOID{
+		TxID: ids.ID{
+			0x0f, 0x2f, 0x4f, 0x6f, 0x8e, 0xae, 0xce, 0xee,
+			0x0d, 0x2d, 0x4d, 0x6d, 0x8c, 0xac, 0xcc, 0xec,
+			0x0b, 0x2b, 0x4b, 0x6b, 0x8a, 0xaa, 0xca, 0xea,
+			0x09, 0x29, 0x49, 0x69, 0x88, 0xa8, 0xc8, 0xe8,
+		},
+	}
+
+	utxo := &avax.UTXO{
+		UTXOID: utxoID,
+		Asset:  avax.Asset{ID: vm.ctx.AVAXAssetID},
+		Out: &secp256k1fx.TransferOutput{
+			Amt: importAmount,
+			OutputOwners: secp256k1fx.OutputOwners{
+				Threshold: 1,
+				Addrs:     []ids.ShortID{testKeys[0].PublicKey().Address()},
+			},
+		},
+	}
+	utxoBytes, err := vm.codec.Marshal(codecVersion, utxo)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	xChainSharedMemory := sharedMemory.NewSharedMemory(vm.ctx.XChainID)
+	inputID := utxo.InputID()
+	if err := xChainSharedMemory.Put(vm.ctx.ChainID, []*atomic.Element{{
+		Key:   inputID[:],
+		Value: utxoBytes,
+		Traits: [][]byte{
+			testKeys[0].PublicKey().Address().Bytes(),
+		},
+	}}); err != nil {
+		t.Fatal(err)
+	}
+
+	importTx, err := vm.newImportTx(vm.ctx.XChainID, testEthAddrs[0], []*crypto.PrivateKeySECP256K1R{testKeys[0]})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := vm.issueTx(importTx); err != nil {
+		t.Fatal(err)
+	}
+
+	<-issuer
+
+	blk, err := vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := blk.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm.SetPreference(blk.ID())
+
+	if err := blk.Reject(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Rejected {
+		t.Fatalf("Expected status of rejected block to be %s, but found %s", choices.Rejected, status)
+	}
+
+	vm.SetPreference(genesisBlkID)
+	<-issuer
+	blk, err = vm.BuildBlock()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := blk.Verify(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Processing {
+		t.Fatalf("Expected status of built block to be %s, but found %s", choices.Processing, status)
+	}
+
+	vm.SetPreference(blk.ID())
+
+	if err := blk.Accept(); err != nil {
+		t.Fatal(err)
+	}
+
+	if status := blk.Status(); status != choices.Accepted {
+		t.Fatalf("Expected status of accepted block to be %s, but found %s", choices.Accepted, status)
+	}
+
+	lastAcceptedID := vm.LastAccepted()
+	if lastAcceptedID != blk.ID() {
 		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
 	}
 }


### PR DESCRIPTION
This PR adds a mempool for atomic transactions. Since building a block may error at multiple stages and invokes multiple callbacks through the dummy consensus engine, the VM needs to signal to the mempool when a potential atomic tx has been issued into a block, fails verification, and whether or not block building was successful.

This PR also updates the getTx and getTxStatus endpoints to return transactions if they are in the mempool and adds a new Status type to include transactions that were "Dropped" from the mempool due to failing verification.