### PR TITLE
Update TxPool base fee prior to filtering txs based on effective tip

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -1841,6 +1841,13 @@ func (pool *TxPool) updateBaseFee() {
 	}
 }
 
+func (pool *TxPool) SetBaseFee(baseFee *big.Int) {
+	pool.mu.Lock()
+	defer pool.mu.Unlock()
+
+	pool.priced.SetBaseFee(baseFee)
+}
+
 // addressByHeartbeat is an account address tagged with its last activity timestamp.
 type addressByHeartbeat struct {
 	address   common.Address

--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -597,8 +597,17 @@ func (pool *TxPool) ContentFrom(addr common.Address) (types.Transactions, types.
 // transactions and only return those whose **effective** tip is large enough in
 // the next pending execution environment.
 func (pool *TxPool) Pending(enforceTips bool) map[common.Address]types.Transactions {
+	return pool.PendingWithBaseFee(enforceTips, nil)
+}
+
+// If baseFee is nil, then pool.priced.urgent.baseFee is used.
+func (pool *TxPool) PendingWithBaseFee(enforceTips bool, baseFee *big.Int) map[common.Address]types.Transactions {
 	pool.mu.Lock()
 	defer pool.mu.Unlock()
+
+	if baseFee == nil {
+		baseFee = pool.priced.urgent.baseFee
+	}
 
 	pending := make(map[common.Address]types.Transactions, len(pool.pending))
 	for addr, list := range pool.pending {
@@ -607,7 +616,7 @@ func (pool *TxPool) Pending(enforceTips bool) map[common.Address]types.Transacti
 		// If the miner requests tip enforcement, cap the lists now
 		if enforceTips && !pool.locals.contains(addr) {
 			for i, tx := range txs {
-				if tx.EffectiveGasTipIntCmp(pool.gasPrice, pool.priced.urgent.baseFee) < 0 {
+				if tx.EffectiveGasTipIntCmp(pool.gasPrice, baseFee) < 0 {
 					txs = txs[:i]
 					break
 				}
@@ -1843,13 +1852,6 @@ func (pool *TxPool) updateBaseFee() {
 	} else {
 		log.Error("failed to update base fee", "currentHead", pool.currentHead.Hash(), "err", err)
 	}
-}
-
-func (pool *TxPool) SetBaseFee(baseFee *big.Int) {
-	pool.mu.Lock()
-	defer pool.mu.Unlock()
-
-	pool.priced.SetBaseFee(baseFee)
 }
 
 // addressByHeartbeat is an account address tagged with its last activity timestamp.

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -192,10 +192,7 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 	}
 
 	// Fill the block with all available pending transactions.
-	if header.BaseFee != nil {
-		w.eth.TxPool().SetBaseFee(header.BaseFee)
-	}
-	pending := w.eth.TxPool().Pending(true)
+	pending := w.eth.TxPool().PendingWithBaseFee(true, header.BaseFee)
 
 	// Split the pending transactions into locals and remotes
 	localTxs := make(map[common.Address]types.Transactions)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -192,6 +192,9 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 	}
 
 	// Fill the block with all available pending transactions.
+	if header.BaseFee != nil {
+		w.eth.TxPool().SetBaseFee(header.BaseFee)
+	}
 	pending := w.eth.TxPool().Pending(true)
 
 	// Split the pending transactions into locals and remotes


### PR DESCRIPTION
## Why this should be merged
This change allows transactions that have used a base fee that is less than the last fee update's estimate but greater than the actual built block's fee to be included in the block.
This is particularly useful when the base fee is decreasing (with time) and the client is using an estimate that is based on the current time, but the periodic update has not taken effect yet.

## How this works
Sets the value used to filter txs before filtering them

## How this was tested
CI