### PR TITLE
Add tx-pool-lifetime config (10m)

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -209,7 +209,7 @@ var DefaultConfig = Config{
 	AccountQueue: 64,
 	GlobalQueue:  1024,
 
-	Lifetime: 3 * time.Hour,
+	Lifetime: 10 * time.Minute,
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/plugin/evm/config.go
+++ b/plugin/evm/config.go
@@ -133,12 +133,13 @@ type Config struct {
 	// API Settings
 	LocalTxsEnabled bool `json:"local-txs-enabled"`
 
-	TxPoolPriceLimit   uint64 `json:"tx-pool-price-limit"`
-	TxPoolPriceBump    uint64 `json:"tx-pool-price-bump"`
-	TxPoolAccountSlots uint64 `json:"tx-pool-account-slots"`
-	TxPoolGlobalSlots  uint64 `json:"tx-pool-global-slots"`
-	TxPoolAccountQueue uint64 `json:"tx-pool-account-queue"`
-	TxPoolGlobalQueue  uint64 `json:"tx-pool-global-queue"`
+	TxPoolPriceLimit   uint64   `json:"tx-pool-price-limit"`
+	TxPoolPriceBump    uint64   `json:"tx-pool-price-bump"`
+	TxPoolAccountSlots uint64   `json:"tx-pool-account-slots"`
+	TxPoolGlobalSlots  uint64   `json:"tx-pool-global-slots"`
+	TxPoolAccountQueue uint64   `json:"tx-pool-account-queue"`
+	TxPoolGlobalQueue  uint64   `json:"tx-pool-global-queue"`
+	TxPoolLifetime     Duration `json:"tx-pool-lifetime"`
 
 	APIMaxDuration           Duration      `json:"api-max-duration"`
 	WSCPURefillRate          Duration      `json:"ws-cpu-refill-rate"`
@@ -240,6 +241,7 @@ func (c *Config) SetDefaults() {
 	c.TxPoolGlobalSlots = txpool.DefaultConfig.GlobalSlots
 	c.TxPoolAccountQueue = txpool.DefaultConfig.AccountQueue
 	c.TxPoolGlobalQueue = txpool.DefaultConfig.GlobalQueue
+	c.TxPoolLifetime.Duration = txpool.DefaultConfig.Lifetime
 
 	c.APIMaxDuration.Duration = defaultApiMaxDuration
 	c.WSCPURefillRate.Duration = defaultWsCpuRefillRate

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -516,6 +516,7 @@ func (vm *VM) Initialize(
 	vm.ethConfig.TxPool.GlobalSlots = vm.config.TxPoolGlobalSlots
 	vm.ethConfig.TxPool.AccountQueue = vm.config.TxPoolAccountQueue
 	vm.ethConfig.TxPool.GlobalQueue = vm.config.TxPoolGlobalQueue
+	vm.ethConfig.TxPool.Lifetime = vm.config.TxPoolLifetime.Duration
 
 	vm.ethConfig.AllowUnfinalizedQueries = vm.config.AllowUnfinalizedQueries
 	vm.ethConfig.AllowUnprotectedTxs = vm.config.AllowUnprotectedTxs


### PR DESCRIPTION
## Why this should be merged

Currently the `txpool.Lifetime` is hardcoded to `3h`. This makes it configurable and defaults to `10m`.

## How this works

Add to config + update default.

## How this was tested