### PR TITLE
Expose GetMessage in Warp API

### DIFF
--- a/warp/client.go
+++ b/warp/client.go
@@ -15,6 +15,7 @@ import (
 var _ Client = (*client)(nil)
 
 type Client interface {
+	GetMessage(ctx context.Context, messageID ids.ID) ([]byte, error)
 	GetMessageSignature(ctx context.Context, messageID ids.ID) ([]byte, error)
 	GetMessageAggregateSignature(ctx context.Context, messageID ids.ID, quorumNum uint64, subnetIDStr string) ([]byte, error)
 	GetBlockSignature(ctx context.Context, blockID ids.ID) ([]byte, error)
@@ -35,6 +36,14 @@ func NewClient(uri, chain string) (Client, error) {
 	return &client{
 		client: innerClient,
 	}, nil
+}
+
+func (c *client) GetMessage(ctx context.Context, messageID ids.ID) ([]byte, error) {
+	var res hexutil.Bytes
+	if err := c.client.CallContext(ctx, &res, "warp_getMessage", messageID); err != nil {
+		return nil, fmt.Errorf("call to warp_getMessage failed. err: %w", err)
+	}
+	return res, nil
 }
 
 func (c *client) GetMessageSignature(ctx context.Context, messageID ids.ID) ([]byte, error) {

--- a/warp/service.go
+++ b/warp/service.go
@@ -40,6 +40,15 @@ func NewAPI(networkID uint32, sourceSubnetID ids.ID, sourceChainID ids.ID, state
 	}
 }
 
+// GetMessage returns the Warp message associated with a messageID.
+func (a *API) GetMessage(ctx context.Context, messageID ids.ID) (hexutil.Bytes, error) {
+	message, err := a.backend.GetMessage(messageID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get message %s with error %w", messageID, err)
+	}
+	return hexutil.Bytes(message.Bytes()), nil
+}
+
 // GetMessageSignature returns the BLS signature associated with a messageID.
 func (a *API) GetMessageSignature(ctx context.Context, messageID ids.ID) (hexutil.Bytes, error) {
 	signature, err := a.backend.GetMessageSignature(messageID)


### PR DESCRIPTION
## Why this should be merged
Exposes `GetMessage` in the Warp API. The use case is for clients (such as awm-relayer) to fetch a Warp message while only needing to know the ID, not the full message bytes.

Corresponding subnet-evm PR: https://github.com/ava-labs/subnet-evm/pull/1062

## How this works
Adds `GetMessage` to client.go and service.go

## How this was tested
Manually tested via the client in a local deployment

## How is this documented
N/A
