### PR TITLE
prepare v0.13.6 release cycle

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## [v0.13.6](https://github.com/ava-labs/coreth/releases/tag/v0.13.5)
+- rpc: truncate call error data logs
+- logging: remove path prefix (up to coreth@version/) from logged file names.
+- cleanup: removes pre-Durango scripts
+
 ## [v0.13.5](https://github.com/ava-labs/coreth/releases/tag/v0.13.5)
 - Bump AvalancheGo to v1.11.7
 - Bump golang version requirement to 1.21.11

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## [v0.13.6](https://github.com/ava-labs/coreth/releases/tag/v0.13.5)
+## [v0.13.6](https://github.com/ava-labs/coreth/releases/tag/v0.13.6)
 - rpc: truncate call error data logs
 - logging: remove path prefix (up to coreth@version/) from logged file names.
 - cleanup: removes pre-Durango scripts

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.13.5"
+	Version string = "v0.13.6"
 )
 
 func init() {


### PR DESCRIPTION
## Why this should be merged
Bump version numbers in preparation for next release

## How this was tested
CI