### PR TITLE
Start v0.12.8 release

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,19 @@
 # Release Notes
 
+## [v0.12.8](https://github.com/ava-labs/coreth/releases/tag/v0.12.8)
+
+- Bump AvalancheGo to v1.10.15
+- Fix crash in prestate tracer on memory read
+
+## [v0.12.7](https://github.com/ava-labs/coreth/releases/tag/v0.12.7)
+
+- Bump AvalancheGo to v1.10.14
+
 ## [v0.12.6](https://github.com/ava-labs/coreth/releases/tag/v0.12.6)
+
+- Remove lock options from HTTP handlers
+- Fix deadlock in `eth_getLogs` when matcher session hits a missing block
+- Replace Kurtosis E2E tests with avctl test framework
 
 ## [v0.12.5](https://github.com/ava-labs/coreth/releases/tag/v0.12.5)
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.15-rc.1
+	github.com/ava-labs/avalanchego v1.10.15
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.15-rc.1 h1:5MQ6JAojk1oxTkD/Fj833+X3/4ARM1oOuLwNOuOFjKc=
-github.com/ava-labs/avalanchego v1.10.15-rc.1/go.mod h1:IT0UDCv0JjeAog/wSC8eFbr/wsmiUhdDZ2wpYVGIFE0=
+github.com/ava-labs/avalanchego v1.10.15 h1:GQ1bkwgKnv5D/yUwXUjWPFqx1cWrf35WOaHSykHUXyE=
+github.com/ava-labs/avalanchego v1.10.15/go.mod h1:fHTzxKZOMdM0n4EEXDDR0V3Ieb/Jnz7PM8zAsJRsh2U=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.12.7"
+	Version string = "v0.12.8"
 )
 
 func init() {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.15-rc.1'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.15'}


### PR DESCRIPTION
- Start the release cycle for v0.12.8
- Update AvalancheGo to v1.10.15
- Update RELEASES.md