### PR TITLE
Wait for chain state updates to report atomic tx as Accepted

### DIFF
--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -473,10 +473,10 @@ func (service *AvaxAPI) GetAtomicTxStatus(r *http.Request, args *api.JSONTxID, r
 
 	reply.Status = status
 	if status == Accepted {
-		lastAccepted := service.vm.blockChain.LastAcceptedBlock()
 		// Since chain state updates run asynchronously with VM block acceptance,
 		// avoid returning [Accepted] until the chain state reaches the block
 		// containing the atomic tx.
+		lastAccepted := service.vm.blockChain.LastAcceptedBlock()
 		if height > lastAccepted.NumberU64() {
 			reply.Status = Processing
 			return nil

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -512,7 +512,7 @@ func (service *AvaxAPI) GetAtomicTx(r *http.Request, args *api.GetTxArgs, reply 
 	reply.Encoding = args.Encoding
 
 	// Since chain state updates run asynchronously with VM block acceptance,
-	// avoid returning [Accepted] while the chain state hasn't reached the block
+	// avoid returning [Accepted] until the chain state reaches the block
 	// containing the atomic tx.
 	lastAccepted := service.vm.blockChain.LastAcceptedBlock()
 	if status == Accepted && height >= lastAccepted.NumberU64() {

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -473,6 +473,15 @@ func (service *AvaxAPI) GetAtomicTxStatus(r *http.Request, args *api.JSONTxID, r
 
 	reply.Status = status
 	if status == Accepted {
+		lastAccepted := service.vm.blockChain.LastAcceptedBlock()
+		// Since chain state updates run asynchronously with VM block acceptance,
+		// avoid returning [Accepted] until the chain state reaches the block
+		// containing the atomic tx.
+		if height > lastAccepted.NumberU64() {
+			reply.Status = Processing
+			return nil
+		}
+
 		jsonHeight := json.Uint64(height)
 		reply.BlockHeight = &jsonHeight
 	}
@@ -511,11 +520,15 @@ func (service *AvaxAPI) GetAtomicTx(r *http.Request, args *api.GetTxArgs, reply 
 	reply.Tx = txBytes
 	reply.Encoding = args.Encoding
 
-	// Since chain state updates run asynchronously with VM block acceptance,
-	// avoid returning [Accepted] until the chain state reaches the block
-	// containing the atomic tx.
-	lastAccepted := service.vm.blockChain.LastAcceptedBlock()
-	if status == Accepted && height >= lastAccepted.NumberU64() {
+	if status == Accepted {
+		// Since chain state updates run asynchronously with VM block acceptance,
+		// avoid returning [Accepted] until the chain state reaches the block
+		// containing the atomic tx.
+		lastAccepted := service.vm.blockChain.LastAcceptedBlock()
+		if height > lastAccepted.NumberU64() {
+			return nil
+		}
+
 		jsonHeight := json.Uint64(height)
 		reply.BlockHeight = &jsonHeight
 	}

--- a/plugin/evm/service.go
+++ b/plugin/evm/service.go
@@ -519,7 +519,6 @@ func (service *AvaxAPI) GetAtomicTx(r *http.Request, args *api.GetTxArgs, reply 
 	}
 	reply.Tx = txBytes
 	reply.Encoding = args.Encoding
-
 	if status == Accepted {
 		// Since chain state updates run asynchronously with VM block acceptance,
 		// avoid returning [Accepted] until the chain state reaches the block


### PR DESCRIPTION
## Why this should be merged
https://github.com/ava-labs/avalanchego/issues/2853

## How this works
Since chain state updates run asynchronously with VM block acceptance,
avoid returning [Accepted] until the chain state reaches the block
containing the atomic tx.

## How this was tested
CI