### PR TITLE
enables cancun at EUpgrade

### DIFF
--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -129,3 +129,10 @@ func getUpgradeTime(networkID uint32, upgradeTimes map[uint32]time.Time) *uint64
 	// genesis.
 	return utils.NewUint64(0)
 }
+
+// SetEVMUpgrades sets the mapped upgrades (Avalanche > EVM upgrades) for the chain config.
+func (c *ChainConfig) SetEVMUpgrades() {
+	if c.EUpgradeTime != nil {
+		c.CancunTime = utils.NewUint64(*c.EUpgradeTime)
+	}
+}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -490,6 +490,8 @@ func (vm *VM) Initialize(
 
 	vm.chainID = g.Config.ChainID
 
+	g.Config.SetEVMUpgrades()
+
 	vm.ethConfig = ethconfig.NewDefaultConfig()
 	vm.ethConfig.Genesis = g
 	vm.ethConfig.NetworkId = vm.chainID.Uint64()


### PR DESCRIPTION
## Why this should be merged
https://github.com/avalanche-foundation/ACPs/pull/131

## How this works
Enables Cancun upgrade at the same time as the Avalanche "EUpgrade"

## How this was tested
CI