### PR TITLE
Add pubsub event listener for C-Chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ For the full documentation of precompiles for interacting with ANTs and using th
 Blocks are produced asynchronously in Snowman Consensus, so the timing assumptions that apply to Ethereum do not apply to Coreth. To support block production in an async environment, a block is permitted to have the same timestamp as its parent. Since there is no general assumption that a block will be produced every 10 seconds, smart contracts built on Avalanche should use the block timestamp instead of the block number for their timing assumptions.
 
 A block with a timestamp more than 10 seconds in the future will not be considered valid. However, a block with a timestamp more than 10 seconds in the past will still be considered valid as long as its timestamp is greater than or equal to the timestamp of its parent block.
+

--- a/go.sum
+++ b/go.sum
@@ -523,6 +523,7 @@ github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIK
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2 h1:m8/z1t7/fwjysjQRYbP0RD+bUIF/8tJwPdEZsI83ACI=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -133,7 +133,7 @@ func (b *Block) Accept() error {
 		if err := vm.writeAtomicTx(b, tx); err != nil {
 			return err
 		}
-		chainID, txRequest, err := tx.UnsignedAtomicTx.Accept()
+		chainID, txRequest, err := tx.UnsignedAtomicTx.Accept(vm)
 		if err != nil {
 			return err
 		}

--- a/plugin/evm/export_tx.go
+++ b/plugin/evm/export_tx.go
@@ -231,7 +231,7 @@ func (tx *UnsignedExportTx) SemanticVerify(
 }
 
 // Accept this transaction.
-func (tx *UnsignedExportTx) Accept() (vm *VM, ids.ID, *atomic.Requests, error) {
+func (tx *UnsignedExportTx) Accept(vm *VM) (ids.ID, *atomic.Requests, error) {
 	txID := tx.ID()
 
 	elems := make([]*atomic.Element, len(tx.ExportedOutputs))
@@ -261,7 +261,7 @@ func (tx *UnsignedExportTx) Accept() (vm *VM, ids.ID, *atomic.Requests, error) {
 		elems[i] = elem
 	}
 
-	vm.pubsub.Publish(tx.ID(), NewPubSubExportFilterer(tx))
+	vm.pubsub.Publish(NewPubSubExportFilterer(tx))
 
 	return tx.DestinationChain, &atomic.Requests{PutRequests: elems}, nil
 }

--- a/plugin/evm/export_tx.go
+++ b/plugin/evm/export_tx.go
@@ -231,7 +231,7 @@ func (tx *UnsignedExportTx) SemanticVerify(
 }
 
 // Accept this transaction.
-func (tx *UnsignedExportTx) Accept() (ids.ID, *atomic.Requests, error) {
+func (tx *UnsignedExportTx) Accept() (vm *VM, ids.ID, *atomic.Requests, error) {
 	txID := tx.ID()
 
 	elems := make([]*atomic.Element, len(tx.ExportedOutputs))
@@ -260,6 +260,8 @@ func (tx *UnsignedExportTx) Accept() (ids.ID, *atomic.Requests, error) {
 
 		elems[i] = elem
 	}
+
+	vm.pubsub.Publish(tx.ID(), NewPubSubExportFilterer(tx))
 
 	return tx.DestinationChain, &atomic.Requests{PutRequests: elems}, nil
 }

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -999,7 +999,7 @@ func TestExportTxAccept(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create commit batch for VM due to %s", err)
 	}
-	chainID, atomicRequests, err := tx.Accept()
+	chainID, atomicRequests, err := tx.Accept(vm)
 	if err != nil {
 		t.Fatalf("Failed to accept export transaction due to: %s", err)
 	}
@@ -1621,7 +1621,7 @@ func TestNewExportTx(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create commit batch for VM due to %s", err)
 			}
-			chainID, atomicRequests, err := exportTx.Accept()
+			chainID, atomicRequests, err := exportTx.Accept(vm)
 
 			if err != nil {
 				t.Fatalf("Failed to accept export transaction due to: %s", err)
@@ -1809,7 +1809,7 @@ func TestNewExportTxMulticoin(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Failed to create commit batch for VM due to %s", err)
 			}
-			chainID, atomicRequests, err := exportTx.Accept()
+			chainID, atomicRequests, err := exportTx.Accept(vm)
 
 			if err != nil {
 				t.Fatalf("Failed to accept export transaction due to: %s", err)

--- a/plugin/evm/import_tx.go
+++ b/plugin/evm/import_tx.go
@@ -257,13 +257,13 @@ func (tx *UnsignedImportTx) SemanticVerify(
 // we don't want to remove an imported UTXO in semanticVerify
 // only to have the transaction not be Accepted. This would be inconsistent.
 // Recall that imported UTXOs are not kept in a versionDB.
-func (tx *UnsignedImportTx) Accept() (ids.ID, *atomic.Requests, error) {
+func (tx *UnsignedImportTx) Accept(vm *VM) (ids.ID, *atomic.Requests, error) {
 	utxoIDs := make([][]byte, len(tx.ImportedInputs))
 	for i, in := range tx.ImportedInputs {
 		inputID := in.InputID()
 		utxoIDs[i] = inputID[:]
 	}
-	tx.vm.pubsub.Publish(tx.ID(), NewPubSubFilterer(tx))
+	vm.pubsub.Publish(NewPubSubImportFilterer(tx))
 
 	return tx.SourceChain, &atomic.Requests{RemoveRequests: utxoIDs}, nil
 }

--- a/plugin/evm/import_tx.go
+++ b/plugin/evm/import_tx.go
@@ -35,6 +35,16 @@ type UnsignedImportTx struct {
 	ImportedInputs []*avax.TransferableInput `serialize:"true" json:"importedInputs"`
 	// Outputs
 	Outs []EVMOutput `serialize:"true" json:"outputs"`
+
+	vm *VM
+}
+
+func (tx *UnsignedImportTx) Addresses() [][]byte {
+	addrs := make([][]byte, len(tx.Outs))
+	for i, out := range tx.Outs {
+		addrs[i] = out.Address.Bytes()
+	}
+	return addrs
 }
 
 // InputUTXOs returns the UTXOIDs of the imported funds
@@ -253,6 +263,8 @@ func (tx *UnsignedImportTx) Accept() (ids.ID, *atomic.Requests, error) {
 		inputID := in.InputID()
 		utxoIDs[i] = inputID[:]
 	}
+	tx.vm.pubsub.Publish(tx.ID(), NewPubSubFilterer(tx))
+
 	return tx.SourceChain, &atomic.Requests{RemoveRequests: utxoIDs}, nil
 }
 

--- a/plugin/evm/pubsub_filterer.go
+++ b/plugin/evm/pubsub_filterer.go
@@ -1,0 +1,33 @@
+package evm
+
+import (
+	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/pubsub"
+)
+
+var _ pubsub.Filterer = &filterer{}
+
+type filterer struct {
+	tx *UnsignedImportTx
+}
+
+func NewPubSubFilterer(tx *UnsignedImportTx) pubsub.Filterer {
+	return &filterer{tx: tx}
+}
+
+// Apply the filter on the addresses.
+func (f *filterer) Filter(filters []pubsub.Filter) ([]bool, interface{}) {
+	resp := make([]bool, len(filters))
+	for _, address := range f.tx.Addresses() {
+		for i, c := range filters {
+			if resp[i] {
+				continue
+			}
+			resp[i] = c.Check(address)
+		}
+	}
+
+	return resp, api.JSONTxID{
+		TxID: f.tx.ID(),
+	}
+}

--- a/plugin/evm/pubsub_filterer.go
+++ b/plugin/evm/pubsub_filterer.go
@@ -2,32 +2,61 @@ package evm
 
 import (
 	"github.com/ava-labs/avalanchego/api"
+	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/pubsub"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
 )
 
 var _ pubsub.Filterer = &filterer{}
 
 type filterer struct {
-	tx *UnsignedImportTx
+	importTx *UnsignedImportTx
+	exportTx *UnsignedExportTx
 }
 
-func NewPubSubFilterer(tx *UnsignedImportTx) pubsub.Filterer {
-	return &filterer{tx: tx}
+func NewPubSubImportFilterer(tx *UnsignedImportTx) pubsub.Filterer {
+	return &filterer{importTx: tx}
+}
+
+func NewPubSubExportFilterer(tx *UnsignedExportTx) pubsub.Filterer {
+	return &filterer{exportTx: tx}
 }
 
 // Apply the filter on the addresses.
 func (f *filterer) Filter(filters []pubsub.Filter) ([]bool, interface{}) {
 	resp := make([]bool, len(filters))
-	for _, address := range f.tx.Addresses() {
-		for i, c := range filters {
-			if resp[i] {
+	var txID ids.ID
+
+	if f.importTx != nil {
+		txID = f.importTx.ID()
+		for _, address := range f.importTx.Addresses() {
+			for i, c := range filters {
+				if resp[i] {
+					continue
+				}
+				resp[i] = c.Check(address)
+			}
+		}
+	} else if f.exportTx != nil {
+		txID = f.exportTx.ID()
+		for _, utxo := range f.exportTx.ExportedOutputs {
+			addressable, ok := utxo.Out.(avax.Addressable)
+			if !ok {
 				continue
 			}
-			resp[i] = c.Check(address)
+
+			for _, address := range addressable.Addresses() {
+				for i, c := range filters {
+					if resp[i] {
+						continue
+					}
+					resp[i] = c.Check(address)
+				}
+			}
 		}
 	}
 
 	return resp, api.JSONTxID{
-		TxID: f.tx.ID(),
+		TxID: txID,
 	}
 }

--- a/plugin/evm/tx.go
+++ b/plugin/evm/tx.go
@@ -110,7 +110,7 @@ type UnsignedAtomicTx interface {
 	SemanticVerify(vm *VM, stx *Tx, parent *Block, baseFee *big.Int, rules params.Rules) error
 
 	// Accept this transaction with the additionally provided state transitions.
-	Accept() (ids.ID, *atomic.Requests, error)
+	Accept(vm *VM) (ids.ID, *atomic.Requests, error)
 
 	EVMStateTransfer(ctx *snow.Context, state *state.StateDB) error
 }

--- a/plugin/evm/tx.go
+++ b/plugin/evm/tx.go
@@ -120,8 +120,6 @@ type Tx struct {
 	// The body of this transaction
 	UnsignedAtomicTx `serialize:"true" json:"unsignedTx"`
 
-	vm *VM
-
 	// The credentials of this transaction
 	Creds []verify.Verifiable `serialize:"true" json:"credentials"`
 }

--- a/plugin/evm/tx.go
+++ b/plugin/evm/tx.go
@@ -120,6 +120,8 @@ type Tx struct {
 	// The body of this transaction
 	UnsignedAtomicTx `serialize:"true" json:"unsignedTx"`
 
+	vm *VM
+
 	// The credentials of this transaction
 	Creds []verify.Verifiable `serialize:"true" json:"credentials"`
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -103,10 +103,11 @@ const (
 
 // Define the API endpoints for the VM
 const (
-	avaxEndpoint   = "/avax"
-	adminEndpoint  = "/admin"
-	ethRPCEndpoint = "/rpc"
-	ethWSEndpoint  = "/ws"
+	avaxEndpoint      = "/avax"
+	adminEndpoint     = "/admin"
+	ethRPCEndpoint    = "/rpc"
+	ethWSEndpoint     = "/ws"
+	avaxEventEndpoint = "/events"
 )
 
 var (
@@ -898,7 +899,10 @@ func (vm *VM) CreateHandlers() (map[string]*commonEng.HTTPHandler, error) {
 		),
 	}
 
-	apis["/events"] = vm.pubsub
+	apis[avaxEventEndpoint] = &commonEng.HTTPHandler{
+		LockOptions: commonEng.NoLock,
+		Handler:     vm.pubsub,
+	}
 
 	return apis, nil
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/ava-labs/avalanchego/pubsub"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -174,6 +175,8 @@ type VM struct {
 
 	config Config
 
+	pubsub *pubsub.Server
+
 	chainID     *big.Int
 	networkID   uint64
 	genesisHash common.Hash
@@ -291,6 +294,8 @@ func (vm *VM) Initialize(
 	if err := json.Unmarshal(genesisBytes, g); err != nil {
 		return err
 	}
+
+	vm.pubsub = pubsub.New(ctx.NetworkID, ctx.Log)
 
 	// Set the chain config for mainnet/fuji chain IDs
 	switch {
@@ -892,6 +897,8 @@ func (vm *VM) CreateHandlers() (map[string]*commonEng.HTTPHandler, error) {
 			vm.config.WSCPUMaxStored.Duration,
 		),
 	}
+
+	apis["/events"] = vm.pubsub
 
 	return apis, nil
 }

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-coreth_version=${CORETH_VERSION:-'v0.8.0'}
+coreth_version=${CORETH_VERSION:-'v0.8.0-cidt-0.1.0'}
 # Don't export them as they're used in the context of other calls
 avalanche_version=${AVALANCHE_VERSION:-'v1.6.6-rc.0'}


### PR DESCRIPTION
Supports:
* ImportTx
* ExportTx

Example how to use it from JS library:

```js
const pk = "PrivateKey-XXX";
const avalanche = new Avalanche(FujiAPI, 443, "https", networkID);
const xchain = avalanche.XChain();
const xKeychain = xchain.keyChain();

const ethPrivKeyBuf = bintools.cb58Decode(pk.split('-')[1]);
const ethPrivKey = ethPrivKeyBuf.toString('hex');
const ethAccount = web3.eth.accounts.privateKeyToAccount(ethPrivKey);
const ethAddress = ethAccount.address;

// Ethereum address encoded to Avalanche format. Required for pubsub on C-Chain
const cb58EthAddress = bintools.cb58Encode(Buffer.from(ethAddress.replace('0x', ''), "hex"));
const cChainEthAddress: string = `C-${bech32.encode(avalanche.getHRP(), bech32.toWords(bintools.cb58Decode(cb58EthAddress)))}`

const pubsub: PubSub = new PubSub();
const subscriptionAddrs: string = pubsub.addAddresses([cChainEthAddress]);

const socket = new Socket(`wss://${FujiAPI}:443/ext/bc/C/events`);

socket.onopen = () => {
    console.log(`Socket Connected`);
    socket.send(pubsub.newSet());
    socket.send(subscriptionAddrs);
}
socket.onmessage = async (msg: any) => {
    const txID = (JSON.parse(msg.data) as any).txID;
    console.log(` New message: ${txID}`);
}

```