### PR TITLE
Update e2e test script to support hash pins

### DIFF
--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -32,14 +32,12 @@ if [[ -d "${AVALANCHEGO_CLONE_PATH}" ]]; then
   echo "updating existing clone"
   cd "${AVALANCHEGO_CLONE_PATH}"
   git fetch
-  git checkout -B "${avalanche_version}"
 else
   echo "creating new clone"
-  git clone -b "${avalanche_version}"\
-      --single-branch https://github.com/ava-labs/avalanchego.git\
-      "${AVALANCHEGO_CLONE_PATH}"
+  git clone https://github.com/ava-labs/avalanchego.git "${AVALANCHEGO_CLONE_PATH}"
   cd "${AVALANCHEGO_CLONE_PATH}"
 fi
+git checkout -B "${avalanche_version}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -37,7 +37,8 @@ else
   git clone https://github.com/ava-labs/avalanchego.git "${AVALANCHEGO_CLONE_PATH}"
   cd "${AVALANCHEGO_CLONE_PATH}"
 fi
-git checkout -B "${avalanche_version}"
+# Branch will be reset to $avalanche_version if it already exists
+git checkout -B "test-${avalanche_version}" "${avalanche_version}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"


### PR DESCRIPTION
I don't see another way to do this except doing a full clone instead of the previous single branch clone.
