### PR TITLE
fix:evm.VM: use ChainID from the genesis block

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -313,6 +313,7 @@ func (vm *VM) Initialize(
 
 	ethConfig := ethconfig.NewDefaultConfig()
 	ethConfig.Genesis = g
+	ethConfig.NetworkId = vm.chainID.Uint64()
 
 	// Set log level
 	logLevel := defaultLogLevel


### PR DESCRIPTION
Make `net_version` call return the correct network ID.