### PR TITLE
Fix codec size for large blocks

### DIFF
--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -22,7 +22,7 @@ var (
 
 func init() {
 	Codec = codec.NewManager(maxMessageSize)
-	c := linearcodec.NewDefault()
+	c := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs := wrappers.Errs{}
 	errs.Add(
@@ -54,7 +54,7 @@ func init() {
 	}
 
 	CrossChainCodec = codec.NewManager(maxMessageSize)
-	ccc := linearcodec.NewDefault()
+	ccc := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs = wrappers.Errs{}
 	errs.Add(

--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -21,7 +21,7 @@ var (
 )
 
 func init() {
-	Codec = codec.NewManager(maxMessageSize)
+	Codec = codec.NewManager(maxMessageSize + wrappers.ShortLen) // Add room for the codec version
 	c := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs := wrappers.Errs{}

--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -53,7 +53,7 @@ func init() {
 		panic(errs.Err)
 	}
 
-	CrossChainCodec = codec.NewManager(maxMessageSize)
+	CrossChainCodec = codec.NewManager(maxMessageSize + wrappers.ShortLen) // Add room for the codec version
 	ccc := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs = wrappers.Errs{}

--- a/plugin/evm/message/codec.go
+++ b/plugin/evm/message/codec.go
@@ -21,7 +21,7 @@ var (
 )
 
 func init() {
-	Codec = codec.NewManager(maxMessageSize + wrappers.ShortLen) // Add room for the codec version
+	Codec = codec.NewManager(maxMessageSize)
 	c := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs := wrappers.Errs{}
@@ -53,7 +53,7 @@ func init() {
 		panic(errs.Err)
 	}
 
-	CrossChainCodec = codec.NewManager(maxMessageSize + wrappers.ShortLen) // Add room for the codec version
+	CrossChainCodec = codec.NewManager(maxMessageSize)
 	ccc := linearcodec.NewCustomMaxLength(maxMessageSize)
 
 	errs = wrappers.Errs{}

--- a/plugin/evm/message/message_test.go
+++ b/plugin/evm/message/message_test.go
@@ -63,7 +63,7 @@ func TestEthTxsTooLarge(t *testing.T) {
 	assert := assert.New(t)
 
 	builtMsg := EthTxsGossip{
-		Txs: utils.RandomBytes(1024 * units.KiB),
+		Txs: utils.RandomBytes(maxMessageSize),
 	}
 	_, err := BuildGossipMessage(Codec, builtMsg)
 	assert.Error(err)

--- a/sync/client/client.go
+++ b/sync/client/client.go
@@ -351,7 +351,7 @@ func (c *client) get(ctx context.Context, request message.Request, parseFn parse
 			responseIntf, numElements, err = parseFn(c.codec, request, response)
 			if err != nil {
 				lastErr = err
-				log.Info("could not validate response, retrying", "nodeID", nodeID, "attempt", attempt, "request", request, "err", err)
+				log.Debug("could not validate response, retrying", "nodeID", nodeID, "attempt", attempt, "request", request, "err", err)
 				c.networkClient.TrackBandwidth(nodeID, 0)
 				metric.IncFailed()
 				metric.IncInvalidResponse()

--- a/sync/handlers/block_request_test.go
+++ b/sync/handlers/block_request_test.go
@@ -167,7 +167,7 @@ func TestBlockRequestHandlerLargeBlocks(t *testing.T) {
 	blocks, _, err := core.GenerateChain(gspec.Config, genesis, engine, memdb, 96, 0, func(i int, b *core.BlockGen) {
 		var data []byte
 		switch {
-		case i < 32:
+		case i <= 32:
 			data = make([]byte, units.MiB)
 		default:
 			data = make([]byte, units.MiB/16)


### PR DESCRIPTION
## Why this should be merged
Initializing the codec as such:

https://github.com/ava-labs/coreth/blame/abde8d63c32d75b8e966e41eabea0051a2ffa50d/plugin/evm/message/codec.go#L24-L25

does not result in the codec's max slice marshal capacity increasing (see https://github.com/ava-labs/avalanchego/blob/master/codec/linearcodec/codec.go#L55-L65)

Fixes https://github.com/ava-labs/avalanchego/issues/2454

Also this reduces the log level for retrying failed messages from peers to Debug so invalid responses cannot cause syncing clients to log @ info.

## How this works
Calls `NewCustomMaxLength`.

## How this was tested
Fixes the UT to encode a large block