### PR TITLE
remove no-op handler

### DIFF
--- a/plugin/evm/gossip.go
+++ b/plugin/evm/gossip.go
@@ -71,7 +71,6 @@ func newTxGossipHandler[T gossip.Gossipable](
 }
 
 type txGossipHandler struct {
-	p2p.NoOpHandler
 	appGossipHandler  p2p.Handler
 	appRequestHandler p2p.Handler
 }

--- a/plugin/evm/gossip.go
+++ b/plugin/evm/gossip.go
@@ -83,6 +83,10 @@ func (t txGossipHandler) AppRequest(ctx context.Context, nodeID ids.NodeID, dead
 	return t.appRequestHandler.AppRequest(ctx, nodeID, deadline, requestBytes)
 }
 
+func (t txGossipHandler) CrossChainAppRequest(context.Context, ids.ID, time.Time, []byte) ([]byte, error) {
+	return nil, nil
+}
+
 type GossipAtomicTxMarshaller struct{}
 
 func (g GossipAtomicTxMarshaller) MarshalGossip(tx *GossipAtomicTx) ([]byte, error) {


### PR DESCRIPTION
## Why this should be merged

Embedding the no-op handler could result into unexpected behavior in case interface changes and no-op handler implementation changes. IMO it's better to depend on the interface type check and introduce breaking change rather than using a no-op implementation

## How this works

Removes embedded no-op handler and implements interface functions.

## How this was tested

UTs should cover this.
