### PR TITLE
Clarify bonus block inclusion in atomic trie

### DIFF
--- a/plugin/evm/atomic_backend.go
+++ b/plugin/evm/atomic_backend.go
@@ -161,10 +161,8 @@ func (a *atomicBackend) initialize(lastAcceptedHeight uint64) error {
 			return err
 		}
 
-		if _, found := a.bonusBlocks[height]; found {
-			// If [height] is a bonus block, do not index the atomic operations into the trie
-			continue
-		}
+		// Note: The atomic trie canonically contains the duplicate operations
+		// from any bonus blocks.
 		if err := a.atomicTrie.UpdateTrie(tr, height, combinedOps); err != nil {
 			return err
 		}
@@ -400,7 +398,10 @@ func (a *atomicBackend) InsertTxs(blockHash common.Hash, blockHeight uint64, par
 		return common.Hash{}, err
 	}
 
-	// update the atomic trie
+	// Update the atomic trie with the atomic operations
+	//
+	// Note: The atomic trie canonically contains the duplicate operations from
+	// any bonus blocks.
 	atomicOps, err := mergeAtomicOps(txs)
 	if err != nil {
 		return common.Hash{}, err

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -982,6 +982,9 @@ func (vm *VM) onExtraStateChange(block *types.Block, state *state.StateDB) (*big
 			}
 		}
 		// Update the atomic backend with [txs] from this block.
+		//
+		// Note: The atomic trie canonically contains the duplicate operations
+		// from any bonus blocks.
 		_, err := vm.atomicBackend.InsertTxs(block.Hash(), block.NumberU64(), block.ParentHash(), txs)
 		if err != nil {
 			return nil, nil, err


### PR DESCRIPTION
## Why this should be merged

The atomic trie canonically includes bonus block operations. This clarifies (and fixes) this behavior.

## How this works

Adds comments and removes a bonus block check.

## How this was tested

CI