### PR TITLE
Fix collect unflattened logs

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1395,8 +1395,10 @@ func (bc *BlockChain) collectUnflattenedLogs(b *types.Block, removed bool) [][]*
 	receipts := rawdb.ReadRawReceipts(bc.db, b.Hash(), b.NumberU64())
 	receipts.DeriveFields(bc.chainConfig, b.Hash(), b.NumberU64(), b.Time(), b.BaseFee(), b.Transactions())
 
-	var logs [][]*types.Log
-	for _, receipt := range receipts {
+	// Note: gross but this needs to be initialized here because returning nil will be treated specially as an incorrect
+	// error case downstream.
+	logs := make([][]*types.Log, len(receipts))
+	for i, receipt := range receipts {
 		receiptLogs := make([]*types.Log, len(receipt.Logs))
 		for i, log := range receipt.Logs {
 			l := *log
@@ -1405,7 +1407,7 @@ func (bc *BlockChain) collectUnflattenedLogs(b *types.Block, removed bool) [][]*
 			}
 			receiptLogs[i] = &l
 		}
-		logs = append(logs, receiptLogs)
+		logs[i] = receiptLogs
 	}
 	return logs
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -739,6 +739,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 	} else if lastAcceptedID != blk.ID() {
 		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
 	}
+	vm.blockChain.DrainAcceptorQueue()
 	filterAPI := filters.NewFilterAPI(filters.NewFilterSystem(vm.eth.APIBackend, filters.Config{
 		Timeout: 5 * time.Minute,
 	}))
@@ -751,6 +752,9 @@ func TestIssueAtomicTxs(t *testing.T) {
 	}
 	if len(logs) != 0 {
 		t.Fatalf("Expected log length to be 0, but found %d", len(logs))
+	}
+	if logs == nil {
+		t.Fatal("Expected logs to be non-nil")
 	}
 
 	exportTx, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-(2*params.AvalancheAtomicTxFee), vm.ctx.XChainID, testShortIDAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 	"github.com/ethereum/go-ethereum/rlp"
 
+	"github.com/ava-labs/coreth/eth/filters"
 	"github.com/ava-labs/coreth/internal/ethapi"
 	"github.com/ava-labs/coreth/metrics"
 	"github.com/ava-labs/coreth/plugin/evm/message"
@@ -737,6 +738,19 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal(err)
 	} else if lastAcceptedID != blk.ID() {
 		t.Fatalf("Expected last accepted blockID to be the accepted block: %s, but found %s", blk.ID(), lastAcceptedID)
+	}
+	filterAPI := filters.NewFilterAPI(filters.NewFilterSystem(vm.eth.APIBackend, filters.Config{
+		Timeout: 5 * time.Minute,
+	}))
+	blockHash := common.Hash(blk.ID())
+	logs, err := filterAPI.GetLogs(context.Background(), filters.FilterCriteria{
+		BlockHash: &blockHash,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(logs) != 0 {
+		t.Fatalf("Expected log length to be 0, but found %d", len(logs))
 	}
 
 	exportTx, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-(2*params.AvalancheAtomicTxFee), vm.ctx.XChainID, testShortIDAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})


### PR DESCRIPTION
## Why this should be merged

This PR fixes a regression introduced in v0.12.3 where `collectUnflattenedLogs` returns nil for a block that contains no transactions, which causes `nil` to be returned from `core/blockchain.go` and this is treated as an error in the filter system code here: https://github.com/ava-labs/coreth/blob/v0.12.3/eth/filters/filter_system.go#L117.

This has caused a request for `eth_getLogs` to return an error for blocks that only contain an atomic transaction.

## How this works

This patches the bug by ensuring that the `logs` slice is initialized to a non-empty value instead of only appending to it inside of the for loop, which is never hit if there are no logs.

## How this was tested

Add to existing unit test for atomic transactions in the VM. This is the simplest place to add the test. We cannot add it in the core package because it creates a circular dependency and the filters package mocks the backend that contains the bug.
