### PR TITLE
Remove optional gatherer

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.10
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.6
+	github.com/ava-labs/avalanchego v1.11.7-remove-optional-gatherer
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.6 h1:gPWNQSV+bY3XW9OhfJ4wNwxp/qidTSHA4V+VYP8kWpQ=
-github.com/ava-labs/avalanchego v1.11.6/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
+github.com/ava-labs/avalanchego v1.11.7-remove-optional-gatherer h1:zypQAMneAPjwuifqoZYhisqH58GZ2pquFeRqVTLI2p8=
+github.com/ava-labs/avalanchego v1.11.7-remove-optional-gatherer/go.mod h1:s8U9tOakcU6ftSL4JcRcFrNNYI5JbekNCjTkdqZWYdE=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -17,7 +17,6 @@ import (
 	"sync"
 	"time"
 
-	avalanchegoMetrics "github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	avalanchegoConstants "github.com/ava-labs/avalanchego/utils/constants"
@@ -137,6 +136,7 @@ const (
 
 	// Prefixes for metrics gatherers
 	ethMetricsPrefix        = "eth"
+	sdkMetricsPrefix        = "sdk"
 	chainStateMetricsPrefix = "chain_state"
 
 	targetAtomicTxsSize = 40 * units.KiB
@@ -316,8 +316,7 @@ type VM struct {
 	validators *p2p.Validators
 
 	// Metrics
-	multiGatherer avalanchegoMetrics.MultiGatherer
-	sdkMetrics    *prometheus.Registry
+	sdkMetrics *prometheus.Registry
 
 	bootstrapped bool
 	IsPlugin     bool
@@ -667,18 +666,13 @@ func (vm *VM) Initialize(
 
 func (vm *VM) initializeMetrics() error {
 	vm.sdkMetrics = prometheus.NewRegistry()
-	vm.multiGatherer = avalanchegoMetrics.NewMultiGatherer()
-	// If metrics are enabled, register the default metrics regitry
+	// If metrics are enabled, register the default metrics registry
 	if metrics.Enabled {
 		gatherer := corethPrometheus.Gatherer(metrics.DefaultRegistry)
-		if err := vm.multiGatherer.Register(ethMetricsPrefix, gatherer); err != nil {
+		if err := vm.ctx.Metrics.Register(ethMetricsPrefix, gatherer); err != nil {
 			return err
 		}
-		if err := vm.multiGatherer.Register("sdk", vm.sdkMetrics); err != nil {
-			return err
-		}
-		// Register [multiGatherer] after registerers have been registered to it
-		if err := vm.ctx.Metrics.Register(vm.multiGatherer); err != nil {
+		if err := vm.ctx.Metrics.Register(sdkMetricsPrefix, vm.sdkMetrics); err != nil {
 			return err
 		}
 	}
@@ -816,7 +810,7 @@ func (vm *VM) initChainState(lastAcceptedBlock *types.Block) error {
 	}
 	vm.State = state
 
-	return vm.multiGatherer.Register(chainStateMetricsPrefix, chainStateRegisterer)
+	return vm.ctx.Metrics.Register(chainStateMetricsPrefix, chainStateRegisterer)
 }
 
 func (vm *VM) createConsensusCallbacks() dummy.ConsensusCallbacks {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.6'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.7-remove-optional-gatherer'}

--- a/utils/snow.go
+++ b/utils/snow.go
@@ -26,7 +26,7 @@ func TestSnowContext() *snow.Context {
 		PublicKey:      pk,
 		Log:            logging.NoLog{},
 		BCLookup:       ids.NewAliaser(),
-		Metrics:        metrics.NewOptionalGatherer(),
+		Metrics:        metrics.NewMultiGatherer(),
 		ChainDataDir:   "",
 		ValidatorState: &validators.TestState{},
 	}


### PR DESCRIPTION
## Why this should be merged

Avalanchego is no longer supporting the `metrics.OptionalGatherer`.

## How this works

Simplifies metrics creation.

## How this was tested

- [X] CI