### PR TITLE
`ci`: Add shellcheck step to lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,9 @@ jobs:
           version: v1.54
           working-directory: .
           args: --timeout 3m
+      - name: Run shellcheck
+        shell: bash
+        run: scripts/shellcheck.sh
   test:
     name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/metrics/validate.sh
+++ b/metrics/validate.sh
@@ -3,8 +3,8 @@
 set -e
 
 # check there are no formatting issues
-GOFMT_LINES=`gofmt -l . | wc -l | xargs`
-test $GOFMT_LINES -eq 0 || echo "gofmt needs to be run, ${GOFMT_LINES} files have issues"
+GOFMT_LINES=$(gofmt -l . | wc -l | xargs)
+test "$GOFMT_LINES" -eq 0 || echo "gofmt needs to be run, ${GOFMT_LINES} files have issues"
 
 # run the tests for the root package
 go test -race .

--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -17,4 +17,4 @@ source "$CORETH_PATH"/scripts/constants.sh
 
 # We pass in the arguments to this script directly to enable easily passing parameters such as enabling race detection,
 # parallelism, and test coverage.
-go test -coverprofile=coverage.out -covermode=atomic -timeout="30m" ./... $@
+go test -coverprofile=coverage.out -covermode=atomic -timeout="30m" ./... "$@"

--- a/scripts/constants.sh
+++ b/scripts/constants.sh
@@ -1,5 +1,10 @@
 #!/usr/bin/env bash
 
+# Ignore warnings about variables appearing unused since this file is not the consumer of the variables it defines.
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
 # Set the PATHS
 GOPATH="$(go env GOPATH)"
 

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -9,7 +9,7 @@ if [ ! -f "coverage.out" ]; then
   exit 0
 fi
 
-totalCoverage=`go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+'`
+totalCoverage=$(go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+')
 echo "Current test coverage : $totalCoverage %"
 echo "========================================"
 

--- a/scripts/lint_allowed_geth_imports.sh
+++ b/scripts/lint_allowed_geth_imports.sh
@@ -9,7 +9,7 @@ set -o pipefail
 # 2. Sort the unique results
 # #. Print out the difference between the search results and the list of specified allowed package imports from geth.
 extra_imports=$(grep -r --include='*.go' '"github.com/ethereum/go-ethereum/.*"' -o -h | sort -u | comm -23 - ./scripts/geth-allowed-packages.txt)
-if [ ! -z "${extra_imports}" ]; then
+if [ -n "${extra_imports}" ]; then
     echo "new go-ethereum imports should be added to ./scripts/geth-allowed-packages.txt to prevent accidental imports:"
     echo "${extra_imports}"
     exit 1

--- a/scripts/mock.gen.sh
+++ b/scripts/mock.gen.sh
@@ -34,10 +34,10 @@ source "$CORETH_PATH"/scripts/constants.sh
 # tuples of (source interface import path, comma-separated interface names, output file path)
 input="scripts/mocks.mockgen.txt"
 while IFS= read -r line; do
-  IFS='=' read src_import_path interface_name output_path <<<"${line}"
-  package_name=$(basename $(dirname $output_path))
+  IFS='=' read -r src_import_path interface_name output_path <<<"${line}"
+  package_name=$(basename "$(dirname "$output_path")")
   echo "Generating ${output_path}..."
-  mockgen -package=${package_name} -destination=${output_path} ${src_import_path} ${interface_name}
+  mockgen -package="${package_name}" -destination="${output_path}" "${src_import_path}" "${interface_name}"
 
   go-license \
     --config=./header.yml \

--- a/scripts/shellcheck.sh
+++ b/scripts/shellcheck.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+VERSION="v0.9.0"
+
+function get_version {
+  local target_path=$1
+  if command -v "${target_path}" > /dev/null; then
+    echo "v$("${target_path}" --version | grep version: | awk '{print $2}')"
+  fi
+}
+
+REPO_ROOT=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
+
+SYSTEM_VERSION="$(get_version shellcheck)"
+if [[ "${SYSTEM_VERSION}" == "${VERSION}" ]]; then
+  SHELLCHECK=shellcheck
+else
+  # Try to install a local version
+  SHELLCHECK="${REPO_ROOT}/bin/shellcheck"
+  LOCAL_VERSION="$(get_version "${SHELLCHECK}")"
+  if [[ -z "${LOCAL_VERSION}" || "${LOCAL_VERSION}" != "${VERSION}" ]]; then
+    if which sw_vers &> /dev/null; then
+      echo "on macos, only x86_64 binaries are available so rosetta is required"
+      echo "to avoid using rosetta, install via homebrew: brew install shellcheck"
+      DIST=darwin.x86_64
+    else
+      # Linux - binaries for common arches *should* be available
+      arch="$(uname -i)"
+      DIST="linux.${arch}"
+    fi
+    curl -s -L "https://github.com/koalaman/shellcheck/releases/download/${VERSION}/shellcheck-${VERSION}.${DIST}.tar.xz" | tar Jxv -C /tmp > /dev/null
+    mkdir -p "$(dirname "${SHELLCHECK}")"
+    cp /tmp/shellcheck-"${VERSION}"/shellcheck "${SHELLCHECK}"
+  fi
+fi
+
+find "${REPO_ROOT}" -name "*.sh" -type f -print0 | xargs -0 "${SHELLCHECK}" "${@}"

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
 
+# Ignore warnings about variables appearing unused since this file is not the consumer of the variables it defines.
+# shellcheck disable=SC2034
+
+set -euo pipefail
+
 # Don't export them as they're used in the context of other calls
 avalanche_version=${AVALANCHE_VERSION:-'v1.10.19-legacy-upgrade-times'}


### PR DESCRIPTION
# #lintallthethings!

We lint code, why not shell scripts? In addition to simplifying the avoidance of common shell errors, the [shellcheck wiki](https://www.shellcheck.net/wiki) has lots of documentation for all the error types it checks for.

### Testing

In addition to CI, local testing on arm64 linux and macos verified the logic for downloading and using a local (vs one in the path) shellcheck.

Related: [AvalancheGo PR](https://github.com/ava-labs/avalanchego/pull/2650)


