### PR TITLE
remove extra err check

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1174,9 +1174,6 @@ func (vm *VM) buildBlock(_ context.Context) (snowman.Block, error) {
 		vm.mempool.DiscardCurrentTxs()
 		return nil, err
 	}
-	if err != nil {
-		return nil, err
-	}
 
 	// Verify is called on a non-wrapped block here, such that this
 	// does not add [blk] to the processing blocks map in ChainState.


### PR DESCRIPTION
## Why this should be merged
There is an extra err nil check for `vm.newBlock()`. We can remove this
## How this works

## How this was tested
