### PR TITLE
bump golangci-lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51
+          version: v1.54
           working-directory: .
           args: --timeout 3m
   test:


### PR DESCRIPTION
## Why this should be merged
Bump golangci version to latest

## How this works
Similar to https://github.com/ava-labs/subnet-evm/pull/927/files

## How this was tested
N/A