### PR TITLE
Fix secp dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.14
+	github.com/ava-labs/avalanchego v1.10.15-0.20231027224434-66375f57eed9
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -57,6 +57,8 @@ github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kd
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.10.14 h1:1jTMrikYD49Pb64ZLUi2z2BnNGLzIGip4fValq6/YfE=
 github.com/ava-labs/avalanchego v1.10.14/go.mod h1:En/ti2xoxQqJuN6t9ne2ogckU9leuZzTjl5mbEsfjTc=
+github.com/ava-labs/avalanchego v1.10.15-0.20231027224434-66375f57eed9 h1:F8qkILo9tFRBwlBOI49e6f0CneUHuEqQc0lCmGeQmAU=
+github.com/ava-labs/avalanchego v1.10.15-0.20231027224434-66375f57eed9/go.mod h1:IT0UDCv0JjeAog/wSC8eFbr/wsmiUhdDZ2wpYVGIFE0=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/plugin/evm/export_tx.go
+++ b/plugin/evm/export_tx.go
@@ -230,7 +230,7 @@ func (utx *UnsignedExportTx) SemanticVerify(
 		if len(cred.Sigs) != 1 {
 			return fmt.Errorf("expected one signature for EVM Input Credential, but found: %d", len(cred.Sigs))
 		}
-		pubKey, err := vm.secpFactory.RecoverPublicKey(utx.Bytes(), cred.Sigs[0][:])
+		pubKey, err := vm.secpRecoverCache.RecoverPublicKey(utx.Bytes(), cred.Sigs[0][:])
 		if err != nil {
 			return err
 		}

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -123,8 +123,7 @@ func (service *AvaxAPI) ExportKey(r *http.Request, args *ExportKeyArgs, reply *E
 	defer db.Close()
 
 	user := user{
-		secpFactory: &service.vm.secpFactory,
-		db:          db,
+		db: db,
 	}
 	reply.PrivateKey, err = user.getKey(address)
 	if err != nil {
@@ -160,8 +159,7 @@ func (service *AvaxAPI) ImportKey(r *http.Request, args *ImportKeyArgs, reply *a
 	defer db.Close()
 
 	user := user{
-		secpFactory: &service.vm.secpFactory,
-		db:          db,
+		db: db,
 	}
 	if err := user.putAddress(args.PrivateKey); err != nil {
 		return fmt.Errorf("problem saving key %w", err)
@@ -209,8 +207,7 @@ func (service *AvaxAPI) Import(_ *http.Request, args *ImportArgs, response *api.
 	defer db.Close()
 
 	user := user{
-		secpFactory: &service.vm.secpFactory,
-		db:          db,
+		db: db,
 	}
 	privKeys, err := user.getKeys()
 	if err != nil { // Get keys
@@ -310,8 +307,7 @@ func (service *AvaxAPI) Export(_ *http.Request, args *ExportArgs, response *api.
 	defer db.Close()
 
 	user := user{
-		secpFactory: &service.vm.secpFactory,
-		db:          db,
+		db: db,
 	}
 	privKeys, err := user.getKeys()
 	if err != nil {

--- a/plugin/evm/user.go
+++ b/plugin/evm/user.go
@@ -22,7 +22,6 @@ var (
 )
 
 type user struct {
-	secpFactory *secp256k1.Factory
 	// This user's database, acquired from the keystore
 	db *encdb.Database
 }
@@ -116,7 +115,7 @@ func (u *user) getKey(address common.Address) (*secp256k1.PrivateKey, error) {
 	if err != nil {
 		return nil, err
 	}
-	return u.secpFactory.ToPrivateKey(bytes)
+	return secp256k1.ToPrivateKey(bytes)
 }
 
 // Return all private keys controlled by this user

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -122,7 +122,7 @@ const (
 	maxUTXOsToFetch      = 1024
 	defaultMempoolSize   = 4096
 	codecVersion         = uint16(0)
-	secpFactoryCacheSize = 1024
+	secpRecoverCacheSize = 1024
 
 	decidedCacheSize    = 10 * units.MiB
 	missingCacheSize    = 50
@@ -305,8 +305,8 @@ type VM struct {
 	shutdownChan chan struct{}
 	shutdownWg   sync.WaitGroup
 
-	fx          secp256k1fx.Fx
-	secpFactory secp256k1.Factory
+	fx               secp256k1fx.Fx
+	secpRecoverCache secp256k1.RecoverCache
 
 	// Continuous Profiler
 	profiler profiler.ContinuousProfiler
@@ -533,9 +533,9 @@ func (vm *VM) Initialize(
 
 	vm.chainConfig = g.Config
 	vm.networkID = vm.ethConfig.NetworkId
-	vm.secpFactory = secp256k1.Factory{
-		Cache: cache.LRU[ids.ID, *secp256k1.PublicKey]{
-			Size: secpFactoryCacheSize,
+	vm.secpRecoverCache = secp256k1.RecoverCache{
+		LRU: cache.LRU[ids.ID, *secp256k1.PublicKey]{
+			Size: secpRecoverCacheSize,
 		},
 	}
 

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -108,16 +108,13 @@ var (
 )
 
 func init() {
-	var b []byte
-	factory := secp256k1.Factory{}
-
 	for _, key := range []string{
 		"24jUJ9vZexUM6expyMcT48LBx27k1m7xpraoV62oSQAHdziao5",
 		"2MMvUMsxx6zsHSNXJdFD8yc5XkancvwyKPwpw4xUK3TCGDuNBY",
 		"cxb7KpGWhDMALTjNNSJ7UQkkomPesyWAPUaWRGdyeBNzR6f35",
 	} {
-		b, _ = cb58.Decode(key)
-		pk, _ := factory.ToPrivateKey(b)
+		b, _ := cb58.Decode(key)
+		pk, _ := secp256k1.ToPrivateKey(b)
 		testKeys = append(testKeys, pk)
 		testEthAddrs = append(testEthAddrs, GetEthAddress(pk))
 		testShortIDAddrs = append(testShortIDAddrs, pk.PublicKey().Address())


### PR DESCRIPTION
## Why this should be merged

https://github.com/ava-labs/avalanchego/pull/2223 Made breaking changes to `secp.Factory` so this PR updates code to match the new upstream api. This will need to be updated to support the new upstream version of avalanchego.

## How this works

See above

## How this was tested

Build passes