### PR TITLE
[ci] Add actionlint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Run shellcheck
         shell: bash
         run: scripts/shellcheck.sh
+      - name: Run actionlint
+        shell: bash
+        run: scripts/actionlint.sh
   test:
-    name: Golang Unit Tests v${{ matrix.go }} (${{ matrix.os }})
+    name: Golang Unit Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -80,7 +83,7 @@ jobs:
     - name: Set timeout on Windows # Windows UT run slower and need a longer timeout
       shell: bash
       if: matrix.os == 'windows-latest'
-      run: echo "TIMEOUT=1200s" >> $GITHUB_ENV
+      run: echo "TIMEOUT=1200s" >> "$GITHUB_ENV"
     - run: go mod download
       shell: bash
     - run: ./scripts/build.sh evm
@@ -92,7 +95,7 @@ jobs:
     - run: ./scripts/coverage.sh
       shell: bash
   avalanchego_e2e:
-    name: AvalancheGo E2E Tests v${{ matrix.go }} (${{ matrix.os }})
+    name: AvalancheGo E2E Tests (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v3
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -53,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -67,5 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
-
+      uses: github/codeql-action/analyze@v3

--- a/scripts/actionlint.sh
+++ b/scripts/actionlint.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.1
+
+actionlint


### PR DESCRIPTION
Adds linter for github action configuration in keeping with a [similar addition to avalanchego](https://github.com/ava-labs/avalanchego/pull/3160).