### PR TITLE
Use `avax.GetAtomicUTXOs`

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1722,40 +1722,15 @@ func (vm *VM) GetAtomicUTXOs(
 		limit = maxUTXOsToFetch
 	}
 
-	addrsList := make([][]byte, addrs.Len())
-	for i, addr := range addrs.List() {
-		addrsList[i] = addr.Bytes()
-	}
-
-	allUTXOBytes, lastAddr, lastUTXO, err := vm.ctx.SharedMemory.Indexed(
+	return avax.GetAtomicUTXOs(
+		vm.ctx.SharedMemory,
+		vm.codec,
 		chainID,
-		addrsList,
-		startAddr.Bytes(),
-		startUTXOID[:],
+		addrs,
+		startAddr,
+		startUTXOID,
 		limit,
 	)
-	if err != nil {
-		return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("error fetching atomic UTXOs: %w", err)
-	}
-
-	lastAddrID, err := ids.ToShortID(lastAddr)
-	if err != nil {
-		lastAddrID = ids.ShortEmpty
-	}
-	lastUTXOID, err := ids.ToID(lastUTXO)
-	if err != nil {
-		lastUTXOID = ids.Empty
-	}
-
-	utxos := make([]*avax.UTXO, len(allUTXOBytes))
-	for i, utxoBytes := range allUTXOBytes {
-		utxo := &avax.UTXO{}
-		if _, err := vm.codec.Unmarshal(utxoBytes, utxo); err != nil {
-			return nil, ids.ShortID{}, ids.ID{}, fmt.Errorf("error parsing UTXO: %w", err)
-		}
-		utxos[i] = utxo
-	}
-	return utxos, lastAddrID, lastUTXOID, nil
 }
 
 // GetSpendableFunds returns a list of EVMInputs and keys (in corresponding


### PR DESCRIPTION
## Why this should be merged

This code is duplicated from avalanchego. We can call the AvalancheGo helper directly.

## How this works

Calls `avax.GetAtomicUTXOs`

## How this was tested

CI
