### PR TITLE
Increase tipBufferSize from 16 to 128

### DIFF
--- a/core/state_manager.go
+++ b/core/state_manager.go
@@ -37,7 +37,7 @@ import (
 
 const (
 	commitInterval = 4096
-	tipBufferSize  = 16
+	tipBufferSize  = 128
 )
 
 type TrieWriter interface {


### PR DESCRIPTION
The issue is related to the interaction between MetaMask and standard pruning nodes, and is detailed here: https://github.com/MetaMask/metamask-extension/issues/13322
This patch makes pruning nodes to keep the last 128 state tries, instead of 16. Since MetaMask has a 20-seconds block number cache, keeping 16 state tries is not enough, because the number of produced blocks by the Avalanche Network in 20s can be higher and MetaMask ends up asking for data in already pruned state tries.