### PR TITLE
add debug log for dropped pending txs notifications

### DIFF
--- a/plugin/evm/block_builder.go
+++ b/plugin/evm/block_builder.go
@@ -111,6 +111,7 @@ func (b *blockBuilder) needToBuild() bool {
 func (b *blockBuilder) markBuilding() {
 	// If the engine has not called BuildBlock, no need to send another message.
 	if b.buildSent {
+		log.Debug("previous PendingTxs notification still pending in consensus")
 		return
 	}
 	b.buildBlockTimer.Cancel() // Cancel any future attempt from the timer to send a PendingTxs message


### PR DESCRIPTION
## Why this should be merged

Add a debug log for blocks that we're not building due to the previous block still pending

## How this works

Adds a debug log

## How this was tested

Did not test