### PR TITLE
fix Couldn't build abigen binary #355

### DIFF
--- a/cmd/abigen/main.go
+++ b/cmd/abigen/main.go
@@ -35,6 +35,7 @@ import (
 	"strings"
 
 	"github.com/ava-labs/coreth/accounts/abi/bind"
+	"github.com/ava-labs/coreth/cmd/abigen/namefilter"
 	"github.com/ava-labs/coreth/internal/flags"
 	"github.com/ethereum/go-ethereum/cmd/utils"
 	"github.com/ethereum/go-ethereum/common/compiler"
@@ -159,10 +160,10 @@ func abigen(c *cli.Context) error {
 		types = append(types, kind)
 	} else {
 		// Generate the list of types to exclude from binding
-		var exclude *nameFilter
+		var exclude *namefilter.NameFilter
 		if c.IsSet(excFlag.Name) {
 			var err error
-			if exclude, err = newNameFilter(strings.Split(c.String(excFlag.Name), ",")...); err != nil {
+			if exclude, err = namefilter.NewNameFilter(strings.Split(c.String(excFlag.Name), ",")...); err != nil {
 				utils.Fatalf("Failed to parse excludes: %v", err)
 			}
 		}

--- a/cmd/abigen/namefilter/namefilter.go
+++ b/cmd/abigen/namefilter/namefilter.go
@@ -7,21 +7,21 @@
 // original code from which it is derived.
 //
 // Much love to the original authors for their work.
-package main
+package namefilter
 
 import (
 	"fmt"
 	"strings"
 )
 
-type nameFilter struct {
+type NameFilter struct {
 	fulls map[string]bool // path/to/contract.sol:Type
 	files map[string]bool // path/to/contract.sol:*
 	types map[string]bool // *:Type
 }
 
-func newNameFilter(patterns ...string) (*nameFilter, error) {
-	f := &nameFilter{
+func NewNameFilter(patterns ...string) (*NameFilter, error) {
+	f := &NameFilter{
 		fulls: make(map[string]bool),
 		files: make(map[string]bool),
 		types: make(map[string]bool),
@@ -34,7 +34,7 @@ func newNameFilter(patterns ...string) (*nameFilter, error) {
 	return f, nil
 }
 
-func (f *nameFilter) add(pattern string) error {
+func (f *NameFilter) add(pattern string) error {
 	ft := strings.Split(pattern, ":")
 	if len(ft) != 2 {
 		// filenames and types must not include ':' symbol
@@ -53,7 +53,7 @@ func (f *nameFilter) add(pattern string) error {
 	return nil
 }
 
-func (f *nameFilter) Matches(name string) bool {
+func (f *NameFilter) Matches(name string) bool {
 	ft := strings.Split(name, ":")
 	if len(ft) != 2 {
 		// If contract names are always of the fully-qualified form

--- a/cmd/abigen/namefilter/namefilter_test.go
+++ b/cmd/abigen/namefilter/namefilter_test.go
@@ -7,7 +7,7 @@
 // original code from which it is derived.
 //
 // Much love to the original authors for their work.
-package main
+package namefilter
 
 import (
 	"testing"
@@ -17,12 +17,12 @@ import (
 )
 
 func TestNameFilter(t *testing.T) {
-	_, err := newNameFilter("Foo")
+	_, err := NewNameFilter("Foo")
 	require.Error(t, err)
-	_, err = newNameFilter("too/many:colons:Foo")
+	_, err = NewNameFilter("too/many:colons:Foo")
 	require.Error(t, err)
 
-	f, err := newNameFilter("a/path:A", "*:B", "c/path:*")
+	f, err := NewNameFilter("a/path:A", "*:B", "c/path:*")
 	require.NoError(t, err)
 
 	for _, tt := range []struct {


### PR DESCRIPTION
This change fixes errors occured when compiling cmd/abigen/main.go.

Now devs could continue generate go code from Solidity code or ABI file.