### PR TITLE
Atomic Mempool Refactor

### DIFF
--- a/plugin/evm/atomic_backend.go
+++ b/plugin/evm/atomic_backend.go
@@ -44,7 +44,7 @@ type AtomicBackend interface {
 	// This transaction is found in a 'processing' or 'undecided' block.
 	GetPendingTx(txID ids.ID) (*Tx, uint64, error)
 
-	// GetPendingTxs returns all pendingTxs in the atomicBackend's pendingTx map
+	// GetPendingTxs returns all pendingTxs in the pendingTx map
 	GetPendingTxs() map[ids.ID]pendingTx
 
 	// AtomicTrie returns the atomic trie managed by this backend.
@@ -367,7 +367,7 @@ func (a *atomicBackend) GetPendingTx(txID ids.ID) (*Tx, uint64, error) {
 	return nil, 0, errNoAtomicTxsFound
 }
 
-// GetPendingTxs returns all pendingTxs in the atomicBackend's pendingTx map
+// GetPendingTxs returns all pendingTxs in the pendingTx map
 func (a *atomicBackend) GetPendingTxs() map[ids.ID]pendingTx {
 	a.mu.RLock()
 	defer a.mu.RUnlock()

--- a/plugin/evm/atomic_state.go
+++ b/plugin/evm/atomic_state.go
@@ -99,7 +99,7 @@ func (a *atomicState) Reject(deletePending bool) error {
 	// Removes pendingTx associated with block from the pendingTx map
 	if deletePending {
 		for _, tx := range a.txs {
-			a.deletePendingTx(tx.ID(), a.blockHash)
+			a.backend.deletePendingTx(tx.ID(), a.blockHash)
 		}
 	}
 	// Unpin the rejected atomic trie root from memory.

--- a/plugin/evm/gossip_mempool_test.go
+++ b/plugin/evm/gossip_mempool_test.go
@@ -93,7 +93,7 @@ func TestAtomicMempoolIterate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			m, err := NewMempool(&snow.Context{}, 10, nil, nil)
+			m, err := NewMempool(&snow.Context{}, 10, makeAtomicBackend(t), nil)
 			require.NoError(err)
 
 			for _, add := range tt.add {

--- a/plugin/evm/gossip_mempool_test.go
+++ b/plugin/evm/gossip_mempool_test.go
@@ -93,7 +93,7 @@ func TestAtomicMempoolIterate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
-			m, err := NewMempool(&snow.Context{}, 10, nil)
+			m, err := NewMempool(&snow.Context{}, 10, nil, nil)
 			require.NoError(err)
 
 			for _, add := range tt.add {

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -283,7 +283,7 @@ func (n *pushGossiper) gossipAtomicTx(tx *Tx) error {
 	}
 	// If the transaction is not pending according to the mempool
 	// then there is no need to gossip it further.
-	if _, pending := n.atomicMempool.GetTx(txID); !pending {
+	if _, _, pending := n.atomicMempool.GetTx(txID); !pending {
 		return nil
 	}
 	n.recentAtomicTxs.Put(txID, nil)
@@ -456,7 +456,7 @@ func (h *GossipHandler) HandleAtomicTx(nodeID ids.NodeID, msg message.AtomicTxGo
 
 	txID := tx.ID()
 	h.stats.IncAtomicGossipReceived()
-	if _, found := h.atomicMempool.GetTx(txID); found {
+	if _, _, found := h.atomicMempool.GetTx(txID); found {
 		h.stats.IncAtomicGossipReceivedKnown()
 		return nil
 	}

--- a/plugin/evm/gossiper.go
+++ b/plugin/evm/gossiper.go
@@ -283,7 +283,7 @@ func (n *pushGossiper) gossipAtomicTx(tx *Tx) error {
 	}
 	// If the transaction is not pending according to the mempool
 	// then there is no need to gossip it further.
-	if _, pending := n.atomicMempool.GetPendingTx(txID); !pending {
+	if _, pending := n.atomicMempool.GetTx(txID); !pending {
 		return nil
 	}
 	n.recentAtomicTxs.Put(txID, nil)
@@ -456,11 +456,8 @@ func (h *GossipHandler) HandleAtomicTx(nodeID ids.NodeID, msg message.AtomicTxGo
 
 	txID := tx.ID()
 	h.stats.IncAtomicGossipReceived()
-	if _, dropped, found := h.atomicMempool.GetTx(txID); found {
+	if _, found := h.atomicMempool.GetTx(txID); found {
 		h.stats.IncAtomicGossipReceivedKnown()
-		return nil
-	} else if dropped {
-		h.stats.IncAtomicGossipReceivedDropped()
 		return nil
 	}
 

--- a/plugin/evm/gossiper_atomic_gossiping_test.go
+++ b/plugin/evm/gossiper_atomic_gossiping_test.go
@@ -203,10 +203,9 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	txID := tx.ID()
 
 	mempool.AddTx(tx)
-	mempool.NextTx()
-	mempool.DiscardCurrentTx(txID)
+	mempool.RemoveTx(tx)
 
-	// Check the mempool does not contain the discarded transaction
+	// Check the mempool does not contain the removed transaction
 	assert.False(mempool.has(txID))
 
 	// Gossip the transaction to the VM and ensure that it is not added to the mempool

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -16,10 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-const (
-	discardedTxsCacheSize = 50
-)
-
 var errNoGasUsed = errors.New("no gas used")
 
 // mempoolMetrics defines the metrics for the atomic mempool

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ava-labs/avalanchego/cache"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
@@ -25,13 +24,8 @@ var errNoGasUsed = errors.New("no gas used")
 
 // mempoolMetrics defines the metrics for the atomic mempool
 type mempoolMetrics struct {
-	pendingTxs metrics.Gauge // Gauge of currently pending transactions in the txHeap
-	currentTxs metrics.Gauge // Gauge of current transactions to be issued into a block
-	issuedTxs  metrics.Gauge // Gauge of transactions that have been issued into a block
-
-	addedTxs     metrics.Counter // Count of all transactions added to the mempool
-	discardedTxs metrics.Counter // Count of all discarded transactions
-
+	pendingTxs     metrics.Gauge   // Gauge of currently pending transactions in the txHeap
+	addedTxs       metrics.Counter // Count of all transactions added to the mempool
 	newTxsReturned metrics.Counter // Count of transactions returned from GetNewTxs
 }
 
@@ -39,10 +33,7 @@ type mempoolMetrics struct {
 func newMempoolMetrics() *mempoolMetrics {
 	return &mempoolMetrics{
 		pendingTxs:     metrics.GetOrRegisterGauge("atomic_mempool_pending_txs", nil),
-		currentTxs:     metrics.GetOrRegisterGauge("atomic_mempool_current_txs", nil),
-		issuedTxs:      metrics.GetOrRegisterGauge("atomic_mempool_issued_txs", nil),
 		addedTxs:       metrics.GetOrRegisterCounter("atomic_mempool_added_txs", nil),
-		discardedTxs:   metrics.GetOrRegisterCounter("atomic_mempool_discarded_txs", nil),
 		newTxsReturned: metrics.GetOrRegisterCounter("atomic_mempool_new_txs_returned", nil),
 	}
 }
@@ -54,13 +45,6 @@ type Mempool struct {
 	ctx *snow.Context
 	// maxSize is the maximum number of transactions allowed to be kept in mempool
 	maxSize int
-	// currentTxs is the set of transactions about to be added to a block.
-	currentTxs map[ids.ID]*Tx
-	// issuedTxs is the set of transactions that have been issued into a new block
-	issuedTxs map[ids.ID]*Tx
-	// discardedTxs is an LRU Cache of transactions that have been discarded after failing
-	// verification.
-	discardedTxs *cache.LRU[ids.ID, *Tx]
 	// Pending is a channel of length one, which the mempool ensures has an item on
 	// it as long as there is an unissued transaction remaining in [txs]
 	Pending chan struct{}
@@ -88,9 +72,6 @@ func NewMempool(ctx *snow.Context, maxSize int, verify func(tx *Tx) error) (*Mem
 
 	return &Mempool{
 		ctx:          ctx,
-		issuedTxs:    make(map[ids.ID]*Tx),
-		discardedTxs: &cache.LRU[ids.ID, *Tx]{Size: discardedTxsCacheSize},
-		currentTxs:   make(map[ids.ID]*Tx),
 		Pending:      make(chan struct{}, 1),
 		txHeap:       newTxHeap(maxSize),
 		maxSize:      maxSize,
@@ -111,14 +92,13 @@ func (m *Mempool) Len() int {
 
 // assumes the lock is held
 func (m *Mempool) length() int {
-	return m.txHeap.Len() + len(m.issuedTxs)
+	return m.txHeap.Len()
 }
 
-// has indicates if a given [txID] is in the mempool and has not been
-// discarded.
+// has indicates if a given [txID] is in the mempool
 func (m *Mempool) has(txID ids.ID) bool {
-	_, dropped, found := m.GetTx(txID)
-	return found && !dropped
+	_, found := m.GetTx(txID)
+	return found
 }
 
 // atomicTxGasPrice is the [gasPrice] paid by a transaction to burn a given
@@ -156,7 +136,6 @@ func (m *Mempool) AddTx(tx *Tx) error {
 		// unlike local txs, invalid remote txs are recorded as discarded
 		// so that they won't be requested again
 		txID := tx.ID()
-		m.discardedTxs.Put(tx.ID(), tx)
 		log.Debug("failed to issue remote tx to mempool",
 			"txID", txID,
 			"err", err,
@@ -219,12 +198,6 @@ func (m *Mempool) addTx(tx *Tx, force bool) error {
 	// If [txID] has already been issued or is in the currentTxs map
 	// there's no need to add it.
 	if !force {
-		if _, exists := m.issuedTxs[txID]; exists {
-			return nil
-		}
-		if _, exists := m.currentTxs[txID]; exists {
-			return nil
-		}
 		if _, exists := m.txHeap.Get(txID); exists {
 			return nil
 		}
@@ -257,7 +230,7 @@ func (m *Mempool) addTx(tx *Tx, force bool) error {
 		}
 		// Remove any conflicting transactions from the mempool
 		for _, conflictTx := range conflictingTxs {
-			m.removeTx(conflictTx, true)
+			m.removeTx(conflictTx)
 		}
 	}
 	// If adding this transaction would exceed the mempool's size, check if there is a lower priced
@@ -278,21 +251,12 @@ func (m *Mempool) addTx(tx *Tx, force bool) error {
 				)
 			}
 
-			m.removeTx(minTx, true)
+			m.removeTx(minTx)
 		} else {
 			// This could occur if we have used our entire size allowance on
 			// transactions that are currently processing.
 			return errTooManyAtomicTx
 		}
-	}
-
-	// If the transaction was recently discarded, log the event and evict from
-	// discarded transactions so it's not in two places within the mempool.
-	// We allow the transaction to be re-issued since it may have been invalid
-	// due to an atomic UTXO not being present yet.
-	if _, has := m.discardedTxs.Get(txID); has {
-		log.Debug("Adding recently discarded transaction %s back to the mempool", txID)
-		m.discardedTxs.Evict(txID)
 	}
 
 	// Add the transaction to the [txHeap] so we can evaluate new entries based
@@ -351,162 +315,25 @@ func (m *Mempool) GetFilter() ([]byte, []byte, error) {
 	return bloom, salt[:], err
 }
 
-// NextTx returns a transaction to be issued from the mempool.
-func (m *Mempool) NextTx() (*Tx, bool) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	// We include atomic transactions in blocks sorted by the [gasPrice] they
-	// pay.
-	if m.txHeap.Len() > 0 {
-		tx := m.txHeap.PopMax()
-		m.currentTxs[tx.ID()] = tx
-		m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-		m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-		return tx, true
+func (m *Mempool) GetTxs() []*Tx {
+	txs := make([]*Tx, 0, m.txHeap.maxHeap.Len())
+	for _, pendingTx := range m.txHeap.maxHeap.items {
+		txs = append(txs, pendingTx.tx)
 	}
-
-	return nil, false
+	return txs
 }
 
-// GetPendingTx returns the transaction [txID] and true if it is
-// currently in the [txHeap] waiting to be issued into a block.
-// Returns nil, false otherwise.
-func (m *Mempool) GetPendingTx(txID ids.ID) (*Tx, bool) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.txHeap.Get(txID)
-}
-
-// GetTx returns the transaction [txID] if it was issued
-// by this node and returns whether it was dropped and whether
-// it exists.
-func (m *Mempool) GetTx(txID ids.ID) (*Tx, bool, bool) {
+// GetTx retrieves a transaction from the mempool based on its unique [txID].
+// It returns the transaction if found in the mempool, along with a boolean indicating
+// whether the transaction is present or not.
+func (m *Mempool) GetTx(txID ids.ID) (*Tx, bool) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
 	if tx, ok := m.txHeap.Get(txID); ok {
-		return tx, false, true
+		return tx, true
 	}
-	if tx, ok := m.issuedTxs[txID]; ok {
-		return tx, false, true
-	}
-	if tx, ok := m.currentTxs[txID]; ok {
-		return tx, false, true
-	}
-	if tx, exists := m.discardedTxs.Get(txID); exists {
-		return tx, true, true
-	}
-
-	return nil, false, false
-}
-
-// IssueCurrentTx marks [currentTx] as issued if there is one
-func (m *Mempool) IssueCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	for txID := range m.currentTxs {
-		m.issuedTxs[txID] = m.currentTxs[txID]
-		delete(m.currentTxs, txID)
-	}
-	m.metrics.issuedTxs.Update(int64(len(m.issuedTxs)))
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-
-	// If there are more transactions to be issued, add an item
-	// to Pending.
-	if m.txHeap.Len() > 0 {
-		m.addPending()
-	}
-}
-
-// CancelCurrentTx marks the attempt to issue [txID]
-// as being aborted. This should be called after NextTx returns [txID]
-// and the transaction [txID] cannot be included in the block, but should
-// not be discarded. For example, CancelCurrentTx should be called if including
-// the transaction will put the block above the atomic tx gas limit.
-func (m *Mempool) CancelCurrentTx(txID ids.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if tx, ok := m.currentTxs[txID]; ok {
-		m.cancelTx(tx)
-	}
-}
-
-// [CancelCurrentTxs] marks the attempt to issue [currentTxs]
-// as being aborted. If this is called after a buildBlock error
-// caused by the atomic transaction, then DiscardCurrentTx should have been called
-// such that this call will have no effect and should not re-issue the invalid tx.
-func (m *Mempool) CancelCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	// If building a block failed, put the currentTx back in [txs]
-	// if it exists.
-	for _, tx := range m.currentTxs {
-		m.cancelTx(tx)
-	}
-
-	// If there are more transactions to be issued, add an item
-	// to Pending.
-	if m.txHeap.Len() > 0 {
-		m.addPending()
-	}
-}
-
-// cancelTx removes [tx] from current transactions and moves it back into the
-// tx heap.
-// assumes the lock is held.
-func (m *Mempool) cancelTx(tx *Tx) {
-	// Add tx to heap sorted by gasPrice
-	gasPrice, err := m.atomicTxGasPrice(tx)
-	if err == nil {
-		m.txHeap.Push(tx, gasPrice)
-		m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-	} else {
-		// If the err is not nil, we simply discard the transaction because it is
-		// invalid. This should never happen but we guard against the case it does.
-		log.Error("failed to calculate atomic tx gas price while canceling current tx", "err", err)
-		m.removeSpenders(tx)
-		m.discardedTxs.Put(tx.ID(), tx)
-		m.metrics.discardedTxs.Inc(1)
-	}
-
-	delete(m.currentTxs, tx.ID())
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-}
-
-// DiscardCurrentTx marks a [tx] in the [currentTxs] map as invalid and aborts the attempt
-// to issue it since it failed verification.
-func (m *Mempool) DiscardCurrentTx(txID ids.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if tx, ok := m.currentTxs[txID]; ok {
-		m.discardCurrentTx(tx)
-	}
-}
-
-// DiscardCurrentTxs marks all txs in [currentTxs] as discarded.
-func (m *Mempool) DiscardCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	for _, tx := range m.currentTxs {
-		m.discardCurrentTx(tx)
-	}
-}
-
-// discardCurrentTx discards [tx] from the set of current transactions.
-// Assumes the lock is held.
-func (m *Mempool) discardCurrentTx(tx *Tx) {
-	m.removeSpenders(tx)
-	m.discardedTxs.Put(tx.ID(), tx)
-	delete(m.currentTxs, tx.ID())
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-	m.metrics.discardedTxs.Inc(1)
+	return nil, false
 }
 
 // removeTx removes [txID] from the mempool.
@@ -515,23 +342,11 @@ func (m *Mempool) discardCurrentTx(tx *Tx) {
 // removeTx must be called for all conflicts before overwriting the utxoSpenders
 // map.
 // Assumes lock is held.
-func (m *Mempool) removeTx(tx *Tx, discard bool) {
+func (m *Mempool) removeTx(tx *Tx) {
 	txID := tx.ID()
-
 	// Remove from [currentTxs], [txHeap], and [issuedTxs].
-	delete(m.currentTxs, txID)
 	m.txHeap.Remove(txID)
-	delete(m.issuedTxs, txID)
-
-	if discard {
-		m.discardedTxs.Put(txID, tx)
-		m.metrics.discardedTxs.Inc(1)
-	} else {
-		m.discardedTxs.Evict(txID)
-	}
 	m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-	m.metrics.issuedTxs.Update(int64(len(m.issuedTxs)))
 
 	// Remove all entries from [utxoSpenders].
 	m.removeSpenders(tx)
@@ -547,12 +362,21 @@ func (m *Mempool) removeSpenders(tx *Tx) {
 }
 
 // RemoveTx removes [txID] from the mempool completely.
-// Evicts [tx] from the discarded cache if present.
 func (m *Mempool) RemoveTx(tx *Tx) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.removeTx(tx, false)
+	m.removeTx(tx)
+}
+
+// RemoveTxs removes all txs from the mempool completely.
+func (m *Mempool) RemoveTxs() {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	for _, pendingTx := range m.txHeap.maxHeap.lookup {
+		m.removeTx(pendingTx.tx)
+	}
 }
 
 // addPending makes sure that an item is in the Pending channel.

--- a/plugin/evm/mempool_atomic_gossiping_test.go
+++ b/plugin/evm/mempool_atomic_gossiping_test.go
@@ -70,9 +70,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 			assert.True(ok, "unknown block type")
 
 			assert.Equal(txID, evmBlk.atomicTxs[0].ID(), "block does not include expected transaction")
-
-			has = mempool.has(txID)
-			assert.True(has, "tx should stay in mempool until block is accepted")
+			assert.False(mempool.has(txID), "tx should be removed from mempool on issuance")
 
 			err = blk.Verify(context.Background())
 			assert.NoError(err)
@@ -81,7 +79,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 			assert.NoError(err)
 
 			has = mempool.has(txID)
-			assert.False(has, "tx shouldn't be in mempool after block is accepted")
+			assert.False(has, "tx shouldn't be in mempool")
 		})
 	}
 }

--- a/plugin/evm/mempool_test.go
+++ b/plugin/evm/mempool_test.go
@@ -34,3 +34,91 @@ func TestMempoolAddTx(t *testing.T) {
 		require.True(m.bloom.Has(tx))
 	}
 }
+
+func TestMempoolRemoveTx(t *testing.T) {
+	require := require.New(t)
+	m, err := NewMempool(&snow.Context{}, 5_000, nil)
+	require.NoError(err)
+
+	tx := newTestTx()
+
+	err = m.AddTx(tx)
+	require.NoError(err)
+	require.True(m.has(tx.ID()))
+
+	m.RemoveTx(tx)
+	require.False(m.has(tx.ID()))
+}
+
+func TestMempoolRemoveTxs(t *testing.T) {
+	require := require.New(t)
+	m, err := NewMempool(&snow.Context{}, 5_000, nil)
+	require.NoError(err)
+
+	txs := newTestTxs(1000)
+	for _, tx := range txs {
+		err := m.AddTx(tx)
+		require.NoError(err)
+		require.True(m.has(tx.ID()))
+	}
+
+	require.Equal(1000, m.length())
+
+	m.RemoveTxs()
+	require.Zero(m.length())
+	for _, tx := range txs {
+		require.False(m.has(tx.ID()))
+	}
+}
+
+func TestMempoolGetTx(t *testing.T) {
+	require := require.New(t)
+	m, err := NewMempool(&snow.Context{}, 5_000, nil)
+	require.NoError(err)
+
+	tx := newTestTx()
+
+	err = m.AddTx(tx)
+	require.NoError(err)
+	require.True(m.has(tx.ID()))
+
+	fetchedTx, isPending := m.GetTx(tx.ID())
+	require.True(isPending)
+	require.Equal(tx, fetchedTx)
+
+	otherTx := newTestTx()
+	fetchedOtherTx, isPending := m.GetTx(otherTx.ID())
+	require.False(isPending)
+	require.Nil(fetchedOtherTx)
+}
+
+func TestMempoolGetTxs(t *testing.T) {
+	require := require.New(t)
+	m, err := NewMempool(&snow.Context{}, 5_000, nil)
+	require.NoError(err)
+
+	tx := newTestTx()
+
+	err = m.AddTx(tx)
+	require.NoError(err)
+	require.True(m.has(tx.ID()))
+
+	txs := m.GetTxs()
+	require.Len(txs, 1)
+	require.Equal(tx, txs[0])
+
+	m.RemoveTx(tx)
+	require.Equal(0, m.length())
+
+	txs = newTestTxs(1000)
+	for _, tx := range txs {
+		err := m.AddTx(tx)
+		require.NoError(err)
+		require.True(m.has(tx.ID()))
+	}
+
+	require.Equal(1000, m.length())
+	fetchedTxs := m.GetTxs()
+	require.Len(fetchedTxs, 1000)
+	require.ElementsMatch(txs, fetchedTxs)
+}


### PR DESCRIPTION
## Why this should be merged
This PR adds improvements to the atomic mempool including better atomic transaction tracking, consistency with the existing “eth” transaction mempool, and reduction of the complexity of the mempool interface


[Proposal](https://docs.google.com/document/d/1RLcxVi3xlpK9BQEZAm2q1Z4DyrSD3G_ecXInLUldETM/edit#heading=h.kqepxmvh7zci)

### Changes
Remove mempool data structures (Issued, Discarded, Current) and associated functions
Remove Dropped Status
Mempool uses Atomic Backend to track issued txs 
Remove GetPendingTx and use GetTx instead



## How does this work
The [proposal](https://docs.google.com/document/d/1RLcxVi3xlpK9BQEZAm2q1Z4DyrSD3G_ecXInLUldETM/edit#heading=h.kqepxmvh7zci) outlines how it all works








## How this was tested

New mempool unit tests
New VM tests
Tests from parent PR [check-processing-blocks-for-atomic-txs](https://github.com/ava-labs/coreth/tree/check-processing-blocks-for-atomic-txs)

Existing UTs
