### PR TITLE
Fix hanging requests after Shutdown

### DIFF
--- a/peer/network.go
+++ b/peer/network.go
@@ -166,6 +166,7 @@ func (n *network) SendAppRequest(nodeID ids.NodeID, request []byte, responseHand
 // Assumes write lock is held
 func (n *network) sendAppRequest(nodeID ids.NodeID, request []byte, responseHandler message.ResponseHandler) error {
 	if n.closed.Get() {
+		n.activeAppRequests.Release(1)
 		return nil
 	}
 
@@ -206,6 +207,7 @@ func (n *network) SendCrossChainRequest(chainID ids.ID, request []byte, handler 
 	defer n.lock.Unlock()
 
 	if n.closed.Get() {
+		n.activeCrossChainRequests.Release(1)
 		return nil
 	}
 

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -649,6 +649,26 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 	require.True(t, called)
 }
 
+func TestNetworkAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, ids.EmptyNodeID, 1, 0)
+	net.Shutdown()
+
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
+}
+
+func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
+	require := require.New(t)
+
+	net := NewNetwork(nil, nil, nil, ids.EmptyNodeID, 0, 1)
+	net.Shutdown()
+
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
+}
+
 func buildCodec(t *testing.T, types ...interface{}) codec.Manager {
 	codecManager := codec.NewDefaultManager()
 	c := linearcodec.NewDefault()

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -655,7 +655,7 @@ func TestCrossChainRequestOnShutdown(t *testing.T) {
 func TestNetworkAppRequestAfterShutdown(t *testing.T) {
 	require := require.New(t)
 
-	net := NewNetwork(nil, nil, nil, ids.EmptyNodeID, 1, 0)
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 1, 0)
 	net.Shutdown()
 
 	require.NoError(net.SendAppRequest(ids.GenerateTestNodeID(), nil, nil))
@@ -665,11 +665,11 @@ func TestNetworkAppRequestAfterShutdown(t *testing.T) {
 func TestNetworkCrossChainAppRequestAfterShutdown(t *testing.T) {
 	require := require.New(t)
 
-	net := NewNetwork(nil, nil, nil, ids.EmptyNodeID, 0, 1)
+	net := NewNetwork(nil, nil, nil, nil, ids.EmptyNodeID, 0, 1)
 	net.Shutdown()
 
 	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
-	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil)) 
+	require.NoError(net.SendCrossChainRequest(ids.GenerateTestID(), nil, nil))
 }
 
 func TestSDKRouting(t *testing.T) {


### PR DESCRIPTION
## Why this should be merged

We forget to release the requests semaphore after shutting down the p2p layer

## How this works

Adds a release if we drop an outbound request

## How this was tested

Added a regression test
