### PR TITLE
Bump avalanchego to v1.10.6-rc.4

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,9 @@
 
 ## [v0.12.5](https://github.com/ava-labs/coreth/releases/tag/v0.12.5)
 
+- Migrate geth changes from v1.11.4 through v1.12.0
+- Bump AvalancheGo dependency to v1.10.6-rc.4 to use sized LRU for Chain State Cache
+
 ## [v0.12.4](https://github.com/ava-labs/coreth/releases/tag/v0.12.4)
 
 - Fix API handler crash for `lookupState` in `prestate` tracer

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.19
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.5
+	github.com/ava-labs/avalanchego v1.10.6-rc.4
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.5 h1:opYyroLzhJPTJw9LlSRks8ItcezerwuGAT0MkVSotBs=
-github.com/ava-labs/avalanchego v1.10.5/go.mod h1:rXAX4UaE9ORIEJcMyzN6ibv4rnLwv0zUIPLmzA0MCno=
+github.com/ava-labs/avalanchego v1.10.6-rc.4 h1:MRQ0wGoLrvL2iYzGmhfee/j3uCY6epXyzpUMTa3Y9ww=
+github.com/ava-labs/avalanchego v1.10.6-rc.4/go.mod h1:e8LdGy0xM+QejpMoEK6wOFu2O5HMlAHPJiBPjhoTG78=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -122,9 +122,9 @@ const (
 	codecVersion         = uint16(0)
 	secpFactoryCacheSize = 1024
 
-	decidedCacheSize    = 100
-	missingCacheSize    = 50
-	unverifiedCacheSize = 50
+	decidedCacheSize    = 10 * units.MiB
+	missingCacheSize    = 5 * units.MiB
+	unverifiedCacheSize = 5 * units.MiB
 
 	targetAtomicTxsSize = 40 * units.KiB
 )

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -123,8 +123,9 @@ const (
 	secpFactoryCacheSize = 1024
 
 	decidedCacheSize    = 10 * units.MiB
-	missingCacheSize    = 5 * units.MiB
+	missingCacheSize    = 50
 	unverifiedCacheSize = 5 * units.MiB
+	bytesToIDCacheSize  = 5 * units.MiB
 
 	targetAtomicTxsSize = 40 * units.KiB
 )
@@ -675,6 +676,7 @@ func (vm *VM) initChainState(lastAcceptedBlock *types.Block) error {
 		DecidedCacheSize:    decidedCacheSize,
 		MissingCacheSize:    missingCacheSize,
 		UnverifiedCacheSize: unverifiedCacheSize,
+		BytesToIDCacheSize:  bytesToIDCacheSize,
 		GetBlockIDAtHeight:  vm.GetBlockIDAtHeight,
 		GetBlock:            vm.getBlock,
 		UnmarshalBlock:      vm.parseBlock,

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.5-rc.1'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.6-rc.4'}


### PR DESCRIPTION
This PR bumps AvalancheGo dependency to use v1.10.6-rc.4 and updates the cache sizes used by the chain state cache to use the new sized LRU cache to limit the total memory allocated to the cache based off of bytes size (limited to a total of 20MB) as opposed to a specific number of blocks.

Since AvalancheGo imports Coreth, it will replace the version of AvalancheGo imported by Coreth with the actual current code when it's compiled. As a result, since AvalancheGo has switched to inputting sizes based off of the total memory taken up by these caches instead of the number of elements, we need to update the sizes for the AvalancheGo release.

Otherwise, the chain state cache will go from allocating 100/50/50 elements to the respective caches to allocating that number of bytes to each of those caches, which will end up being zero total blocks.