### PR TITLE
Remove lock options from http handlers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.11
+	github.com/ava-labs/avalanchego v1.10.12-rc.5
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,6 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.11 h1:efyC/fYXqHNwjj56xgb0yFFxAr/y7Kyxi4DPYUz5HH4=
-github.com/ava-labs/avalanchego v1.10.11/go.mod h1:a6dQT2+V+qZ8Y9Kj69Ahh3dH+IT+9KzF318T4QEyrh8=
 github.com/ava-labs/avalanchego v1.10.12-rc.5 h1:lOljTUF59rZ/SKlTSZ3XQwuy4uGVNikHIEMQmYHzws4=
 github.com/ava-labs/avalanchego v1.10.12-rc.5/go.mod h1:SrcFAwibYWdUnS7ZRbENDBzQgHYCROuX6w/lhGmJcPo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.10.11 h1:efyC/fYXqHNwjj56xgb0yFFxAr/y7Kyxi4DPYUz5HH4=
 github.com/ava-labs/avalanchego v1.10.11/go.mod h1:a6dQT2+V+qZ8Y9Kj69Ahh3dH+IT+9KzF318T4QEyrh8=
+github.com/ava-labs/avalanchego v1.10.12-rc.5 h1:lOljTUF59rZ/SKlTSZ3XQwuy4uGVNikHIEMQmYHzws4=
+github.com/ava-labs/avalanchego v1.10.12-rc.5/go.mod h1:SrcFAwibYWdUnS7ZRbENDBzQgHYCROuX6w/lhGmJcPo=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/plugin/evm/admin.go
+++ b/plugin/evm/admin.go
@@ -27,6 +27,9 @@ func NewAdminService(vm *VM, performanceDir string) *Admin {
 
 // StartCPUProfiler starts a cpu profile writing to the specified file
 func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	p.vm.ctx.Lock.Lock()
+	defer p.vm.ctx.Lock.Unlock()
+
 	log.Info("Admin: StartCPUProfiler called")
 
 	return p.profiler.StartCPUProfiler()
@@ -34,6 +37,9 @@ func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply
 
 // StopCPUProfiler stops the cpu profile
 func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	p.vm.ctx.Lock.Lock()
+	defer p.vm.ctx.Lock.Unlock()
+
 	log.Info("Admin: StopCPUProfiler called")
 
 	return p.profiler.StopCPUProfiler()
@@ -41,6 +47,9 @@ func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply)
 
 // MemoryProfile runs a memory profile writing to the specified file
 func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	p.vm.ctx.Lock.Lock()
+	defer p.vm.ctx.Lock.Unlock()
+
 	log.Info("Admin: MemoryProfile called")
 
 	return p.profiler.MemoryProfile()
@@ -48,6 +57,9 @@ func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) e
 
 // LockProfile runs a mutex profile writing to the specified file
 func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	p.vm.ctx.Lock.Lock()
+	defer p.vm.ctx.Lock.Unlock()
+
 	log.Info("Admin: LockProfile called")
 
 	return p.profiler.LockProfile()
