### PR TITLE
core/vm: add de-activation of opCallExpert comment

### DIFF
--- a/core/vm/instructions.go
+++ b/core/vm/instructions.go
@@ -717,6 +717,7 @@ func opCall(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byt
 	return ret, nil
 }
 
+// Note: opCallExpert was de-activated in ApricotPhase2.
 func opCallExpert(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) ([]byte, error) {
 	stack := scope.Stack
 	// Pop gas. The actual gas in interpreter.evm.callGasTemp.
@@ -730,6 +731,8 @@ func opCallExpert(pc *uint64, interpreter *EVMInterpreter, scope *ScopeContext) 
 	// Get the arguments from the memory.
 	args := scope.Memory.GetPtr(int64(inOffset.Uint64()), int64(inSize.Uint64()))
 
+	// Note: this code fails to check that value2 is zero, which was a bug when CALLEX was active.
+	// The CALLEX opcode was de-activated in ApricotPhase2 resolving this issue.
 	if interpreter.readOnly && !value.IsZero() {
 		return nil, vmerrs.ErrWriteProtection
 	}


### PR DESCRIPTION
This PR adds a de-activation comment to the `opCallExpert` code to make it clear this code was de-activated in ApricotPhase2.