### PR TITLE
gossip/mempool: refactor Add in GossipEthTxPool and Mempool

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/coreth
 
-go 1.21.9
+go 1.21.10
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.10.0
@@ -129,3 +129,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/ava-labs/avalanchego => github.com/lebdron/avalanchego v0.0.0-20240508232726-d27149c9dba9

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.5 h1:3HCE6I1/9BOSrIvwXXuOhVuMGMi926jKhQ+sgU3LEX8=
-github.com/ava-labs/avalanchego v1.11.5/go.mod h1:XPNUEh0ezPEW1IV6yo6AwvqjTZSG1twGskDb7dVcIRA=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
@@ -368,6 +366,8 @@ github.com/labstack/echo/v4 v4.5.0/go.mod h1:czIriw4a0C1dFun+ObrXp7ok03xON0N1awS
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9 h1:fQjYxZaynp97ozCzfOyOuAGOU4aU/z37zf/tOujFk7c=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
+github.com/lebdron/avalanchego v0.0.0-20240508232726-d27149c9dba9 h1:yrfdra8qJB+MLorRLTfxAY7Dc5rj94magz40aBLiJj8=
+github.com/lebdron/avalanchego v0.0.0-20240508232726-d27149c9dba9/go.mod h1:jMherpoO1MQCB16DCqvncmSOA7OpfmkjIevxKG2TZWU=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.6 h1:5ibWZ6iY0NctNGWo87LalDlEZ6R41TqbbDamhfG/Qzo=
 github.com/magiconair/properties v1.8.6/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=

--- a/plugin/evm/gossip.go
+++ b/plugin/evm/gossip.go
@@ -187,10 +187,14 @@ func (g *GossipEthTxPool) Subscribe(ctx context.Context) {
 	}
 }
 
-// Add enqueues the transaction to the mempool. Subscribe should be called
+// Add enqueues the transactions to the mempool. Subscribe should be called
 // to receive an event if tx is actually added to the mempool or not.
-func (g *GossipEthTxPool) Add(tx *GossipEthTx) error {
-	return g.mempool.Add([]*types.Transaction{tx.Tx}, false, false)[0]
+func (g *GossipEthTxPool) Add(txs ...*GossipEthTx) []error {
+	unwrapped := make([]*types.Transaction, len(txs))
+	for i, tx := range txs {
+		unwrapped[i] = tx.Tx
+	}
+	return g.mempool.Add(unwrapped, false, false)
 }
 
 // Has should just return whether or not the [txID] is still in the mempool,

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -110,8 +110,9 @@ func TestAtomicMempoolIterate(t *testing.T) {
 			m, err := NewMempool(&snow.Context{}, prometheus.NewRegistry(), 10, nil)
 			require.NoError(err)
 
-			for _, add := range tt.add {
-				require.NoError(m.Add(add))
+			errs := m.Add(tt.add...)
+			for _, err := range errs {
+				require.NoError(err)
 			}
 
 			matches := make([]*GossipAtomicTx, 0)

--- a/plugin/evm/mempool_test.go
+++ b/plugin/evm/mempool_test.go
@@ -28,7 +28,10 @@ func TestMempoolAddTx(t *testing.T) {
 		}
 
 		txs = append(txs, tx)
-		require.NoError(m.Add(tx))
+	}
+	errs := m.Add(txs...)
+	for _, err := range errs {
+		require.NoError(err)
 	}
 
 	for _, tx := range txs {
@@ -50,7 +53,7 @@ func TestMempoolAdd(t *testing.T) {
 		},
 	}
 
-	require.NoError(m.Add(tx))
-	err = m.Add(tx)
+	require.NoError(m.Add(tx)[0])
+	err = m.Add(tx)[0]
 	require.ErrorIs(err, errTxAlreadyKnown)
 }


### PR DESCRIPTION
## Why this should be merged

Refactor Add to implement the refactored interface https://github.com/ava-labs/avalanchego/pull/2986 , allowing not to require mutex acquire and release on every added transaction in gossip.

## How this works

## How this was tested
