### PR TITLE
move MaxCodeHashesPerRequest

### DIFF
--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -38,11 +38,6 @@ const (
 	AtomicTxBaseCost uint64 = 10_000
 )
 
-// Constants for message sizes
-const (
-	MaxCodeHashesPerRequest = 5
-)
-
 // The atomic gas limit specifies the maximum amount of gas that can be consumed by the atomic
 // transactions included in a block and is enforced as of ApricotPhase5. Prior to ApricotPhase5,
 // a block included a single atomic transaction. As of ApricotPhase5, each block can include a set

--- a/plugin/evm/message/leafs_request.go
+++ b/plugin/evm/message/leafs_request.go
@@ -12,6 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
+const MaxCodeHashesPerRequest = 5
+
 var _ Request = LeafsRequest{}
 
 // NodeType outlines the trie that a leaf node belongs to

--- a/sync/handlers/code_request.go
+++ b/sync/handlers/code_request.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 
 	"github.com/ava-labs/coreth/core/rawdb"
-	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	"github.com/ava-labs/coreth/sync/handlers/stats"
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +49,7 @@ func (n *CodeRequestHandler) OnCodeRequest(_ context.Context, nodeID ids.NodeID,
 		n.stats.UpdateCodeReadTime(time.Since(startTime))
 	}()
 
-	if len(codeRequest.Hashes) > params.MaxCodeHashesPerRequest {
+	if len(codeRequest.Hashes) > message.MaxCodeHashesPerRequest {
 		n.stats.IncTooManyHashesRequested()
 		log.Debug("too many hashes requested, dropping request", "nodeID", nodeID, "requestID", requestID, "numHashes", len(codeRequest.Hashes))
 		return nil, nil

--- a/sync/statesync/code_syncer.go
+++ b/sync/statesync/code_syncer.go
@@ -12,7 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/coreth/core/rawdb"
-	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/message"
 	statesyncclient "github.com/ava-labs/coreth/sync/client"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/ethdb"
@@ -140,7 +140,7 @@ func (c *codeSyncer) addCodeToFetchFromDBToQueue() error {
 // work fulfills any incoming requests from the producer channel by fetching code bytes from the network
 // and fulfilling them by updating the database.
 func (c *codeSyncer) work(ctx context.Context) error {
-	codeHashes := make([]common.Hash, 0, params.MaxCodeHashesPerRequest)
+	codeHashes := make([]common.Hash, 0, message.MaxCodeHashesPerRequest)
 
 	for {
 		select {
@@ -159,7 +159,7 @@ func (c *codeSyncer) work(ctx context.Context) error {
 			codeHashes = append(codeHashes, codeHash)
 			// Try to wait for at least [MaxCodeHashesPerRequest] code hashes to batch into a single request
 			// if there's more work remaining.
-			if len(codeHashes) < params.MaxCodeHashesPerRequest {
+			if len(codeHashes) < message.MaxCodeHashesPerRequest {
 				continue
 			}
 			if err := c.fulfillCodeRequest(ctx, codeHashes); err != nil {


### PR DESCRIPTION
## Why this should be merged
Moves the definition of MaxCodeHashesPerRequest from params to `evm.message`, to the same place it's defined in subnet-evm.
We could move it to `code_request.go` instead in both repos

## How this works
Moves a constant

## How this was tested
CI