### PR TITLE
Bump coreth to v0.12.5 and bump avalanchego dep to v1.10.5

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,7 @@
 # Release Notes
 
+## [v0.12.5](https://github.com/ava-labs/coreth/releases/tag/v0.12.5)
+
 ## [v0.12.4](https://github.com/ava-labs/coreth/releases/tag/v0.12.4)
 
 - Fix API handler crash for `lookupState` in `prestate` tracer

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.5-rc.1
+	github.com/ava-labs/avalanchego v1.10.5
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -65,8 +65,8 @@ github.com/andreyvit/diff v0.0.0-20170406064948-c7f18ee00883/go.mod h1:rCTlJbsFo
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/apache/arrow/go/arrow v0.0.0-20191024131854-af6fa24be0db/go.mod h1:VTxUBvSJ3s3eHAg65PNgrsn5BtqCRPdmyXh6rAfdxN0=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.5-rc.1 h1:hFgEI2y7pYUE9F7P6SsMJDpPV5Qm2faoCHIfswcYu3A=
-github.com/ava-labs/avalanchego v1.10.5-rc.1/go.mod h1:azK88lcF5jwcPSp//RKUh2VncmrZZUrKu998C7no4Ys=
+github.com/ava-labs/avalanchego v1.10.5 h1:opYyroLzhJPTJw9LlSRks8ItcezerwuGAT0MkVSotBs=
+github.com/ava-labs/avalanchego v1.10.5/go.mod h1:rXAX4UaE9ORIEJcMyzN6ibv4rnLwv0zUIPLmzA0MCno=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.12.4"
+	Version string = "v0.12.5"
 )
 
 func init() {


### PR DESCRIPTION
## Why this should be merged

This PR creates a new section in the release notes for v0.12.5, bumps the reported version to v0.12.5, and bumps the AvalancheGo dependency to the latest release v1.10.5.

## How this works

n/a

## How this was tested

CI