### PR TITLE
renamed flags

### DIFF
--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -144,9 +144,9 @@ type Config struct {
 	KeystoreInsecureUnlockAllowed bool   `json:"keystore-insecure-unlock-allowed"`
 
 	// Gossip Settings
-	RemoteTxGossipOnlyEnabled bool     `json:"remote-tx-gossip-only-enabled"`
-	TxRegossipFrequency       Duration `json:"tx-regossip-frequency"`
-	TxRegossipMaxSize         int      `json:"tx-regossip-max-size"`
+	RemoteGossipOnlyEnabled bool     `json:"remote-gossip-only-enabled"`
+	RegossipFrequency       Duration `json:"regossip-frequency"`
+	RegossipMaxTxs          int      `json:"regossip-max-txs"`
 
 	// Log
 	LogLevel      string `json:"log-level"`
@@ -230,8 +230,8 @@ func (c *Config) SetDefaults() {
 	c.SnapshotCache = defaultSnapshotCache
 	c.AcceptorQueueLimit = defaultAcceptorQueueLimit
 	c.SnapshotWait = defaultSnapshotWait
-	c.TxRegossipFrequency.Duration = defaultTxRegossipFrequency
-	c.TxRegossipMaxSize = defaultTxRegossipMaxSize
+	c.RegossipFrequency.Duration = defaultTxRegossipFrequency
+	c.RegossipMaxTxs = defaultTxRegossipMaxSize
 	c.OfflinePruningBloomFilterSize = defaultOfflinePruningBloomFilterSize
 	c.LogLevel = defaultLogLevel
 	c.PopulateMissingTriesParallelism = defaultPopulateMissingTriesParallelism

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -77,9 +77,11 @@ type Duration struct {
 // Config ...
 type Config struct {
 	// Coreth APIs
-	SnowmanAPIEnabled bool   `json:"snowman-api-enabled"`
-	AdminAPIEnabled   bool   `json:"admin-api-enabled"`
-	AdminAPIDir       string `json:"admin-api-dir"`
+	SnowmanAPIEnabled     bool   `json:"snowman-api-enabled"`
+	AdminAPIEnabled       bool   `json:"admin-api-enabled"`
+	AdminAPIDir           string `json:"admin-api-dir"`
+	CorethAdminAPIEnabled bool   `json:"coreth-admin-api-enabled"` // Deprecated: use AdminAPIEnabled instead
+	CorethAdminAPIDir     string `json:"coreth-admin-api-dir"`     // Deprecated: use AdminAPIDir instead
 
 	// EnabledEthAPIs is a list of Ethereum services that should be enabled
 	// If none is specified, then we use the default list [defaultEnabledAPIs]
@@ -144,9 +146,12 @@ type Config struct {
 	KeystoreInsecureUnlockAllowed bool   `json:"keystore-insecure-unlock-allowed"`
 
 	// Gossip Settings
-	RemoteGossipOnlyEnabled bool     `json:"remote-gossip-only-enabled"`
-	RegossipFrequency       Duration `json:"regossip-frequency"`
-	RegossipMaxTxs          int      `json:"regossip-max-txs"`
+	RemoteGossipOnlyEnabled   bool     `json:"remote-gossip-only-enabled"`
+	RegossipFrequency         Duration `json:"regossip-frequency"`
+	RegossipMaxTxs            int      `json:"regossip-max-txs"`
+	RemoteTxGossipOnlyEnabled bool     `json:"remote-tx-gossip-only-enabled"` // Deprecated: use RemoteGossipOnlyEnabled instead
+	TxRegossipFrequency       Duration `json:"tx-regossip-frequency"`         // Deprecated: use RegossipFrequency instead
+	TxRegossipMaxSize         int      `json:"tx-regossip-max-size"`          // Deprecated: use RegossipMaxTxs instead
 
 	// Log
 	LogLevel      string `json:"log-level"`
@@ -284,4 +289,31 @@ func (c *Config) Validate() error {
 	}
 
 	return nil
+}
+
+func (c *Config) Deprecate() string {
+	msg := ""
+	// Deprecate the old config options and set the new ones.
+	if c.CorethAdminAPIEnabled {
+		msg += "coreth-admin-api-enabled is deprecated, use admin-api-enabled instead. "
+		c.AdminAPIEnabled = c.CorethAdminAPIEnabled
+	}
+	if c.CorethAdminAPIDir != "" {
+		msg += "coreth-admin-api-dir is deprecated, use admin-api-dir instead. "
+		c.AdminAPIDir = c.CorethAdminAPIDir
+	}
+	if c.RemoteTxGossipOnlyEnabled {
+		msg += "remote-tx-gossip-only-enabled is deprecated, use tx-gossip-enabled instead. "
+		c.RemoteGossipOnlyEnabled = c.RemoteTxGossipOnlyEnabled
+	}
+	if c.TxRegossipFrequency != (Duration{}) {
+		msg += "tx-regossip-frequency is deprecated, use regossip-frequency instead. "
+		c.RegossipFrequency = c.TxRegossipFrequency
+	}
+	if c.TxRegossipMaxSize != 0 {
+		msg += "tx-regossip-max-size is deprecated, use regossip-max-txs instead. "
+		c.RegossipMaxTxs = c.TxRegossipMaxSize
+	}
+
+	return msg
 }

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -77,9 +77,9 @@ type Duration struct {
 // Config ...
 type Config struct {
 	// Coreth APIs
-	SnowmanAPIEnabled     bool   `json:"snowman-api-enabled"`
-	CorethAdminAPIEnabled bool   `json:"coreth-admin-api-enabled"`
-	CorethAdminAPIDir     string `json:"coreth-admin-api-dir"`
+	SnowmanAPIEnabled bool   `json:"snowman-api-enabled"`
+	AdminAPIEnabled   bool   `json:"admin-api-enabled"`
+	AdminAPIDir       string `json:"admin-api-dir"`
 
 	// EnabledEthAPIs is a list of Ethereum services that should be enabled
 	// If none is specified, then we use the default list [defaultEnabledAPIs]

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1156,8 +1156,8 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*commonEng.HTTPHandler
 	enabledAPIs = append(enabledAPIs, "avax")
 	apis[avaxEndpoint] = avaxAPI
 
-	if vm.config.CorethAdminAPIEnabled {
-		adminAPI, err := newHandler("admin", NewAdminService(vm, os.ExpandEnv(fmt.Sprintf("%s_coreth_performance_%s", vm.config.CorethAdminAPIDir, primaryAlias))))
+	if vm.config.AdminAPIEnabled {
+		adminAPI, err := newHandler("admin", NewAdminService(vm, os.ExpandEnv(fmt.Sprintf("%s_coreth_performance_%s", vm.config.AdminAPIDir, primaryAlias))))
 		if err != nil {
 			return nil, fmt.Errorf("failed to register service for admin API due to %w", err)
 		}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -333,6 +333,10 @@ func (vm *VM) Initialize(
 	if err := vm.config.Validate(); err != nil {
 		return err
 	}
+	// We should deprecate config flags as the first thing, before we do anything else
+	// because this can set old flags to new flags. log the message after we have
+	// initialized the logger.
+	deprecateMsg := vm.config.Deprecate()
 
 	vm.ctx = chainCtx
 
@@ -354,6 +358,10 @@ func (vm *VM) Initialize(
 	vm.logger = corethLogger
 
 	log.Info("Initializing Coreth VM", "Version", Version, "Config", vm.config)
+
+	if deprecateMsg != "" {
+		log.Warn("Deprecation Warning", "msg", deprecateMsg)
+	}
 
 	if len(fxs) > 0 {
 		return errUnsupportedFXs


### PR DESCRIPTION
We have different flag names in Subnet-EVM as [here](https://github.com/ava-labs/subnet-evm/blob/master/plugin/evm/config.go#L157-L159).  Renamed those to be same with Subnet-EVM.

Also added a deprecation function which would set new configs to old ones if old ones has non-default values, and emits a warn log.

- [ ] document changes 