### PR TITLE
avoid relying on rand.Seed for deterministic results

### DIFF
--- a/plugin/evm/atomic_syncer_test.go
+++ b/plugin/evm/atomic_syncer_test.go
@@ -183,10 +183,11 @@ func TestAtomicSyncerResumeNewRootCheckpoint(t *testing.T) {
 	numTrieKeys1 := int(targetHeight1) - 1 // no atomic ops for genesis
 	root1, _, _ := syncutils.GenerateTrie(t, serverTrieDB, numTrieKeys1, atomicKeyLength)
 
-	rand.Seed(1) // seed rand again to get the same leafs in GenerateTrie
 	targetHeight2 := 20 * uint64(commitInterval)
 	numTrieKeys2 := int(targetHeight2) - 1 // no atomic ops for genesis
-	root2, _, _ := syncutils.GenerateTrie(t, serverTrieDB, numTrieKeys2, atomicKeyLength)
+	root2, _, _ := syncutils.FillTrie(
+		t, numTrieKeys1, numTrieKeys2, atomicKeyLength, serverTrieDB, root1,
+	)
 
 	testAtomicSyncer(t, serverTrieDB, targetHeight1, root1, []atomicSyncTestCheckpoint{
 		{


### PR DESCRIPTION
## Why this should be merged
Other tests that run concurrently may violate the test's assumption that it can reproduce the trie keys by setting the random seed.

## How this works
Creates the larger tree by expanding on the first tree, by making some functions more general.

## How this was tested
CI