### PR TITLE
Use `slices` methods instead of `sort` methods

### DIFF
--- a/plugin/evm/atomic_tx_repository.go
+++ b/plugin/evm/atomic_tx_repository.go
@@ -9,9 +9,10 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
-	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/database"

--- a/plugin/evm/atomic_tx_repository.go
+++ b/plugin/evm/atomic_tx_repository.go
@@ -7,11 +7,11 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"sort"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
+	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/database"
@@ -272,7 +272,9 @@ func (a *atomicTxRepository) write(height uint64, txs []*Tx, bonus bool) error {
 		// with txs initialized from the txID index.
 		copyTxs := make([]*Tx, len(txs))
 		copy(copyTxs, txs)
-		sort.Slice(copyTxs, func(i, j int) bool { return copyTxs[i].ID().Hex() < copyTxs[j].ID().Hex() })
+		slices.SortFunc(copyTxs, func(i, j *Tx) bool {
+			return i.Less(j)
+		})
 		txs = copyTxs
 	}
 	heightBytes := make([]byte, wrappers.LongLen)
@@ -452,6 +454,6 @@ func getAtomicRepositoryRepairHeights(bonusBlocks map[uint64]ids.ID, canonicalBl
 			repairHeights = append(repairHeights, height)
 		}
 	}
-	sort.Slice(repairHeights, func(i, j int) bool { return repairHeights[i] < repairHeights[j] })
+	slices.Sort(repairHeights)
 	return repairHeights
 }

--- a/plugin/evm/atomic_tx_repository_test.go
+++ b/plugin/evm/atomic_tx_repository_test.go
@@ -8,12 +8,13 @@ import (
 	"fmt"
 	"testing"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/prefixdb"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ethereum/go-ethereum/common"
-	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/utils/set"

--- a/plugin/evm/tx.go
+++ b/plugin/evm/tx.go
@@ -10,8 +10,9 @@ import (
 	"math/big"
 	"sort"
 
-	"github.com/ethereum/go-ethereum/common"
 	"golang.org/x/exp/slices"
+
+	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -12,7 +12,6 @@ import (
 	"math/big"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -22,6 +21,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
+	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/coreth/internal/ethapi"
 	"github.com/ava-labs/coreth/metrics"
@@ -4027,8 +4027,7 @@ func TestExtraStateChangeAtomicGasLimitExceeded(t *testing.T) {
 func TestGetAtomicRepositoryRepairHeights(t *testing.T) {
 	mainnetHeights := getAtomicRepositoryRepairHeights(bonusBlockMainnetHeights, canonicalBlockMainnetHeights)
 	assert.Len(t, mainnetHeights, 76)
-	sorted := sort.SliceIsSorted(mainnetHeights, func(i, j int) bool { return mainnetHeights[i] < mainnetHeights[j] })
-	assert.True(t, sorted)
+	assert.True(t, slices.IsSorted(mainnetHeights))
 }
 
 func TestSkipChainConfigCheckCompatible(t *testing.T) {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -16,12 +16,13 @@ import (
 	"testing"
 	"time"
 
+	"golang.org/x/exp/slices"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
-	"golang.org/x/exp/slices"
 
 	"github.com/ava-labs/coreth/internal/ethapi"
 	"github.com/ava-labs/coreth/metrics"


### PR DESCRIPTION
## Why this should be merged

`slices.Sort` is faster.  I only touched files in `plugin` to minimize the diff with geth.

## How this works

Replace `sort.` with `slices.` methods

## How this was tested

Existing UT
