### PR TITLE
update golangci-lint-action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - run: ./scripts/lint_allowed_geth_imports.sh
         shell: bash
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           version: v1.51
           working-directory: .


### PR DESCRIPTION
## Why this should be merged

Warning about using `save-state`

https://github.com/ava-labs/coreth/actions/runs/5268399245/jobs/9530685492?pr=260#step:7:63

## How this works

2 --> 3

## How this was tested

lint action no longer complains