### PR TITLE
Revert "Use int64 timestamp"

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -252,7 +252,7 @@ func (oracle *Oracle) estimateNextBaseFee(ctx context.Context) (*big.Int, error)
 	// If the block does have a baseFee, calculate the next base fee
 	// based on the current time and add it to the tip to estimate the
 	// total gas price estimate.
-	_, nextBaseFee, err := dummy.EstimateNextBaseFee(oracle.backend.ChainConfig(), header, uint64(oracle.clock.Unix()))
+	_, nextBaseFee, err := dummy.EstimateNextBaseFee(oracle.backend.ChainConfig(), header, oracle.clock.Unix())
 	return nextBaseFee, err
 }
 
@@ -320,7 +320,7 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 	var (
 		latestBlockNumber     = head.Number.Uint64()
 		lowerBlockNumberLimit = uint64(0)
-		currentTime           = uint64(oracle.clock.Unix())
+		currentTime           = oracle.clock.Unix()
 		tipResults            []*big.Int
 		baseFeeResults        []*big.Int
 	)

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
-	github.com/ava-labs/avalanchego v1.10.18-rc.9
+	github.com/ava-labs/avalanchego v1.10.18-rc.8
 	github.com/cespare/cp v0.1.0
 	github.com/cockroachdb/pebble v0.0.0-20230209160836-829675f94811
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.10.18-rc.9 h1:/iFB4klsMFZCsp+ibVcC5GK5wNyyM14dkMkkmEwoP2E=
-github.com/ava-labs/avalanchego v1.10.18-rc.9/go.mod h1:fUaYA+VmiZBrMj7z+ZV+sepuovnad8rTEjW0klG0vCc=
+github.com/ava-labs/avalanchego v1.10.18-rc.8 h1:IBGS1psMY+HNm3w9kQHaHF1+SIssv7qdNV8H50mAGY4=
+github.com/ava-labs/avalanchego v1.10.18-rc.8/go.mod h1:duoSU6Xb1HoVhQThAXqcCY7ik7LPWwQHb/YgdauXrfc=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
 # Don't export them as they're used in the context of other calls
-avalanche_version=${AVALANCHE_VERSION:-'v1.10.18-rc.9'}
+avalanche_version=${AVALANCHE_VERSION:-'v1.10.18-rc.8'}


### PR DESCRIPTION
Reverts ava-labs/coreth#433

We aren't ready to merge the avalanchego side of this PR, so we should revert this change until after the next release.