### PR TITLE
Add security file based on AvalancheGo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,20 @@
+# Security Policy
+
+Avalanche takes the security of the platform and of its users very seriously. We and our community recognize the critical role of external security researchers and developers and welcome 
+responsible disclosures. Valid reports will be eligible for a reward (terms and conditions apply).
+
+## Reporting a Vulnerability
+
+**Please do not file a public ticket** mentioning the vulnerability. To disclose a vulnerability submit it through our [Bug Bounty Program](https://hackenproof.com/avalanche).
+
+Vulnerabilities must be disclosed to us privately with reasonable time to respond, and avoid compromise of other users and accounts, or loss of funds that are not your own. We do not reward spam or 
+social engineering vulnerabilities. 
+
+Do not test for or validate any security issues in the live Avalanche networks (Mainnet and Fuji testnet), confirm all exploits in a local private testnet.
+
+Please refer to the [Bug Bounty Page](https://hackenproof.com/avalanche) for the most up-to-date program rules and scope.
+
+## Supported Versions
+
+Please use the [most recently released version](https://github.com/ava-labs/coreth/releases/latest) to perform testing and to validate security issues.
+


### PR DESCRIPTION
This PR replaces https://github.com/ava-labs/coreth/pull/292 and adds the security file from AvalancheGo.