### PR TITLE
Cleanup accepted logs subscription test

### DIFF
--- a/core/blockchain_log_test.go
+++ b/core/blockchain_log_test.go
@@ -19,20 +19,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-/*
-Example contract to test event emission:
+func TestAcceptedLogsSubscription(t *testing.T) {
+	/*
+		Example contract to test event emission:
 
-	pragma solidity >=0.7.0 <0.9.0;
-	contract Callable {
-		event Called();
-		function Call() public { emit Called(); }
-	}
-*/
-const callableAbi = "[{\"anonymous\":false,\"inputs\":[],\"name\":\"Called\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"Call\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+			pragma solidity >=0.7.0 <0.9.0;
+			contract Callable {
+				event Called();
+				function Call() public { emit Called(); }
+			}
+	*/
 
-const callableBin = "6080604052348015600f57600080fd5b5060998061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c806334e2292114602d575b600080fd5b60336035565b005b7f81fab7a4a0aa961db47eefc81f143a5220e8c8495260dd65b1356f1d19d3c7b860405160405180910390a156fea2646970667358221220029436d24f3ac598ceca41d4d712e13ced6d70727f4cdc580667de66d2f51d8b64736f6c63430008010033"
-
-func TestEmitLogsCorrectness(t *testing.T) {
+	const (
+		callableABI = "[{\"anonymous\":false,\"inputs\":[],\"name\":\"Called\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"Call\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]"
+		callableBin = "6080604052348015600f57600080fd5b5060998061001e6000396000f3fe6080604052348015600f57600080fd5b506004361060285760003560e01c806334e2292114602d575b600080fd5b60336035565b005b7f81fab7a4a0aa961db47eefc81f143a5220e8c8495260dd65b1356f1d19d3c7b860405160405180910390a156fea2646970667358221220029436d24f3ac598ceca41d4d712e13ced6d70727f4cdc580667de66d2f51d8b64736f6c63430008010033"
+	)
 	var (
 		require = require.New(t)
 		engine  = dummy.NewFaker()
@@ -48,7 +49,7 @@ func TestEmitLogsCorrectness(t *testing.T) {
 		signer          = types.LatestSigner(gspec.Config)
 	)
 
-	parsed, err := abi.JSON(strings.NewReader(callableAbi))
+	parsed, err := abi.JSON(strings.NewReader(callableABI))
 	require.NoError(err)
 
 	packedFunction, err := parsed.Pack("Call")


### PR DESCRIPTION
## Why this should be merged

This PR cleans up the existing accepted log subscription unit test by renaming it and moving variables only relevant to this test inside of the relevant test.

## How this works

Just cleanup

## How this was tested

Run modified test locally + CI
