### PR TITLE
eupgrade: base definitions

### DIFF
--- a/params/network_upgrades.go
+++ b/params/network_upgrades.go
@@ -16,6 +16,7 @@ func (c *ChainConfig) forkOrder() []fork {
 		{name: "banffBlockTimestamp", timestamp: c.BanffBlockTimestamp},
 		{name: "cortinaBlockTimestamp", timestamp: c.CortinaBlockTimestamp},
 		{name: "durangoBlockTimestamp", timestamp: c.DurangoBlockTimestamp},
+		{name: "eUpgradeTime", timestamp: c.EUpgradeTime},
 	}
 }
 
@@ -25,6 +26,7 @@ type AvalancheRules struct {
 	IsBanff                                                                             bool
 	IsCortina                                                                           bool
 	IsDurango                                                                           bool
+	IsEUpgrade                                                                          bool
 }
 
 func (c *ChainConfig) GetAvalancheRules(timestamp uint64) AvalancheRules {
@@ -40,6 +42,7 @@ func (c *ChainConfig) GetAvalancheRules(timestamp uint64) AvalancheRules {
 	rules.IsBanff = c.IsBanff(timestamp)
 	rules.IsCortina = c.IsCortina(timestamp)
 	rules.IsDurango = c.IsDurango(timestamp)
+	rules.IsEUpgrade = c.IsEUpgrade(timestamp)
 
 	return rules
 }


### PR DESCRIPTION
## Why this should be merged
In preparation for EUpgrade, VM should know when to activate the upgrade.

## How this works
Adds support for passing EUpgrade around the rules & config structs.

## How this was tested
CI