### PR TITLE
Update warp log gas cost to reflect num topics

### DIFF
--- a/precompile/contracts/warp/contract.go
+++ b/precompile/contracts/warp/contract.go
@@ -28,7 +28,7 @@ const (
 	// Note: using trie write for the gas cost results in a conservative overestimate since the message is stored in a
 	// flat database that can be cleaned up after a period of time instead of the EVM trie.
 
-	SendWarpMessageGasCost uint64 = params.LogGas + 4*params.LogTopicGas + AddWarpMessageGasCost + contract.WriteGasCostPerSlot
+	SendWarpMessageGasCost uint64 = params.LogGas + 3*params.LogTopicGas + AddWarpMessageGasCost + contract.WriteGasCostPerSlot
 	// SendWarpMessageGasCostPerByte cost accounts for producing a signed message of a given size
 	SendWarpMessageGasCostPerByte uint64 = params.LogDataGas
 


### PR DESCRIPTION
This PR updates the `SendWarpMessageGasCost` to `3*params.LogTopicGas` to reflect that there are now three topics emitted (instead of 4 previous to https://github.com/ava-labs/subnet-evm/pull/923/files)