### PR TITLE
update avalanchego v1.11.10-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.12
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.10-status-removal
+	github.com/ava-labs/avalanchego v1.11.10-rc.1
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.10-status-removal h1:XHF4iFteHTJo+7SnB9bxIwPmMmDf7gqS5wUS/uuZsxc=
-github.com/ava-labs/avalanchego v1.11.10-status-removal/go.mod h1:NlSe4PE40EWD9rBLoNQrEvhABjcOyrV5McUpD3Q6h3Y=
+github.com/ava-labs/avalanchego v1.11.10-rc.1 h1:ry6BLRpd/0rvYvwMKpwpFTuMR1JD9MEeqpqAY58oRr8=
+github.com/ava-labs/avalanchego v1.11.10-rc.1/go.mod h1:ryRFbHr7sKmez4792NxzJS7AGiE+vd0Tez+qs2kmezE=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.10-status-removal'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.10-rc.1'}


### PR DESCRIPTION
Updates AvalancheGo to [v1.11.10-rc.1](https://github.com/ava-labs/avalanchego/releases/tag/v1.11.10-rc.1)