### PR TITLE
Tx lookup skip

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -489,8 +489,8 @@ func (bc *BlockChain) dispatchTxUnindexer() {
 // - updating the acceptor tip index
 func (bc *BlockChain) writeBlockAcceptedIndices(b *types.Block) error {
 	batch := bc.db.NewBatch()
-	// negative means skip writing tx lookup entries
-	if bc.cacheConfig.TxLookupLimit >= 0 {
+	// -1 means skip writing tx lookup entries
+	if bc.cacheConfig.TxLookupLimit != -1 {
 		rawdb.WriteTxLookupEntriesByBlock(batch, b)
 	}
 	if err := rawdb.WriteAcceptorTip(batch, b.Hash()); err != nil {

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -411,11 +411,9 @@ func NewBlockChain(
 }
 
 // unindexBlocks unindexes transactions depending on user configuration
+// Invariant: This should not be called if TxLookupLimit is negative.
 func (bc *BlockChain) unindexBlocks(tail uint64, head uint64, done chan struct{}) {
 	start := time.Now()
-	if bc.cacheConfig.TxLookupLimit < 0 {
-		return
-	}
 	txLookupLimit := uint64(bc.cacheConfig.TxLookupLimit)
 	defer func() {
 		txUnindexTimer.Inc(time.Since(start).Milliseconds())
@@ -431,12 +429,10 @@ func (bc *BlockChain) unindexBlocks(tail uint64, head uint64, done chan struct{}
 // dispatchTxUnindexer is responsible for the deletion of the
 // transaction index.
 // Invariant: If TxLookupLimit is 0, it means all tx indices will be preserved.
+// Invariant: This should not be called if TxLookupLimit is negative.
 // Meaning that this function should never be called.
 func (bc *BlockChain) dispatchTxUnindexer() {
 	defer bc.wg.Done()
-	if bc.cacheConfig.TxLookupLimit < 0 {
-		return
-	}
 	txLookupLimit := uint64(bc.cacheConfig.TxLookupLimit)
 
 	// If the user just upgraded to a new version which supports transaction

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -489,7 +489,7 @@ func (bc *BlockChain) dispatchTxUnindexer() {
 // - updating the acceptor tip index
 func (bc *BlockChain) writeBlockAcceptedIndices(b *types.Block) error {
 	batch := bc.db.NewBatch()
-	// -1 means skip writing tx lookup entries
+	// negative means skip writing tx lookup entries
 	if bc.cacheConfig.TxLookupLimit >= 0 {
 		rawdb.WriteTxLookupEntriesByBlock(batch, b)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -763,7 +763,7 @@ func TestTransactionIndices(t *testing.T) {
 // TestCanonicalHashMarker tests all the canonical hash markers are updated/deleted
 // correctly in case reorg is called.
 func TestCanonicalHashMarker(t *testing.T) {
-	cases := []struct {
+	var cases = []struct {
 		forkA int
 		forkB int
 	}{

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -661,7 +661,7 @@ func TestTransactionIndices(t *testing.T) {
 			require.Nil(stored)
 			tailValue = 0
 		} else {
-			require.Equal(*tail, *stored)
+			require.EqualValues(*tail, *stored, "expected tail %d, got %d", *tail, *stored)
 			tailValue = *tail
 		}
 		for i := tailValue; i <= lastIndexed; i++ {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -753,7 +753,7 @@ func TestTransactionIndices(t *testing.T) {
 		require.NoError(err)
 
 		chain.DrainAcceptorQueue()
-		time.Sleep(50 * time.Millisecond) // Wait for indices initialisation
+		time.Sleep(500 * time.Millisecond) // Wait for indices initialisation
 
 		chain.Stop()
 		isSkip := l == -1

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -661,7 +661,7 @@ func TestTransactionIndices(t *testing.T) {
 			require.Nil(stored)
 			tailValue = 0
 		} else {
-			require.EqualValues(tail, stored, "expected tail %d, got %d", *tail, *stored)
+			require.Equal(*tail, *stored)
 			tailValue = *tail
 		}
 		for i := tailValue; i <= lastIndexed; i++ {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -927,7 +927,6 @@ func TestCreateThenDeletePreByzantium(t *testing.T) {
 	config.MuirGlacierBlock = nil
 	testCreateThenDelete(t, &config)
 }
-
 func TestCreateThenDeletePostByzantium(t *testing.T) {
 	testCreateThenDelete(t, params.TestChainConfig)
 }
@@ -952,8 +951,7 @@ func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
 		byte(vm.PUSH1), 0x1,
 		byte(vm.SSTORE),
 		// Get the runtime-code on the stack
-		byte(vm.PUSH32),
-	}
+		byte(vm.PUSH32)}
 	initCode = append(initCode, code...)
 	initCode = append(initCode, []byte{
 		byte(vm.PUSH1), 0x0, // offset
@@ -995,8 +993,8 @@ func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
 	})
 	// Import the canonical chain
 	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), DefaultCacheConfig, gspec, engine, vm.Config{
-		// Debug:  true,
-		// Tracer: logger.NewJSONLogger(nil, os.Stdout),
+		//Debug:  true,
+		//Tracer: logger.NewJSONLogger(nil, os.Stdout),
 	}, common.Hash{}, false)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
@@ -1041,8 +1039,7 @@ func TestTransientStorageReset(t *testing.T) {
 		byte(vm.TSTORE),
 
 		// Get the runtime-code on the stack
-		byte(vm.PUSH32),
-	}
+		byte(vm.PUSH32)}
 	initCode = append(initCode, code...)
 	initCode = append(initCode, []byte{
 		byte(vm.PUSH1), 0x0, // offset

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -656,14 +656,15 @@ func TestTransactionIndices(t *testing.T) {
 
 	check := func(tail *uint64, txSkip bool, lastIndexed uint64, chain *BlockChain) {
 		stored := rawdb.ReadTxIndexTail(chain.db)
-
+		var tailValue uint64
 		if tail == nil {
 			require.Nil(stored)
-			tail = new(uint64)
+			tailValue = 0
 		} else {
 			require.EqualValues(tail, stored, "expected tail %d, got %d", *tail, *stored)
+			tailValue = *tail
 		}
-		for i := *tail; i <= lastIndexed; i++ {
+		for i := tailValue; i <= lastIndexed; i++ {
 			block := rawdb.ReadBlock(chain.db, rawdb.ReadCanonicalHash(chain.db, i), i)
 			if block.Transactions().Len() == 0 {
 				continue
@@ -674,7 +675,7 @@ func TestTransactionIndices(t *testing.T) {
 			}
 		}
 
-		for i := uint64(0); i < *tail; i++ {
+		for i := uint64(0); i < tailValue; i++ {
 			block := rawdb.ReadBlock(chain.db, rawdb.ReadCanonicalHash(chain.db, i), i)
 			if block.Transactions().Len() == 0 {
 				continue

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -656,10 +656,12 @@ func TestTransactionIndices(t *testing.T) {
 
 	check := func(tail *uint64, txSkip bool, lastIndexed uint64, chain *BlockChain) {
 		stored := rawdb.ReadTxIndexTail(chain.db)
-		require.EqualValues(tail, stored)
 
 		if tail == nil {
-			return
+			require.Nil(stored)
+			tail = new(uint64)
+		} else {
+			require.EqualValues(tail, stored, "expected tail %d, got %d", *tail, *stored)
 		}
 		for i := *tail; i <= lastIndexed; i++ {
 			block := rawdb.ReadBlock(chain.db, rawdb.ReadCanonicalHash(chain.db, i), i)
@@ -763,7 +765,7 @@ func TestTransactionIndices(t *testing.T) {
 // TestCanonicalHashMarker tests all the canonical hash markers are updated/deleted
 // correctly in case reorg is called.
 func TestCanonicalHashMarker(t *testing.T) {
-	var cases = []struct {
+	cases := []struct {
 		forkA int
 		forkB int
 	}{
@@ -927,6 +929,7 @@ func TestCreateThenDeletePreByzantium(t *testing.T) {
 	config.MuirGlacierBlock = nil
 	testCreateThenDelete(t, &config)
 }
+
 func TestCreateThenDeletePostByzantium(t *testing.T) {
 	testCreateThenDelete(t, params.TestChainConfig)
 }
@@ -951,7 +954,8 @@ func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
 		byte(vm.PUSH1), 0x1,
 		byte(vm.SSTORE),
 		// Get the runtime-code on the stack
-		byte(vm.PUSH32)}
+		byte(vm.PUSH32),
+	}
 	initCode = append(initCode, code...)
 	initCode = append(initCode, []byte{
 		byte(vm.PUSH1), 0x0, // offset
@@ -993,8 +997,8 @@ func testCreateThenDelete(t *testing.T, config *params.ChainConfig) {
 	})
 	// Import the canonical chain
 	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), DefaultCacheConfig, gspec, engine, vm.Config{
-		//Debug:  true,
-		//Tracer: logger.NewJSONLogger(nil, os.Stdout),
+		// Debug:  true,
+		// Tracer: logger.NewJSONLogger(nil, os.Stdout),
 	}, common.Hash{}, false)
 	if err != nil {
 		t.Fatalf("failed to create tester chain: %v", err)
@@ -1039,7 +1043,8 @@ func TestTransientStorageReset(t *testing.T) {
 		byte(vm.TSTORE),
 
 		// Get the runtime-code on the stack
-		byte(vm.PUSH32)}
+		byte(vm.PUSH32),
+	}
 	initCode = append(initCode, code...)
 	initCode = append(initCode, []byte{
 		byte(vm.PUSH1), 0x0, // offset

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -153,7 +153,7 @@ type Config struct {
 
 	// TxLookupLimit is the maximum number of blocks from head whose tx indices
 	// are reserved:
-	// 	* -1:  means skip tx indexing
+	//  * -1:  means skip tx indexing (already indexed txs will not be cleaned)
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
 	TxLookupLimit int64

--- a/eth/ethconfig/config.go
+++ b/eth/ethconfig/config.go
@@ -153,7 +153,8 @@ type Config struct {
 
 	// TxLookupLimit is the maximum number of blocks from head whose tx indices
 	// are reserved:
+	// 	* -1:  means skip tx indexing
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
-	TxLookupLimit uint64
+	TxLookupLimit int64
 }

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -196,7 +196,7 @@ type Config struct {
 
 	// TxLookupLimit is the maximum number of blocks from head whose tx indices
 	// are reserved:
-	// 	* -1:  means skip tx indexing
+	//  * -1:  means skip tx indexing (already indexed txs will not be cleaned)
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
 	TxLookupLimit int64 `json:"tx-lookup-limit"`

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -5,6 +5,7 @@ package evm
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -68,6 +69,8 @@ var (
 	defaultAllowUnprotectedTxHashes = []common.Hash{
 		common.HexToHash("0xfefb2da535e927b85fe68eb81cb2e4a5827c905f78381a01ef2322aa9b0aee8e"), // EIP-1820: https://eips.ethereum.org/EIPS/eip-1820
 	}
+
+	errTxLookupLimit = errors.New("tx-lookup-limit must be >= -1")
 )
 
 type Duration struct {
@@ -289,6 +292,9 @@ func (c *Config) Validate() error {
 		return fmt.Errorf("cannot use commit interval of 0 with pruning enabled")
 	}
 
+	if c.TxLookupLimit < -1 {
+		return errTxLookupLimit
+	}
 	return nil
 }
 

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -193,9 +193,10 @@ type Config struct {
 
 	// TxLookupLimit is the maximum number of blocks from head whose tx indices
 	// are reserved:
+	// 	* -1:  means skip tx indexing
 	//  * 0:   means no limit
 	//  * N:   means N block limit [HEAD-N+1, HEAD] and delete extra indexes
-	TxLookupLimit uint64 `json:"tx-lookup-limit"`
+	TxLookupLimit int64 `json:"tx-lookup-limit"`
 }
 
 // EthAPIs returns an array of strings representing the Eth APIs that should be enabled

--- a/plugin/evm/config_test.go
+++ b/plugin/evm/config_test.go
@@ -87,24 +87,20 @@ func TestUnmarshalConfig(t *testing.T) {
 		{
 			"zero tx lookup limit",
 			[]byte(`{"tx-lookup-limit": 0}`),
-			func() Config {
-				return Config{TxLookupLimit: 0}
-			}(),
+			Config{TxLookupLimit: 0},
 			false,
 		},
 		{
 			"1 tx lookup limit",
 			[]byte(`{"tx-lookup-limit": 1}`),
-			func() Config {
-				return Config{TxLookupLimit: 1}
-			}(),
+			Config{TxLookupLimit: 1},
 			false,
 		},
 		{
 			"-1 tx lookup limit",
 			[]byte(`{"tx-lookup-limit": -1}`),
-			Config{},
-			true,
+			Config{TxLookupLimit: -1},
+			false,
 		},
 		{
 			"allow unprotected tx hashes",


### PR DESCRIPTION
It modifies type of `TxLookupLimit` flag from `uint64` type to `int64` with support for negative numbers which indicates to skip tx indexing.

Using negative number also means stop the tx unindexer from removing old indices. This is because unindexer still writes tail to DB and tries to keep up with the latest tip (even though the actual tx indexing is not performed on DB). Stopping (

Closes: #397 