### PR TITLE
align rpc/types.go with upstream

### DIFF
--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -668,12 +668,6 @@ func (ec *client) SendTransaction(ctx context.Context, tx *types.Transaction) er
 }
 
 func ToBlockNumArg(number *big.Int) string {
-	// The Ethereum implementation uses a different mapping from
-	// negative numbers to special strings (latest, pending) then is
-	// used on its server side. See rpc/types.go for the comparison.
-	// In Coreth, latest, pending, and accepted are all treated the same
-	// therefore, if [number] is nil or a negative number in [-4, -1]
-	// we want the latest accepted block
 	if number == nil {
 		return "latest"
 	}
@@ -681,10 +675,9 @@ func ToBlockNumArg(number *big.Int) string {
 		return hexutil.EncodeBig(number)
 	}
 	// It's negative.
-	low := big.NewInt(-4)
-	high := big.NewInt(-1)
-	if number.Cmp(low) >= 0 && number.Cmp(high) <= 0 {
-		return rpc.LatestBlockNumber.String()
+	if number.IsInt64() {
+		return rpc.BlockNumber(number.Int64()).String()
+
 	}
 	// It's negative and large, which is invalid.
 	return fmt.Sprintf("<invalid %d>", number)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -681,8 +681,10 @@ func ToBlockNumArg(number *big.Int) string {
 		return hexutil.EncodeBig(number)
 	}
 	// It's negative.
-	if number.IsInt64() {
-		return rpc.BlockNumber(number.Int64()).String()
+	low := big.NewInt(-4)
+	high := big.NewInt(-1)
+	if number.Cmp(low) >= 0 && number.Cmp(high) <= 0 {
+		return rpc.LatestBlockNumber.String()
 	}
 	// It's negative and large, which is invalid.
 	return fmt.Sprintf("<invalid %d>", number)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -677,7 +677,6 @@ func ToBlockNumArg(number *big.Int) string {
 	// It's negative.
 	if number.IsInt64() {
 		return rpc.BlockNumber(number.Int64()).String()
-
 	}
 	// It's negative and large, which is invalid.
 	return fmt.Sprintf("<invalid %d>", number)

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -73,6 +73,7 @@ type jsonWriter interface {
 type BlockNumber int64
 
 const (
+	SafeBlockNumber     = BlockNumber(-4)
 	AcceptedBlockNumber = BlockNumber(-3)
 	LatestBlockNumber   = BlockNumber(-2)
 	PendingBlockNumber  = BlockNumber(-1)
@@ -101,10 +102,12 @@ func (bn *BlockNumber) UnmarshalJSON(data []byte) error {
 	case "pending":
 		*bn = PendingBlockNumber
 		return nil
-	// Include "finalized" and "safe" as an option for compatibility with
-	// FinalizedBlockNumber and SafeBlockNumber from geth.
-	case "accepted", "finalized", "safe":
+	// Include "finalized" as an option for compatibility with FinalizedBlockNumber
+	case "accepted", "finalized":
 		*bn = AcceptedBlockNumber
+		return nil
+	case "safe":
+		*bn = SafeBlockNumber
 		return nil
 	}
 
@@ -151,7 +154,7 @@ func (bn BlockNumber) String() string {
 
 // IsAccepted returns true if this blockNumber should be treated as a request for the last accepted block
 func (bn BlockNumber) IsAccepted() bool {
-	return bn < EarliestBlockNumber && bn >= AcceptedBlockNumber
+	return bn < EarliestBlockNumber && bn >= SafeBlockNumber
 }
 
 type BlockNumberOrHash struct {
@@ -191,10 +194,13 @@ func (bnh *BlockNumberOrHash) UnmarshalJSON(data []byte) error {
 		bn := PendingBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
-	// Include "finalized" and "safe" as an option for compatibility with
-	// FinalizedBlockNumber and SafeBlockNumber from geth.
-	case "accepted", "finalized", "safe":
+	// Include "finalized" as an option for compatibility with FinalizedBlockNumber from geth.
+	case "accepted", "finalized":
 		bn := AcceptedBlockNumber
+		bnh.BlockNumber = &bn
+		return nil
+	case "safe":
+		bn := SafeBlockNumber
 		bnh.BlockNumber = &bn
 		return nil
 	default:

--- a/rpc/types.go
+++ b/rpc/types.go
@@ -144,6 +144,8 @@ func (bn BlockNumber) String() string {
 		return "pending"
 	case AcceptedBlockNumber:
 		return "accepted"
+	case SafeBlockNumber:
+		return "safe"
 	default:
 		if bn < 0 {
 			return fmt.Sprintf("<invalid %d>", bn)


### PR DESCRIPTION
## Why this should be merged
Aligns rpc/types.go more with upstream by adding SafeBlock as a constant and permitting the blockNr -4 to map to it.
Behaviorally, we continue to use lastAccepted block for valid negative block numbers and this change modifies IsAccepted to account for this.

## How this works
As described above

## How this was tested
CI