### PR TITLE
Add SDK Router message handling

### DIFF
--- a/peer/network.go
+++ b/peer/network.go
@@ -88,16 +88,16 @@ type network struct {
 	outstandingRequestHandlers map[uint32]message.ResponseHandler // maps avalanchego requestID => message.ResponseHandler
 	activeAppRequests          *semaphore.Weighted                // controls maximum number of active outbound requests
 	activeCrossChainRequests   *semaphore.Weighted                // controls maximum number of active outbound cross chain requests
-	router                     *p2p.Router
-	appSender                  common.AppSender                 // avalanchego AppSender for sending messages
-	codec                      codec.Manager                    // Codec used for parsing messages
-	crossChainCodec            codec.Manager                    // Codec used for parsing cross chain messages
-	appRequestHandler          message.RequestHandler           // maps request type => handler
-	crossChainRequestHandler   message.CrossChainRequestHandler // maps cross chain request type => handler
-	gossipHandler              message.GossipHandler            // maps gossip type => handler
-	peers                      *peerTracker                     // tracking of peers & bandwidth
-	appStats                   stats.RequestHandlerStats        // Provide request handler metrics
-	crossChainStats            stats.RequestHandlerStats        // Provide cross chain request handler metrics
+	router                     *p2p.Router                        // handles messages being sent to the generic networking SDK
+	appSender                  common.AppSender                   // avalanchego AppSender for sending messages
+	codec                      codec.Manager                      // Codec used for parsing messages
+	crossChainCodec            codec.Manager                      // Codec used for parsing cross chain messages
+	appRequestHandler          message.RequestHandler             // maps request type => handler
+	crossChainRequestHandler   message.CrossChainRequestHandler   // maps cross chain request type => handler
+	gossipHandler              message.GossipHandler              // maps gossip type => handler
+	peers                      *peerTracker                       // tracking of peers & bandwidth
+	appStats                   stats.RequestHandlerStats          // Provide request handler metrics
+	crossChainStats            stats.RequestHandlerStats          // Provide cross chain request handler metrics
 
 	// Set to true when Shutdown is called, after which all operations on this
 	// struct are no-ops.

--- a/peer/network.go
+++ b/peer/network.go
@@ -103,12 +103,10 @@ type network struct {
 	// struct are no-ops.
 	//
 	// Invariant: Even though `closed` is an atomic, `lock` is required to be
-	// held when sending requests and receiving responses to guarantee that the
-	// network isn't closed during these calls. This is because closing the
-	// network cancels all outstanding requests, which means we must guarantee
-	// never to fulfill, or cancel again, after having cancelled the request.
-	// Similarly, we must ensure we don't register a request that will never be
-	// fulfilled or cancelled.
+	// held when sending requests to guarantee that the network isn't closed
+	// during these calls. This is because closing the network cancels all
+	// outstanding requests, which means we must guarantee never to register a
+	// request that will never be fulfilled or cancelled.
 	closed utils.Atomic[bool]
 }
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -564,6 +564,9 @@ func (n *network) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {
 
 // invariant: peer/network must use explicitly even request ids.
 // for this reason, [n.requestID] is initialized as zero and incremented by 2.
+// This is for backwards-compatibility while the SDK router exists with the
+// legacy coreth handlers to avoid a (very) narrow edge case where request ids
+// can overlap, resulting in a dropped timeout.
 func (n *network) nextRequestID() uint32 {
 	next := n.requestIDGen
 	n.requestIDGen += 2

--- a/peer/network.go
+++ b/peer/network.go
@@ -332,7 +332,7 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	var req message.Request
 	if _, err := n.codec.Unmarshal(request, &req); err != nil {
-		log.Debug("forwarding unregistered AppRequest", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
+		log.Debug("forwarding AppRequest to SDK router", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
 		return n.router.AppRequest(ctx, nodeID, requestID, deadline, request)
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -333,7 +333,7 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	var req message.Request
 	if _, err := n.codec.Unmarshal(request, &req); err != nil {
-		log.Debug("forwarding unknown AppRequest", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
+		log.Debug("forwarding unregistered AppRequest", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
 		return n.router.AppRequest(ctx, nodeID, requestID, deadline, request)
 	}
 
@@ -376,7 +376,7 @@ func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID 
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unknown AppResponse", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
+		log.Debug("forwarding unregistered AppResponse", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
 		return n.router.AppResponse(ctx, nodeID, requestID, response)
 	}
 
@@ -404,7 +404,7 @@ func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reque
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unknown AppRequestFailed", "nodeID", nodeID, "requestID", requestID)
+		log.Debug("forwarding unregistered AppRequestFailed", "nodeID", nodeID, "requestID", requestID)
 		return n.router.AppRequestFailed(ctx, nodeID, requestID)
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -234,6 +234,10 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 // Send a CrossChainAppResponse to [chainID] in response to a valid message using the same
 // [requestID] before the deadline.
 func (n *network) CrossChainAppRequest(ctx context.Context, requestingChainID ids.ID, requestID uint32, deadline time.Time, request []byte) error {
+	if n.closed.Get() {
+		return nil
+	}
+
 	log.Debug("received CrossChainAppRequest from chain", "requestingChainID", requestingChainID, "requestID", requestID, "requestLen", len(request))
 
 	var req message.CrossChainRequest
@@ -312,6 +316,10 @@ func (n *network) CrossChainAppResponse(ctx context.Context, respondingChainID i
 // sends a response back to the sender if length of response returned by the handler is >0
 // expects the deadline to not have been passed
 func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID uint32, deadline time.Time, request []byte) error {
+	if n.closed.Get() {
+		return nil
+	}
+
 	log.Debug("received AppRequest from node", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request))
 
 	var req message.Request

--- a/peer/network.go
+++ b/peer/network.go
@@ -339,7 +339,7 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 
 	var req message.Request
 	if _, err := n.codec.Unmarshal(request, &req); err != nil {
-		log.Debug("forwarding unknown AppRequest to sdk", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
+		log.Debug("forwarding unknown AppRequest", "nodeID", nodeID, "requestID", requestID, "requestLen", len(request), "err", err)
 		return n.router.AppRequest(ctx, nodeID, requestID, deadline, request)
 	}
 
@@ -382,7 +382,7 @@ func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID 
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unknown AppResponse to sdk", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
+		log.Debug("forwarding unknown AppResponse", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
 		return n.router.AppResponse(ctx, nodeID, requestID, response)
 	}
 
@@ -410,7 +410,7 @@ func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reque
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unknown AppRequestFailed to sdk", "nodeID", nodeID, "requestID", requestID)
+		log.Debug("forwarding unknown AppRequestFailed", "nodeID", nodeID, "requestID", requestID)
 		return n.router.AppRequestFailed(ctx, nodeID, requestID)
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -375,7 +375,7 @@ func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID 
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unregistered AppResponse", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
+		log.Debug("forwarding AppResponse to SDK router", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
 		return n.router.AppResponse(ctx, nodeID, requestID, response)
 	}
 
@@ -403,7 +403,7 @@ func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, reque
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		log.Debug("forwarding unregistered AppRequestFailed", "nodeID", nodeID, "requestID", requestID)
+		log.Debug("forwarding AppRequestFailed to SDK router", "nodeID", nodeID, "requestID", requestID)
 		return n.router.AppRequestFailed(ctx, nodeID, requestID)
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -176,10 +176,7 @@ func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 	log.Debug("sending request to peer", "nodeID", nodeID, "requestLen", len(request))
 	n.peers.TrackPeer(nodeID)
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = responseHandler
 
 	nodeIDs := set.NewSet[ids.NodeID](1)
@@ -213,10 +210,7 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 		return nil
 	}
 
-	// generate requestID
-	requestID := n.requestIDGen
-	n.requestIDGen++
-
+	requestID := n.nextRequestID()
 	n.outstandingRequestHandlers[requestID] = handler
 
 	// Send cross chain request to [chainID].
@@ -565,4 +559,13 @@ func (n *network) TrackBandwidth(nodeID ids.NodeID, bandwidth float64) {
 	defer n.lock.Unlock()
 
 	n.peers.TrackBandwidth(nodeID, bandwidth)
+}
+
+// invariant: peer/network must use explicitly even request ids.
+// for this reason, [n.requestID] is initialized as zero and incremented by 2.
+func (n *network) nextRequestID() uint32 {
+	next := n.requestIDGen
+	n.requestIDGen += 2
+
+	return next
 }

--- a/peer/network.go
+++ b/peer/network.go
@@ -415,7 +415,7 @@ func calculateTimeUntilDeadline(deadline time.Time, stats stats.RequestHandlerSt
 
 // markRequestFulfilled fetches the handler for [requestID] and marks the request with [requestID] as having been fulfilled.
 // This is called by either [AppResponse] or [AppRequestFailed].
-// Assumes that the write lock is held.
+// Assumes that the write lock is not held.
 func (n *network) markRequestFulfilled(requestID uint32) (message.ResponseHandler, bool) {
 	n.lock.Lock()
 	defer n.lock.Unlock()

--- a/peer/network.go
+++ b/peer/network.go
@@ -365,15 +365,16 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
 	n.lock.Lock()
-	defer n.lock.Unlock()
 
 	if n.closed.Get() {
+		n.lock.Unlock()
 		return nil
 	}
 
 	log.Debug("received AppResponse from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
+	n.lock.Unlock()
 	if !exists {
 		log.Debug("forwarding AppResponse to SDK router", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
 		return n.router.AppResponse(ctx, nodeID, requestID, response)
@@ -393,15 +394,16 @@ func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID 
 // returns error only when the response handler returns an error
 func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
 	n.lock.Lock()
-	defer n.lock.Unlock()
 
 	if n.closed.Get() {
+		n.lock.Unlock()
 		return nil
 	}
 
 	log.Debug("received AppRequestFailed from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
+	n.lock.Unlock()
 	if !exists {
 		log.Debug("forwarding AppRequestFailed to SDK router", "nodeID", nodeID, "requestID", requestID)
 		return n.router.AppRequestFailed(ctx, nodeID, requestID)

--- a/peer/network.go
+++ b/peer/network.go
@@ -101,6 +101,14 @@ type network struct {
 
 	// Set to true when Shutdown is called, after which all operations on this
 	// struct are no-ops.
+	//
+	// Invariant: Even though `closed` is an atomic, `lock` is required to be
+	// held when sending requests and receiving responses to guarantee that the
+	// network isn't closed during these calls. This is because closing the
+	// network cancels all outstanding requests, which means we must guarantee
+	// never to fulfill, or cancel again, after having cancelled the request.
+	// Similarly, we must ensure we don't register a request that will never be
+	// fulfilled or cancelled.
 	closed utils.Atomic[bool]
 }
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -269,9 +269,6 @@ func (n *network) CrossChainAppRequest(ctx context.Context, requestingChainID id
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChainID ids.ID, requestID uint32) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
 	if n.closed.Get() {
 		return nil
 	}
@@ -296,9 +293,6 @@ func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChai
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) CrossChainAppResponse(ctx context.Context, respondingChainID ids.ID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-
 	if n.closed.Get() {
 		return nil
 	}
@@ -364,17 +358,13 @@ func (n *network) AppRequest(ctx context.Context, nodeID ids.NodeID, requestID u
 // If [requestID] is not known, this function will emit a log and return a nil error.
 // If the response handler returns an error it is propagated as a fatal error.
 func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID uint32, response []byte) error {
-	n.lock.Lock()
-
 	if n.closed.Get() {
-		n.lock.Unlock()
 		return nil
 	}
 
 	log.Debug("received AppResponse from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
-	n.lock.Unlock()
 	if !exists {
 		log.Debug("forwarding AppResponse to SDK router", "nodeID", nodeID, "requestID", requestID, "responseLen", len(response))
 		return n.router.AppResponse(ctx, nodeID, requestID, response)
@@ -393,17 +383,13 @@ func (n *network) AppResponse(ctx context.Context, nodeID ids.NodeID, requestID 
 // error returned by this function is expected to be treated as fatal by the engine
 // returns error only when the response handler returns an error
 func (n *network) AppRequestFailed(ctx context.Context, nodeID ids.NodeID, requestID uint32) error {
-	n.lock.Lock()
-
 	if n.closed.Get() {
-		n.lock.Unlock()
 		return nil
 	}
 
 	log.Debug("received AppRequestFailed from peer", "nodeID", nodeID, "requestID", requestID)
 
 	handler, exists := n.markRequestFulfilled(requestID)
-	n.lock.Unlock()
 	if !exists {
 		log.Debug("forwarding AppRequestFailed to SDK router", "nodeID", nodeID, "requestID", requestID)
 		return n.router.AppRequestFailed(ctx, nodeID, requestID)
@@ -439,8 +425,10 @@ func calculateTimeUntilDeadline(deadline time.Time, stats stats.RequestHandlerSt
 
 // markRequestFulfilled fetches the handler for [requestID] and marks the request with [requestID] as having been fulfilled.
 // This is called by either [AppResponse] or [AppRequestFailed].
-// Assumes that the write lock is held.
 func (n *network) markRequestFulfilled(requestID uint32) (message.ResponseHandler, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+
 	handler, exists := n.outstandingRequestHandlers[requestID]
 	if !exists {
 		return nil, false

--- a/peer/network.go
+++ b/peer/network.go
@@ -279,8 +279,8 @@ func (n *network) CrossChainAppRequestFailed(ctx context.Context, respondingChai
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppRequestFailed to unknown request", "respondingChainID", respondingChainID, "requestID", requestID)
 		return nil
 	}
 
@@ -299,8 +299,8 @@ func (n *network) CrossChainAppResponse(ctx context.Context, respondingChainID i
 
 	handler, exists := n.markRequestFulfilled(requestID)
 	if !exists {
-		// Should never happen since the engine should be managing outstanding requests
-		log.Error("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
+		// Can happen after the network has been closed.
+		log.Debug("received CrossChainAppResponse to unknown request", "respondingChainID", respondingChainID, "requestID", requestID, "responseLen", len(response))
 		return nil
 	}
 

--- a/peer/network.go
+++ b/peer/network.go
@@ -15,7 +15,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ava-labs/avalanchego/codec"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"

--- a/peer/network.go
+++ b/peer/network.go
@@ -12,12 +12,12 @@ import (
 
 	"golang.org/x/sync/semaphore"
 
-	"github.com/ava-labs/avalanchego/network/p2p"
-
 	"github.com/ethereum/go-ethereum/log"
 
 	"github.com/ava-labs/avalanchego/codec"
+
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/validators"
 	"github.com/ava-labs/avalanchego/utils"

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	avalanchegoMetrics "github.com/ava-labs/avalanchego/api/metrics"
+	"github.com/ava-labs/avalanchego/network/p2p"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	corethConstants "github.com/ava-labs/coreth/constants"
@@ -276,6 +277,8 @@ type VM struct {
 	client       peer.NetworkClient
 	networkCodec codec.Manager
 
+	router *p2p.Router
+
 	// Metrics
 	multiGatherer avalanchegoMetrics.MultiGatherer
 
@@ -506,8 +509,9 @@ func (vm *VM) Initialize(
 	}
 
 	// initialize peer network
+	vm.router = p2p.NewRouter(vm.ctx.Log, appSender)
 	vm.networkCodec = message.Codec
-	vm.Network = peer.NewNetwork(appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
+	vm.Network = peer.NewNetwork(vm.router, appSender, vm.networkCodec, message.CrossChainCodec, chainCtx.NodeID, vm.config.MaxOutboundActiveRequests, vm.config.MaxOutboundActiveCrossChainRequests)
 	vm.client = peer.NewNetworkClient(vm.Network)
 
 	if err := vm.initializeChain(lastAcceptedHash); err != nil {


### PR DESCRIPTION
## Why this should be merged

Adds the P2P SDK's router to handle incoming sdk messages

## How this works

Forwards messages that fail unmarshaling against the codec into the SDK router

## How this was tested

Added a unit test
