### PR TITLE
e2e: Save network data as artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,3 +134,9 @@ jobs:
     - name: Run e2e tests
       run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
       shell: bash
+    - name: Upload testnet network dir
+      uses: actions/upload-artifact@v3
+      if: always()
+      with:
+        name: testnet-data
+        path: ~/.testnetctl/networks/1000


### PR DESCRIPTION
Saving the network data produced by the e2e test is essential to diagnosing CI failures.