### PR TITLE
Fix trie reuse after Commit in atomic sync

### DIFF
--- a/plugin/evm/atomic_backend.go
+++ b/plugin/evm/atomic_backend.go
@@ -181,6 +181,11 @@ func (a *atomicBackend) initialize(lastAcceptedHeight uint64) error {
 				return err
 			}
 		}
+		// Trie should be re-opened after committing.
+		tr, err = a.atomicTrie.OpenTrie(root)
+		if err != nil {
+			return err
+		}
 
 		heightsIndexed++
 		if time.Since(lastUpdate) > progressLogFrequency {

--- a/plugin/evm/atomic_backend.go
+++ b/plugin/evm/atomic_backend.go
@@ -181,7 +181,7 @@ func (a *atomicBackend) initialize(lastAcceptedHeight uint64) error {
 				return err
 			}
 		}
-		// Trie should be re-opened after committing.
+		// Trie must be re-opened after committing (not safe for re-use after commit)
 		tr, err = a.atomicTrie.OpenTrie(root)
 		if err != nil {
 			return err

--- a/plugin/evm/atomic_syncer.go
+++ b/plugin/evm/atomic_syncer.go
@@ -107,7 +107,7 @@ func (s *atomicSyncer) onLeafs(keys [][]byte, values [][]byte) error {
 					return err
 				}
 			}
-			// Trie should be re-opened after committing.
+			// Trie must be re-opened after committing (not safe for re-use after commit)
 			trie, err := s.atomicTrie.OpenTrie(root)
 			if err != nil {
 				return err

--- a/plugin/evm/atomic_syncer.go
+++ b/plugin/evm/atomic_syncer.go
@@ -107,6 +107,12 @@ func (s *atomicSyncer) onLeafs(keys [][]byte, values [][]byte) error {
 					return err
 				}
 			}
+			// Trie should be re-opened after committing.
+			trie, err := s.atomicTrie.OpenTrie(root)
+			if err != nil {
+				return err
+			}
+			s.trie = trie
 			s.lastHeight = height
 		}
 


### PR DESCRIPTION
## Why this should be merged
plugin/evm code should honor the invariant specified for committing tries here:
https://github.com/ava-labs/coreth/blob/0eef20a5aca777b5177961bc349fdb0da99c2d6a/trie/trie.go#L41-L48

## How this works
Re-opens the trie from the database after commit.

## How this was tested
CI