### PR TITLE
Fix mismatched method names in comments

### DIFF
--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -187,7 +187,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	return newRollupWindow, baseFee, nil
 }
 
-// EstiamteNextBaseFee attempts to estimate the next base fee based on a block with [parent] being built at
+// EstimateNextBaseFee attempts to estimate the next base fee based on a block with [parent] being built at
 // [timestamp].
 // If [timestamp] is less than the timestamp of [parent], then it uses the same timestamp as parent.
 // Warning: This function should only be used in estimation and should not be used when calculating the canonical

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1002,7 +1002,7 @@ func (bc *BlockChain) setPreference(block *types.Block) error {
 	return nil
 }
 
-// LastAcceptedBlock returns the last block to be marked as accepted. It may or
+// LastConsensusAcceptedBlock returns the last block to be marked as accepted. It may or
 // may not yet be processed.
 func (bc *BlockChain) LastConsensusAcceptedBlock() *types.Block {
 	bc.chainmu.Lock()

--- a/core/rawdb/accessors_snapshot.go
+++ b/core/rawdb/accessors_snapshot.go
@@ -70,7 +70,7 @@ func ReadSnapshotBlockHash(db ethdb.KeyValueReader) common.Hash {
 	return common.BytesToHash(data)
 }
 
-// WriteSnapshotRoot stores the root of the block whose state is contained in
+// WriteSnapshotBlockHash stores the root of the block whose state is contained in
 // the persisted snapshot.
 func WriteSnapshotBlockHash(db ethdb.KeyValueWriter, blockHash common.Hash) {
 	if err := db.Put(snapshotBlockHashKey, blockHash[:]); err != nil {


### PR DESCRIPTION
## Why this should be merged

Fix mismatched method names in comments

## How this works

## How this was tested
