### PR TITLE
Use go1.19 in CI for consistency with avalanchego

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.20"
+          go-version: "1.19"
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.19']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.20']
+        go: ['1.19']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.20' ]
+        go: [ '1.19' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ============= Compilation Stage ================
-FROM golang:1.20.1-buster AS builder
+FROM golang:1.19.10-buster AS builder
 
 RUN apt-get update && apt-get install -y --no-install-recommends bash=5.0-4 make=4.2.1-1.2 gcc=4:8.3.0-1 musl-dev=1.1.21-2 ca-certificates=20200601~deb10u2 linux-headers-amd64
 


### PR DESCRIPTION
## Why this should be merged
For consistency we should use the same go version across ci and release

## How this works
Changes 1.20 -> 1.19

## How this was tested
CI
