### PR TITLE
Update avalanchego dependency to v1.10.18-rc.8

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.18-rc.5
+	github.com/ava-labs/avalanchego v1.10.18-rc.8
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.18-rc.5 h1:kGfadhGDa/jKLunRJvQ4cLvKvJzd1MJDspHFnKWEsHk=
-github.com/ava-labs/avalanchego v1.10.18-rc.5/go.mod h1:RfJ7vv0nOk9iZrxcjQC6HnLNwlPFxkRVJhvGq+++0po=
+github.com/ava-labs/avalanchego v1.10.18-rc.8 h1:IBGS1psMY+HNm3w9kQHaHF1+SIssv7qdNV8H50mAGY4=
+github.com/ava-labs/avalanchego v1.10.18-rc.8/go.mod h1:duoSU6Xb1HoVhQThAXqcCY7ik7LPWwQHb/YgdauXrfc=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/plugin/evm/gossip.go
+++ b/plugin/evm/gossip.go
@@ -175,10 +175,7 @@ func (g *GossipEthTxPool) GetFilter() ([]byte, []byte, error) {
 	g.lock.RLock()
 	defer g.lock.RUnlock()
 
-	bloom, err := g.bloom.Bloom.MarshalBinary()
-	salt := g.bloom.Salt
-
-	return bloom, salt[:], err
+	return g.bloom.Marshal()
 }
 
 type GossipEthTxMarshaller struct{}

--- a/plugin/evm/mempool.go
+++ b/plugin/evm/mempool.go
@@ -379,10 +379,7 @@ func (m *Mempool) GetFilter() ([]byte, []byte, error) {
 	m.lock.RLock()
 	defer m.lock.RUnlock()
 
-	bloom, err := m.bloom.Bloom.MarshalBinary()
-	salt := m.bloom.Salt
-
-	return bloom, salt[:], err
+	return m.bloom.Marshal()
 }
 
 // NextTx returns a transaction to be issued from the mempool.

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -99,7 +99,7 @@ func TestEthTxGossip(t *testing.T) {
 	// Ask the VM for any new transactions. We should get nothing at first.
 	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
 	require.NoError(err)
-	emptyBloomFilterBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	emptyBloomFilterBytes, _, err := emptyBloomFilter.Marshal()
 	require.NoError(err)
 	request := &sdk.PullGossipRequest{
 		Filter: emptyBloomFilterBytes,
@@ -227,7 +227,7 @@ func TestAtomicTxGossip(t *testing.T) {
 	// Ask the VM for any new transactions. We should get nothing at first.
 	emptyBloomFilter, err := gossip.NewBloomFilter(txGossipBloomMaxItems, txGossipBloomFalsePositiveRate)
 	require.NoError(err)
-	emptyBloomFilterBytes, err := emptyBloomFilter.Bloom.MarshalBinary()
+	emptyBloomFilterBytes, _, err := emptyBloomFilter.Marshal()
 	require.NoError(err)
 	request := &sdk.PullGossipRequest{
 		Filter: emptyBloomFilterBytes,

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.18-rc.5'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.18-rc.8'}


### PR DESCRIPTION
## Why this should be merged

See: https://github.com/ava-labs/avalanchego/pull/2547

## How this works

Updates the avalanchego version.

## How this was tested

- [X] CI