### PR TITLE
core/state/snapshot: increase batch size during diffToDisk

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -634,7 +634,7 @@ func diffToDisk(bottom *diffLayer) (*diskLayer, bool, error) {
 			// Ensure we don't delete too much data blindly (contract can be
 			// huge). It's ok to flush, the root will go missing in case of a
 			// crash and we'll detect and regenerate the snapshot.
-			if batch.ValueSize() > ethdb.IdealBatchSize {
+			if batch.ValueSize() > 64*1024*1024 {
 				if err := batch.Write(); err != nil {
 					log.Crit("Failed to write storage deletions", "err", err)
 				}
@@ -660,7 +660,7 @@ func diffToDisk(bottom *diffLayer) (*diskLayer, bool, error) {
 		// Ensure we don't write too much data blindly. It's ok to flush, the
 		// root will go missing in case of a crash and we'll detect and regen
 		// the snapshot.
-		if batch.ValueSize() > ethdb.IdealBatchSize {
+		if batch.ValueSize() > 64*1024*1024 {
 			if err := batch.Write(); err != nil {
 				log.Crit("Failed to write storage deletions", "err", err)
 			}


### PR DESCRIPTION
This PR migrates https://github.com/ethereum/go-ethereum/pull/27977.

This increases the cap on the size of a batch when flattening a snapshot diff layer to disk. This is a non-atomic operation to ensure that flattening does not create such a large batch that it causes an OOM.

However, breaking this up may result in invalidating the snapshot since you may apply only part of the change, which results in needing to re-generate the snapshot.

Increasing the capped size to 64MB provides a reasonable cap to avoid an OOM and drastically increases the size of a diff that is needed to potentially corrupt a snapshot.