### PR TITLE
Add GetPreference implementation to the VM

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1364,6 +1364,10 @@ func (vm *VM) SetPreference(ctx context.Context, blkID ids.ID) error {
 	return vm.blockChain.SetPreference(block.(*Block).ethBlock)
 }
 
+func (vm *VM) GetPreference(ctx context.Context) (ids.ID, error) {
+	return ids.ID(vm.blockChain.CurrentBlock().Hash()), nil
+}
+
 // VerifyHeightIndex always returns a nil error since the index is maintained by
 // vm.blockChain.
 func (vm *VM) VerifyHeightIndex(context.Context) error {


### PR DESCRIPTION
This PR adds a `GetPreference` implementation to the VM. This simply returns the preference based off of the last written head block of the blockchain.

This is slightly different than just returning the last value set by `SetPreference`, since the head block is updated when inserting or building a block on top of the current head. For the Snowman consensus engine, inserting or building a new block on top of the current head successfully, should result in setting the preference to that new head afterwards, so this should not deviate from the expected preference of the Snowman consensus engine.