### PR TITLE
fix data race in snapshot

### DIFF
--- a/metrics/meter.go
+++ b/metrics/meter.go
@@ -205,7 +205,6 @@ func (m *StandardMeter) Count() int64 {
 func (m *StandardMeter) Mark(n int64) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
-
 	m.snapshot.temp += n
 }
 


### PR DESCRIPTION
## Why this should be merged
Found a data race where we're not holding the write-lock when modifying the snapshot. Looks like we use an atomic add which isn't safe since the other goroutine is using a read lock instead of compare-and-swap.
```
[node4] ==================
[node4] WARNING: DATA RACE
[node4] Write at 0x00c000f67a10 by goroutine 2027:
[node4]   sync/atomic.AddInt64()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/runtime/race_amd64.s:289 +0xb
[node4]   sync/atomic.AddInt64()
[node4]       <autogenerated>:1 +0x1b
[node4]   github.com/ava-labs/coreth/trie.(*Database).node()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/trie/database.go:401 +0x1fd
[node4]   github.com/ava-labs/coreth/trie.(*Database).EncodedNode()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/trie/database.go:379 +0xbd
[node4]   github.com/ava-labs/coreth/trie.(*Trie).resolveHash()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/trie/trie.go:566 +0x13e
[node4]   github.com/ava-labs/coreth/trie.New()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/trie/trie.go:115 +0x1d5
[node4]   github.com/ava-labs/coreth/trie.NewStateTrie()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/trie/secure_trie.go:81 +0xb1
[node4]   github.com/ava-labs/coreth/core/state.(*cachingDB).OpenTrie()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/core/state/database.go:156 +0xac
[node4]   github.com/ava-labs/coreth/core/state.NewWithSnapshot()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/core/state/statedb.go:154 +0x8c
[node4]   github.com/ava-labs/coreth/core/state.New()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/core/state/statedb.go:146 +0xba
[node4]   github.com/ava-labs/coreth/core.(*BlockChain).StateAt()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/core/blockchain_reader.go:248 +0x267
[node4]   github.com/ava-labs/coreth/plugin/evm.(*pushGossiper).queueRegossipTxs()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/plugin/evm/gossiper.go:192 +0x183
[node4]   github.com/ava-labs/coreth/plugin/evm.(*pushGossiper).awaitEthTxGossip.func1()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/plugin/evm/gossiper.go:243 +0x2dc
[node4]   github.com/ava-labs/avalanchego/utils/logging.(*log).RecoverAndPanic()
[node4]       /home/runner/work/avalanchego/avalanchego/utils/logging/log.go:125 +0x6d
[node4]   github.com/ava-labs/coreth/plugin/evm.(*pushGossiper).awaitEthTxGossip.func2()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/plugin/evm/gossiper.go:221 +0x59
[node4] 
[node4] Previous read at 0x00c000f67a10 by goroutine 2520:
[node4]   github.com/ava-labs/coreth/metrics.(*StandardMeter).Snapshot()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/metrics/meter.go:244 +0x6e
[node4]   github.com/ava-labs/coreth/metrics/prometheus.gatherer.Gather()
[node4]       /home/runner/go/pkg/mod/github.com/ava-labs/coreth@v0.11.10-0.20230414205138-8fa796880922/metrics/prometheus/prometheus.go:106 +0x12f9
[node4]   github.com/ava-labs/coreth/metrics/prometheus.(*gatherer).Gather()
[node4]       <autogenerated>:1 +0x5a
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*multiGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/multi_gatherer.go:51 +0x1ec
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*optionalGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/optional_gatherer.go:49 +0xf3
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*multiGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/multi_gatherer.go:51 +0x1ec
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*optionalGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/optional_gatherer.go:49 +0xf3
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*multiGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/multi_gatherer.go:51 +0x1ec
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*optionalGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/optional_gatherer.go:49 +0xf3
[node4]   github.com/ava-labs/avalanchego/api/metrics.(*multiGatherer).Gather()
[node4]       /home/runner/work/avalanchego/avalanchego/api/metrics/multi_gatherer.go:51 +0x1ec
[node4]   github.com/prometheus/client_golang/prometheus.(*noTransactionGatherer).Gather()
[node4]       /home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.13.0/prometheus/registry.go:1042 +0x44
[node4]   github.com/prometheus/client_golang/prometheus/promhttp.HandlerForTransactional.func1()
[node4]       /home/runner/go/pkg/mod/github.com/prometheus/client_golang@v1.13.0/prometheus/promhttp/http.go:135 +0x107
[node4]   net/http.HandlerFunc.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2109 +0x4d
[node4]   github.com/ava-labs/avalanchego/api/server.(*metrics).wrapHandler.func1()
[node4]       /home/runner/work/avalanchego/avalanchego/api/server/metrics.go:72 +0x1c8
[node4]   net/http.HandlerFunc.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2109 +0x4d
[node4]   github.com/gorilla/mux.(*Router).ServeHTTP()
[node4]       /home/runner/go/pkg/mod/github.com/gorilla/mux@v1.8.0/mux.go:210 +0x371
[node4]   github.com/ava-labs/avalanchego/api/server.(*router).ServeHTTP()
[node4]       /home/runner/work/avalanchego/avalanchego/api/server/router.go:45 +0xcf
[node4]   github.com/rs/cors.(*Cors).Handler.func1()
[node4]       /home/runner/go/pkg/mod/github.com/rs/cors@v1.7.0/cors.go:219 +0x32a
[node4]   net/http.HandlerFunc.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2109 +0x4d
[node4]   github.com/NYTimes/gziphandler.GzipHandlerWithOpts.func1.1()
[node4]       /home/runner/go/pkg/mod/github.com/!n!y!times/gziphandler@v1.1.1/gzip.go:336 +0x457
[node4]   net/http.HandlerFunc.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2109 +0x4d
[node4]   github.com/ava-labs/avalanchego/api/server.New.func1()
[node4]       /home/runner/work/avalanchego/avalanchego/api/server/server.go:139 +0x19c
[node4]   net/http.HandlerFunc.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2109 +0x4d
[node4]   net/http.serverHandler.ServeHTTP()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:2947 +0x641
[node4]   net/http.(*conn).serve()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:1991 +0xbe4
[node4]   net/http.(*Server).Serve.func3()
[node4]       /opt/hostedtoolcache/go/1.19.8/x64/src/net/http/server.go:3102 +0x58
```

## How this works

Grab lock when modifying snapshot

## How this was tested

Did not
