### PR TITLE
Remove set preference warn log

### DIFF
--- a/accounts/abi/reflect.go
+++ b/accounts/abi/reflect.go
@@ -183,13 +183,10 @@ func setStruct(dst, src reflect.Value) error {
 
 // mapArgNamesToStructFields maps a slice of argument names to struct fields.
 // first round: for each Exportable field that contains a `abi:""` tag
-//
-//	and this field name exists in the given argument name list, pair them together.
-//
+// and this field name exists in the given argument name list, pair them together.
 // second round: for each argument name that has not been already linked,
-//
-//	find what variable is expected to be mapped into, if it exists and has not been
-//	used, pair them.
+// find what variable is expected to be mapped into, if it exists and has not been
+// used, pair them.
 //
 // Note this function assumes the given value is a struct value.
 func mapArgNamesToStructFields(argNames []string, value reflect.Value) (map[string]string, error) {

--- a/accounts/abi/utils.go
+++ b/accounts/abi/utils.go
@@ -38,9 +38,8 @@ import "fmt"
 //     may eventually lead to name conflicts.
 //
 // Name conflicts are mostly resolved by adding number suffix.
-//
-//		 e.g. if the abi contains Methods send, send1
-//	  ResolveNameConflict would return send2 for input send.
+// e.g. if the abi contains Methods send, send1
+// ResolveNameConflict would return send2 for input send.
 func ResolveNameConflict(rawName string, used func(string) bool) string {
 	name := rawName
 	ok := used(name)

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1406,7 +1406,6 @@ func mergeLogs(logs [][]*types.Log, reverse bool) []*types.Log {
 func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 	var (
 		newHead = newBlock
-		oldHead = oldBlock
 
 		newChain    types.Blocks
 		oldChain    types.Blocks
@@ -1484,8 +1483,6 @@ func (bc *BlockChain) reorg(oldBlock, newBlock *types.Block) error {
 		}
 		logFn(msg, "number", commonBlock.Number(), "hash", commonBlock.Hash(),
 			"drop", len(oldChain), "dropfrom", oldChain[0].Hash(), "add", len(newChain), "addfrom", newChain[0].Hash())
-	} else {
-		log.Warn("Unlikely preference change (rewind to ancestor) occurred", "oldnum", oldHead.Number(), "oldhash", oldHead.Hash(), "newnum", newHead.Number(), "newhash", newHead.Hash())
 	}
 	// Insert the new chain(except the head block(reverse order)),
 	// taking care of the proper incremental order.


### PR DESCRIPTION
## Why this should be merged

This PR should be merged to remove a warn log on set preference which can occur during normal operation on restart.

## How this works

Removes the log

## How this was tested

CI no real change to test in this