### PR TITLE
params: enumerate changes in DUpgrade including Shanghai upgrade

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -531,7 +531,9 @@ type ChainConfig struct {
 	BanffBlockTimestamp *uint64 `json:"banffBlockTimestamp,omitempty"`
 	// Cortina increases the block gas limit to 15M. (nil = no fork, 0 = already activated)
 	CortinaBlockTimestamp *uint64 `json:"cortinaBlockTimestamp,omitempty"`
-	// DUpgrade activates the Shanghai upgrade from Ethereum. (nil = no fork, 0 = already activated)
+	// DUpgrade activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
+	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
+	// Note: EIP-4895 is excluded since withdrawal are not relevant to the Avalanche C-Chain or Subnets running the EVM.
 	DUpgradeBlockTimestamp *uint64 `json:"dUpgradeBlockTimestamp,omitempty"`
 	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
 	CancunTime *uint64 `json:"cancunTime,omitempty"`

--- a/params/config.go
+++ b/params/config.go
@@ -533,7 +533,7 @@ type ChainConfig struct {
 	CortinaBlockTimestamp *uint64 `json:"cortinaBlockTimestamp,omitempty"`
 	// DUpgrade activates the Shanghai Execution Spec Upgrade from Ethereum (https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips)
 	// and Avalanche Warp Messaging. (nil = no fork, 0 = already activated)
-	// Note: EIP-4895 is excluded since withdrawal are not relevant to the Avalanche C-Chain or Subnets running the EVM.
+	// Note: EIP-4895 is excluded since withdrawals are not relevant to the Avalanche C-Chain or Subnets running the EVM.
 	DUpgradeBlockTimestamp *uint64 `json:"dUpgradeBlockTimestamp,omitempty"`
 	// Cancun activates the Cancun upgrade from Ethereum. (nil = no fork, 0 = already activated)
 	CancunTime *uint64 `json:"cancunTime,omitempty"`


### PR DESCRIPTION
This PR adds a comment enumerating the changes included in the DUpgrade. The scheduled changes include the activation of the EIPs from the [Shanghai Upgrade](https://github.com/ethereum/execution-specs/blob/master/network-upgrades/mainnet-upgrades/shanghai.md#included-eips) and [Avalanche Warp Messaging](https://github.com/ava-labs/subnet-evm/blob/v0.5.6/x/warp/README.md).

The Shanghai Upgrade includes EIPs:
- EIP-3651 (Warm Coinbase)
- EIP3855 (PUSH0)
- EIP-3860 (Limit and meter initcode)
- EIP-4895 (Beacon chain push withdrawls as operations, ignored since it is not relevant here)
- EIP-6049 (Deprecate SELFDESTRUCT, this is an official deprecation notice and not a change in behavior)
