### PR TITLE
Bump version to v0.12.0 and bump ago dep to v1.9.16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,16 +20,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           repository: ${{ github.event.inputs.avalanchegoRepo }}
           ref: ${{ github.event.inputs.avalanchegoBranch }}
           path: avalanchego
           token: ${{ secrets.AVALANCHE_PAT }}
-      - uses: actions/setup-go@v1
+      - uses: actions/setup-go@v3
         with:
           go-version: "1.20"
       - name: change avalanchego dep
@@ -54,16 +54,16 @@ jobs:
         go: ['1.20']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ github.event.inputs.avalanchegoRepo }}
         ref: ${{ github.event.inputs.avalanchegoBranch }}
         path: avalanchego
         token: ${{ secrets.AVALANCHE_PAT }}
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - name: change avalanchego dep
@@ -87,16 +87,16 @@ jobs:
         go: ['1.20']
         os: [ubuntu-20.04]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ github.event.inputs.avalanchegoRepo }}
         ref: ${{ github.event.inputs.avalanchegoBranch }}
         path: avalanchego
         token: ${{ secrets.AVALANCHE_PAT }}
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - name: change avalanchego dep
@@ -118,16 +118,16 @@ jobs:
         go: [ '1.20' ]
         os: [ ubuntu-20.04 ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
       if: ${{ github.event_name == 'workflow_dispatch' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ github.event.inputs.avalanchegoRepo }}
         ref: ${{ github.event.inputs.avalanchegoBranch }}
         path: avalanchego
         token: ${{ secrets.AVALANCHE_PAT }}
-    - uses: actions/setup-go@v1
+    - uses: actions/setup-go@v3
       with:
         go-version: ${{ matrix.go }}
     - name: change avalanchego dep

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.9.11
+	github.com/ava-labs/avalanchego v1.9.16
 	github.com/cespare/cp v0.1.0
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -59,8 +59,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo29Kk6CurOXKm700vrz8f0KW0JNfpkRJY/8=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
-github.com/ava-labs/avalanchego v1.9.11 h1:5hXHJMvErfaolWD7Hw9gZaVylck2shBaV/2NTHA0BfA=
-github.com/ava-labs/avalanchego v1.9.11/go.mod h1:nNc+4JCIJMaEt2xRmeMVAUyQwDIap7RvnMrfWD2Tpo8=
+github.com/ava-labs/avalanchego v1.9.16 h1:JarxIn7gy4V9f1dBgUxubRRO6CrqY2MprOLGqEmk+Vg=
+github.com/ava-labs/avalanchego v1.9.16/go.mod h1:Unm7ruhAvLSRP+7gIfwyHNf+wEehWLsFhY9yp10nDbw=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.11.9"
+	Version string = "v0.12.0"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 # Set up the versions to be used
-coreth_version=${CORETH_VERSION:-'v0.11.9'}
+coreth_version=${CORETH_VERSION:-'v0.12.0'}
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.9.11'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.9.16'}


### PR DESCRIPTION
## Why this should be merged

This PR bumps the version to v0.12.0 and bumps the AvalancheGo dependency to v1.9.16

## How this was tested

CI
