### PR TITLE
Remove unused journaling configs

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -196,7 +196,9 @@ type Config struct {
 // DefaultConfig contains the default configurations for the transaction
 // pool.
 var DefaultConfig = Config{
-	Journal:   "transactions.rlp",
+	// If we re-enable txpool journaling, we should also add the saved local
+	// transactions to the p2p gossip on startup.
+	Journal:   "",
 	Rejournal: time.Hour,
 
 	PriceLimit: 1,

--- a/core/txpool/txpool_test.go
+++ b/core/txpool/txpool_test.go
@@ -55,16 +55,13 @@ import (
 var (
 	// testTxPoolConfig is a transaction pool configuration without stateful disk
 	// sideeffects used during testing.
-	testTxPoolConfig Config
+	testTxPoolConfig = DefaultConfig
 
 	// eip1559Config is a chain config with EIP-1559 enabled at block 0.
 	eip1559Config *params.ChainConfig
 )
 
 func init() {
-	testTxPoolConfig = DefaultConfig
-	testTxPoolConfig.Journal = ""
-
 	cpy := *params.TestChainConfig
 	eip1559Config = &cpy
 	eip1559Config.ApricotPhase2BlockTimestamp = utils.NewUint64(0)

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -224,7 +224,6 @@ func New(
 
 	eth.bloomIndexer.Start(eth.blockchain)
 
-	config.TxPool.Journal = ""
 	eth.txPool = txpool.NewTxPool(config.TxPool, eth.blockchain.Config(), eth.blockchain)
 
 	eth.miner = miner.New(eth, &config.Miner, eth.blockchain.Config(), eth.EventMux(), eth.engine, clock)

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -128,14 +128,12 @@ type Config struct {
 	// API Settings
 	LocalTxsEnabled bool `json:"local-txs-enabled"`
 
-	TxPoolJournal      string   `json:"tx-pool-journal"`
-	TxPoolRejournal    Duration `json:"tx-pool-rejournal"`
-	TxPoolPriceLimit   uint64   `json:"tx-pool-price-limit"`
-	TxPoolPriceBump    uint64   `json:"tx-pool-price-bump"`
-	TxPoolAccountSlots uint64   `json:"tx-pool-account-slots"`
-	TxPoolGlobalSlots  uint64   `json:"tx-pool-global-slots"`
-	TxPoolAccountQueue uint64   `json:"tx-pool-account-queue"`
-	TxPoolGlobalQueue  uint64   `json:"tx-pool-global-queue"`
+	TxPoolPriceLimit   uint64 `json:"tx-pool-price-limit"`
+	TxPoolPriceBump    uint64 `json:"tx-pool-price-bump"`
+	TxPoolAccountSlots uint64 `json:"tx-pool-account-slots"`
+	TxPoolGlobalSlots  uint64 `json:"tx-pool-global-slots"`
+	TxPoolAccountQueue uint64 `json:"tx-pool-account-queue"`
+	TxPoolGlobalQueue  uint64 `json:"tx-pool-global-queue"`
 
 	APIMaxDuration           Duration      `json:"api-max-duration"`
 	WSCPURefillRate          Duration      `json:"ws-cpu-refill-rate"`
@@ -229,8 +227,6 @@ func (c *Config) SetDefaults() {
 	c.RPCTxFeeCap = defaultRpcTxFeeCap
 	c.MetricsExpensiveEnabled = defaultMetricsExpensiveEnabled
 
-	c.TxPoolJournal = txpool.DefaultConfig.Journal
-	c.TxPoolRejournal = Duration{txpool.DefaultConfig.Rejournal}
 	c.TxPoolPriceLimit = txpool.DefaultConfig.PriceLimit
 	c.TxPoolPriceBump = txpool.DefaultConfig.PriceBump
 	c.TxPoolAccountSlots = txpool.DefaultConfig.AccountSlots

--- a/plugin/evm/config_test.go
+++ b/plugin/evm/config_test.go
@@ -28,8 +28,8 @@ func TestUnmarshalConfig(t *testing.T) {
 	}{
 		{
 			"string durations parsed",
-			[]byte(`{"api-max-duration": "1m", "continuous-profiler-frequency": "2m", "tx-pool-rejournal": "3m30s"}`),
-			Config{APIMaxDuration: Duration{1 * time.Minute}, ContinuousProfilerFrequency: Duration{2 * time.Minute}, TxPoolRejournal: Duration{3*time.Minute + 30*time.Second}},
+			[]byte(`{"api-max-duration": "1m", "continuous-profiler-frequency": "2m"}`),
+			Config{APIMaxDuration: Duration{1 * time.Minute}, ContinuousProfilerFrequency: Duration{2 * time.Minute}},
 			false,
 		},
 		{
@@ -40,8 +40,8 @@ func TestUnmarshalConfig(t *testing.T) {
 		},
 		{
 			"nanosecond durations parsed",
-			[]byte(`{"api-max-duration": 5000000000, "continuous-profiler-frequency": 5000000000, "tx-pool-rejournal": 9000000000}`),
-			Config{APIMaxDuration: Duration{5 * time.Second}, ContinuousProfilerFrequency: Duration{5 * time.Second}, TxPoolRejournal: Duration{9 * time.Second}},
+			[]byte(`{"api-max-duration": 5000000000, "continuous-profiler-frequency": 5000000000}`),
+			Config{APIMaxDuration: Duration{5 * time.Second}, ContinuousProfilerFrequency: Duration{5 * time.Second}},
 			false,
 		},
 		{
@@ -53,9 +53,8 @@ func TestUnmarshalConfig(t *testing.T) {
 
 		{
 			"tx pool configurations",
-			[]byte(`{"tx-pool-journal": "hello", "tx-pool-price-limit": 1, "tx-pool-price-bump": 2, "tx-pool-account-slots": 3, "tx-pool-global-slots": 4, "tx-pool-account-queue": 5, "tx-pool-global-queue": 6}`),
+			[]byte(`{"tx-pool-price-limit": 1, "tx-pool-price-bump": 2, "tx-pool-account-slots": 3, "tx-pool-global-slots": 4, "tx-pool-account-queue": 5, "tx-pool-global-queue": 6}`),
 			Config{
-				TxPoolJournal:      "hello",
 				TxPoolPriceLimit:   1,
 				TxPoolPriceBump:    2,
 				TxPoolAccountSlots: 3,

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -206,7 +206,6 @@ func setupPoolWithConfig(t *testing.T, config *params.ChainConfig, fundedAddress
 	chain, err := core.NewBlockChain(diskdb, core.DefaultCacheConfig, gspec, engine, vm.Config{}, common.Hash{}, false)
 	require.NoError(t, err)
 	testTxPoolConfig := txpool.DefaultConfig
-	testTxPoolConfig.Journal = ""
 	pool := txpool.NewTxPool(testTxPoolConfig, config, chain)
 
 	return pool

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -511,8 +511,6 @@ func (vm *VM) Initialize(
 	vm.ethConfig.RPCTxFeeCap = vm.config.RPCTxFeeCap
 
 	vm.ethConfig.TxPool.NoLocals = !vm.config.LocalTxsEnabled
-	vm.ethConfig.TxPool.Journal = vm.config.TxPoolJournal
-	vm.ethConfig.TxPool.Rejournal = vm.config.TxPoolRejournal.Duration
 	vm.ethConfig.TxPool.PriceLimit = vm.config.TxPoolPriceLimit
 	vm.ethConfig.TxPool.PriceBump = vm.config.TxPoolPriceBump
 	vm.ethConfig.TxPool.AccountSlots = vm.config.TxPoolAccountSlots


### PR DESCRIPTION
## Why this should be merged

Currently the txpool journal is disabled by explicitly setting `Journal = ""` in the `eth/backend`. This is fairly odd - as we explicitly support users to configure the `Journal`.

## How this works

- Removes the `Journal` config options and sets the default value to be disabled.
- Adds a comment that we should ensure that local transactions are gossiped if we re-enable journaling.

## How this was tested

- [X] CI