### PR TITLE
e2e: Add avalanchego e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.19' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3
@@ -166,7 +165,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: Run e2e tests
       run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,3 +147,26 @@ jobs:
         DOCKER_PASS: ${{ secrets.DOCKER_PASS }}
         KURTOSIS_CLIENT_ID: ${{ secrets.KURTOSIS_CLIENT_ID }}
         KURTOSIS_CLIENT_SECRET: ${{ secrets.KURTOSIS_CLIENT_SECRET }}
+  avalanchego_e2e:
+    name: AvalancheGo E2E Tests v${{ matrix.go }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        go: [ '1.19' ]
+        os: [ ubuntu-20.04 ]
+    steps:
+    - uses: actions/checkout@v3
+    - name: check out ${{ github.event.inputs.avalanchegoRepo }} ${{ github.event.inputs.avalanchegoBranch }}
+      if: ${{ github.event_name == 'workflow_dispatch' }}
+      uses: actions/checkout@v3
+      with:
+        repository: ${{ github.event.inputs.avalanchegoRepo }}
+        ref: ${{ github.event.inputs.avalanchegoBranch }}
+        path: avalanchego
+        token: ${{ secrets.AVALANCHE_PAT }}
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ${{ matrix.go }}
+    - name: Run e2e tests
+      run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
+      shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ awscpu
 
 bin/
 build/
+
+# Used for e2e testing
+avalanchego

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -7,30 +7,45 @@ set -euo pipefail
 # e.g.,
 # ./scripts/tests.e2e.sh
 # AVALANCHE_VERSION=v1.10.x ./scripts/tests.e2e.sh
+if ! [[ "$0" =~ scripts/tests.e2e.sh ]]; then
+  echo "must be run from repository root"
+  exit 255
+fi
 
 # Coreth root directory
 CORETH_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 
+# Allow configuring the clone path to point to an existing clone
+AVALANCHEGO_CLONE_PATH="${AVALANCHEGO_CLONE_PATH:-avalanchego}"
+
 # Load the version
 source "$CORETH_PATH"/scripts/versions.sh
 
+# Always return to the coreth path on exit
+function cleanup {
+  cd "${CORETH_PATH}"
+}
+trap cleanup EXIT
+
 echo "checking out target AvalancheGo version ${avalanche_version}"
-if [[ -d avalanchego ]]; then
+if [[ -d "${AVALANCHEGO_CLONE_PATH}" ]]; then
   echo "updating existing clone"
-  cd avalanchego
-  git pull
+  cd "${AVALANCHEGO_CLONE_PATH}"
+  git fetch
   git checkout -B "${avalanche_version}"
 else
   echo "creating new clone"
-  git clone -b "${avalanche_version}" --single-branch https://github.com/ava-labs/avalanchego.git
-  cd avalanchego
+  git clone -b "${avalanche_version}"\
+      --single-branch https://github.com/ava-labs/avalanchego.git\
+      "${AVALANCHEGO_CLONE_PATH}"
+  cd "${AVALANCHEGO_CLONE_PATH}"
 fi
 
-echo "updating coreth dependency to point to local path"
-go mod edit -replace github.com/ava-labs/coreth=../
+echo "updating coreth dependency to point to ${CORETH_PATH}"
+go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
 go mod tidy
 
-echo "building with race detection"
+echo "building avalanchego"
 ./scripts/build.sh -r
 
 echo "running AvalancheGo e2e tests"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Run AvalancheGo e2e tests from the target version against the current state of coreth.
+
+# e.g.,
+# ./scripts/tests.e2e.sh
+# AVALANCHE_VERSION=v1.10.x ./scripts/tests.e2e.sh
+
+# Coreth root directory
+CORETH_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+# Load the version
+source "$CORETH_PATH"/scripts/versions.sh
+
+echo "checking out target AvalancheGo version ${avalanche_version}"
+if [[ -d avalanchego ]]; then
+  echo "updating existing clone"
+  cd avalanchego
+  git pull
+  git checkout -B "${avalanche_version}"
+else
+  echo "creating new clone"
+  git clone -b "${avalanche_version}" --single-branch https://github.com/ava-labs/avalanchego.git
+  cd avalanchego
+fi
+
+echo "updating coreth dependency to point to local path"
+go mod edit -replace github.com/ava-labs/coreth=../
+go mod tidy
+
+echo "building with race detection"
+./scripts/build.sh -r
+
+echo "running AvalancheGo e2e tests"
+./scripts/tests.e2e.sh ./build/avalanchego


### PR DESCRIPTION
## Why this should be merged

Adds a CI job to run the pinned version of the avalanchego e2e tests against the latest version of coreth. Once the PRs for #1547 are merged to avalanchego to ensure equivalent coverage to the current kurtosis e2e, the current coreth kurtosis e2e job can be disabled.

## How this works

A new script in the coreth repo - `./scripts/tests.e2e.sh`:
 - checks out the target version of AvalancheGo
 - configures it to use the local working directory as its coreth dependency
 - builds avalanchego binary
 - runs the AvalancheGo e2e test script

## How this was tested

Checked that the new `AvalancheGo E2E Tests` job exists and is passing.
