### PR TITLE
Bump golang version to 1.19.12 for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19"
+          go-version: "1.19.12"
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -51,7 +51,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
+        go: ['1.19.12']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19']
+        go: ['1.19.12']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v3
@@ -115,7 +115,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.19' ]
+        go: [ '1.19.12' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.19.12"
+          go-version: '~1.19.12'
+          check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -51,7 +52,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19.12']
         os: [macos-11.0, ubuntu-20.04, windows-latest]
     steps:
     - uses: actions/checkout@v3
@@ -65,7 +65,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
@@ -84,7 +85,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: ['1.19.12']
         os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v3
@@ -98,7 +98,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |
@@ -115,7 +116,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        go: [ '1.19.12' ]
         os: [ ubuntu-20.04 ]
     steps:
     - uses: actions/checkout@v3
@@ -129,7 +129,8 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v3
       with:
-        go-version: ${{ matrix.go }}
+        go-version: '~1.19.12'
+        check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
       run: |

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.6-rc.4'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.8'}


### PR DESCRIPTION
Also bump targeted version of avalanchego to the v1.10.8 (which also uses golang 1.19.12).
