### PR TITLE
bump version to v0.13.3 & go 1.21.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v5
         with:
-          go-version: '~1.21.7'
+          go-version: '~1.21.9'
           check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -68,7 +68,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v5
       with:
-        go-version: '~1.21.7'
+        go-version: '~1.21.9'
         check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -101,7 +101,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v5
       with:
-        go-version: '~1.21.7'
+        go-version: '~1.21.9'
         check-latest: true
     - name: change avalanchego dep
       if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -132,7 +132,7 @@ jobs:
         token: ${{ secrets.AVALANCHE_PAT }}
     - uses: actions/setup-go@v5
       with:
-        go-version: '~1.21.7'
+        go-version: '~1.21.9'
         check-latest: true
     - name: Run e2e tests
       run: E2E_SERIAL=1 ./scripts/tests.e2e.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # ============= Compilation Stage ================
-FROM golang:1.21.7-bullseye AS builder
+FROM golang:1.21.9-bullseye AS builder
 
 ARG AVALANCHE_VERSION
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
 ## [v0.13.0](https://github.com/ava-labs/coreth/releases/tag/v0.13.0)
 
 - Bump AvalancheGo to v1.11.1
-- Bump minimum Go version to 1.21.9
+- Bump minimum Go version to 1.21.7
 - Add more error messages to warp backend
 
 ## [v0.12.10](https://github.com/ava-labs/coreth/releases/tag/v0.12.10)

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
 ## [v0.13.0](https://github.com/ava-labs/coreth/releases/tag/v0.13.0)
 
 - Bump AvalancheGo to v1.11.1
-- Bump minimum Go version to 1.21.7
+- Bump minimum Go version to 1.21.9
 - Add more error messages to warp backend
 
 ## [v0.12.10](https://github.com/ava-labs/coreth/releases/tag/v0.12.10)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/coreth
 
-go 1.21
+go 1.21.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.13.2"
+	Version string = "v0.13.3"
 )
 
 func init() {

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,30 +4,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-go_version_minimum="1.18.1"
-
-go_version() {
-    go version | sed -nE -e 's/[^0-9.]+([0-9.]+).+/\1/p'
-}
-
-version_lt() {
-    # Return true if $1 is a lower version than than $2,
-    local ver1=$1
-    local ver2=$2
-    # Reverse sort the versions, if the 1st item != ver1 then ver1 < ver2
-    if  [[ $(echo -e -n "$ver1\n$ver2\n" | sort -rV | head -n1) != "$ver1" ]]; then
-        return 0
-    else
-        return 1
-    fi
-}
-
-if version_lt "$(go_version)" "$go_version_minimum"; then
-    echo "Coreth requires Go >= $go_version_minimum, Go $(go_version) found." >&2
-    exit 1
-fi
-
-# Coreth root directory
+# Root directory
 CORETH_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )"; cd .. && pwd )
 
 # Load the versions


### PR DESCRIPTION
## Why this should be merged
Updates the version string and golang versions in preparations for an RC

## How this works
updates versions

## How this was tested
CI