@@ -58,6 +70,9 @@ type SetLogLevelArgs struct {
 }
 
 func (p *Admin) SetLogLevel(_ *http.Request, args *SetLogLevelArgs, reply *api.EmptyReply) error {
+	p.vm.ctx.Lock.Lock()
+	defer p.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: SetLogLevel called", "logLevel", args.Level)
 	if err := p.vm.logger.SetLogLevel(args.Level); err != nil {
 		return fmt.Errorf("failed to parse log level: %w ", err)

--- a/plugin/evm/admin.go
+++ b/plugin/evm/admin.go
@@ -27,40 +27,40 @@ func NewAdminService(vm *VM, performanceDir string) *Admin {
 
 // StartCPUProfiler starts a cpu profile writing to the specified file
 func (p *Admin) StartCPUProfiler(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	log.Info("Admin: StartCPUProfiler called")
+
 	p.vm.ctx.Lock.Lock()
 	defer p.vm.ctx.Lock.Unlock()
-
-	log.Info("Admin: StartCPUProfiler called")
 
 	return p.profiler.StartCPUProfiler()
 }
 
 // StopCPUProfiler stops the cpu profile
 func (p *Admin) StopCPUProfiler(r *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	log.Info("Admin: StopCPUProfiler called")
+
 	p.vm.ctx.Lock.Lock()
 	defer p.vm.ctx.Lock.Unlock()
-
-	log.Info("Admin: StopCPUProfiler called")
 
 	return p.profiler.StopCPUProfiler()
 }
 
 // MemoryProfile runs a memory profile writing to the specified file
 func (p *Admin) MemoryProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	log.Info("Admin: MemoryProfile called")
+
 	p.vm.ctx.Lock.Lock()
 	defer p.vm.ctx.Lock.Unlock()
-
-	log.Info("Admin: MemoryProfile called")
 
 	return p.profiler.MemoryProfile()
 }
 
 // LockProfile runs a mutex profile writing to the specified file
 func (p *Admin) LockProfile(_ *http.Request, _ *struct{}, _ *api.EmptyReply) error {
+	log.Info("Admin: LockProfile called")
+
 	p.vm.ctx.Lock.Lock()
 	defer p.vm.ctx.Lock.Unlock()
-
-	log.Info("Admin: LockProfile called")
 
 	return p.profiler.LockProfile()
 }
@@ -70,10 +70,11 @@ type SetLogLevelArgs struct {
 }
 
 func (p *Admin) SetLogLevel(_ *http.Request, args *SetLogLevelArgs, reply *api.EmptyReply) error {
+	log.Info("EVM: SetLogLevel called", "logLevel", args.Level)
+
 	p.vm.ctx.Lock.Lock()
 	defer p.vm.ctx.Lock.Unlock()
 
-	log.Info("EVM: SetLogLevel called", "logLevel", args.Level)
 	if err := p.vm.logger.SetLogLevel(args.Level); err != nil {
 		return fmt.Errorf("failed to parse log level: %w ", err)
 	}

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -86,7 +86,7 @@ type VersionReply struct {
 }
 
 // ClientVersion returns the version of the VM running
-func (service *AvaxAPI) Version(r *http.Request, args *struct{}, reply *VersionReply) error {
+func (service *AvaxAPI) Version(r *http.Request, _ *struct{}, reply *VersionReply) error {
 	reply.Version = Version
 	return nil
 }
@@ -106,6 +106,9 @@ type ExportKeyReply struct {
 
 // ExportKey returns a private key from the provided user
 func (service *AvaxAPI) ExportKey(r *http.Request, args *ExportKeyArgs, reply *ExportKeyReply) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: ExportKey called")
 
 	address, err := ParseEthAddress(args.Address)
@@ -139,6 +142,9 @@ type ImportKeyArgs struct {
 
 // ImportKey adds a private key to the provided user
 func (service *AvaxAPI) ImportKey(r *http.Request, args *ImportKeyArgs, reply *api.JSONAddress) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: ImportKey called", "username", args.Username)
 
 	if args.PrivateKey == nil {
@@ -185,6 +191,9 @@ func (service *AvaxAPI) ImportAVAX(_ *http.Request, args *ImportArgs, response *
 // Import issues a transaction to import AVAX from the X-chain. The AVAX
 // must have already been exported from the X-Chain.
 func (service *AvaxAPI) Import(_ *http.Request, args *ImportArgs, response *api.JSONTxID) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: ImportAVAX called")
 
 	chainID, err := service.vm.ctx.BCLookup.Lookup(args.SourceChain)
@@ -266,6 +275,9 @@ type ExportArgs struct {
 // Export exports an asset from the C-Chain to the X-Chain
 // It must be imported on the X-Chain to complete the transfer
 func (service *AvaxAPI) Export(_ *http.Request, args *ExportArgs, response *api.JSONTxID) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: Export called")
 
 	assetID, err := service.parseAssetID(args.AssetID)
@@ -336,6 +348,9 @@ func (service *AvaxAPI) Export(_ *http.Request, args *ExportArgs, response *api.
 
 // GetUTXOs gets all utxos for passed in addresses
 func (service *AvaxAPI) GetUTXOs(r *http.Request, args *api.GetUTXOsArgs, reply *api.GetUTXOsReply) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: GetUTXOs called", "Addresses", args.Addresses)
 
 	if len(args.Addresses) == 0 {
@@ -413,8 +428,10 @@ func (service *AvaxAPI) GetUTXOs(r *http.Request, args *api.GetUTXOsArgs, reply 
 	return nil
 }
 
-// IssueTx ...
 func (service *AvaxAPI) IssueTx(r *http.Request, args *api.FormattedTx, response *api.JSONTxID) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: IssueTx called")
 
 	txBytes, err := formatting.Decode(args.Encoding, args.Tx)
@@ -442,6 +459,9 @@ type GetAtomicTxStatusReply struct {
 
 // GetAtomicTxStatus returns the status of the specified transaction
 func (service *AvaxAPI) GetAtomicTxStatus(r *http.Request, args *api.JSONTxID, reply *GetAtomicTxStatusReply) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: GetAtomicTxStatus called", "txID", args.TxID)
 
 	if args.TxID == ids.Empty {
@@ -465,6 +485,9 @@ type FormattedTx struct {
 
 // GetAtomicTx returns the specified transaction
 func (service *AvaxAPI) GetAtomicTx(r *http.Request, args *api.GetTxArgs, reply *FormattedTx) error {
+	service.vm.ctx.Lock.Lock()
+	defer service.vm.ctx.Lock.Unlock()
+
 	log.Info("EVM: GetAtomicTx called", "txID", args.TxID)
 
 	if args.TxID == ids.Empty {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"math/big"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1289,26 +1290,15 @@ func (vm *VM) Version(context.Context) (string, error) {
 //   - The handler's functionality is defined by [service]
 //     [service] should be a gorilla RPC service (see https://www.gorillatoolkit.org/pkg/rpc/v2)
 //   - The name of the service is [name]
-//   - The LockOption is the first element of [lockOption]
-//     By default the LockOption is WriteLock
-//     [lockOption] should have either 0 or 1 elements. Elements beside the first are ignored.
-func newHandler(name string, service interface{}, lockOption ...commonEng.LockOption) (*commonEng.HTTPHandler, error) {
+func newHandler(name string, service interface{}) (http.Handler, error) {
 	server := avalancheRPC.NewServer()
 	server.RegisterCodec(avalancheJSON.NewCodec(), "application/json")
 	server.RegisterCodec(avalancheJSON.NewCodec(), "application/json;charset=UTF-8")
-	if err := server.RegisterService(service, name); err != nil {
-		return nil, err
-	}
-
-	var lock commonEng.LockOption = commonEng.WriteLock
-	if len(lockOption) != 0 {
-		lock = lockOption[0]
-	}
-	return &commonEng.HTTPHandler{LockOptions: lock, Handler: server}, nil
+	return server, server.RegisterService(service, name)
 }
 
 // CreateHandlers makes new http handlers that can handle API calls
-func (vm *VM) CreateHandlers(context.Context) (map[string]*commonEng.HTTPHandler, error) {
+func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	handler := rpc.NewServer(vm.config.APIMaxDuration.Duration)
 	enabledAPIs := vm.config.EthAPIs()
 	if err := attachEthService(handler, vm.eth.APIs(), enabledAPIs); err != nil {
@@ -1319,7 +1309,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*commonEng.HTTPHandler
 	if err != nil {
 		return nil, fmt.Errorf("failed to get primary alias for chain due to %w", err)
 	}
-	apis := make(map[string]*commonEng.HTTPHandler)
+	apis := make(map[string]http.Handler)
 	avaxAPI, err := newHandler("avax", &AvaxAPI{vm})
 	if err != nil {
 		return nil, fmt.Errorf("failed to register service for AVAX API due to %w", err)
@@ -1344,32 +1334,26 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]*commonEng.HTTPHandler
 	}
 
 	log.Info(fmt.Sprintf("Enabled APIs: %s", strings.Join(enabledAPIs, ", ")))
-	apis[ethRPCEndpoint] = &commonEng.HTTPHandler{
-		LockOptions: commonEng.NoLock,
-		Handler:     handler,
-	}
-	apis[ethWSEndpoint] = &commonEng.HTTPHandler{
-		LockOptions: commonEng.NoLock,
-		Handler: handler.WebsocketHandlerWithDuration(
-			[]string{"*"},
-			vm.config.APIMaxDuration.Duration,
-			vm.config.WSCPURefillRate.Duration,
-			vm.config.WSCPUMaxStored.Duration,
-		),
-	}
+	apis[ethRPCEndpoint] = handler
+	apis[ethWSEndpoint] = handler.WebsocketHandlerWithDuration(
+		[]string{"*"},
+		vm.config.APIMaxDuration.Duration,
+		vm.config.WSCPURefillRate.Duration,
+		vm.config.WSCPUMaxStored.Duration,
+	)
 
 	return apis, nil
 }
 
 // CreateStaticHandlers makes new http handlers that can handle API calls
-func (vm *VM) CreateStaticHandlers(context.Context) (map[string]*commonEng.HTTPHandler, error) {
+func (vm *VM) CreateStaticHandlers(context.Context) (map[string]http.Handler, error) {
 	handler := rpc.NewServer(0)
 	if err := handler.RegisterName("static", &StaticService{}); err != nil {
 		return nil, err
 	}
 
-	return map[string]*commonEng.HTTPHandler{
-		"/rpc": {LockOptions: commonEng.NoLock, Handler: handler},
+	return map[string]http.Handler{
+		"/rpc": handler,
 	}, nil
 }
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.11'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.12-rc.5'}


### PR DESCRIPTION
## Why this should be merged

See: [#2148](https://github.com/ava-labs/avalanchego/pull/2148)

## How this works

Explicitly grabs the context lock where it would have implicitly been grabbed before. There were a _couple_ APIs that I felt obviously didn't require a lock. But this should be a ~noop change.

## How this was tested

CI