### PR TITLE
fix: use `avalanchego` new `*test` packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.12
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.10-prerelease
+	github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.10-prerelease h1:QUhVqvxrwDmsTvXXnKoePe5WU3Eh8GXB/QE2R2xHa0c=
-github.com/ava-labs/avalanchego v1.11.10-prerelease/go.mod h1:ryRFbHr7sKmez4792NxzJS7AGiE+vd0Tez+qs2kmezE=
+github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef h1:w0N/YXgNoXjDUwdFHGpWYq41uHxvBneHaJ+X0BxSj2w=
+github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/peer/network_test.go
+++ b/peer/network_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/set"
 	ethcommon "github.com/ethereum/go-ethereum/common"
@@ -510,7 +511,7 @@ func TestHandleInvalidMessages(t *testing.T) {
 
 	nodeID := ids.GenerateTestNodeID()
 	requestID := uint32(1)
-	sender := &common.SenderTest{
+	sender := &enginetest.Sender{
 		SendAppErrorF: func(context.Context, ids.NodeID, uint32, int32, string) error {
 			return nil
 		},

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -127,7 +128,7 @@ func TestStateSyncToggleEnabledToDisabled(t *testing.T) {
 	test.expectedErr = nil
 
 	syncDisabledVM := &VM{}
-	appSender := &commonEng.SenderTest{T: t}
+	appSender := &enginetest.Sender{T: t}
 	appSender.SendAppGossipF = func(context.Context, commonEng.SendConfig, []byte) error { return nil }
 	appSender.SendAppRequestF = func(ctx context.Context, nodeSet set.Set[ids.NodeID], requestID uint32, request []byte) error {
 		nodeID, hasItem := nodeSet.Pop()
@@ -421,7 +422,7 @@ func createSyncServerAndClientVMs(t *testing.T, test syncTest, numBlocks int) *s
 // off of a server VM.
 type syncVMSetup struct {
 	serverVM        *VM
-	serverAppSender *commonEng.SenderTest
+	serverAppSender *enginetest.Sender
 
 	includedAtomicTxs []*Tx
 	fundedAccounts    map[*keystore.Key]*types.StateAccount

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/set"
@@ -262,7 +263,7 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 	minimumValidPChainHeight := uint64(10)
 	getValidatorSetTestErr := errors.New("can't get validator set test error")
 
-	vm.ctx.ValidatorState = &validators.TestState{
+	vm.ctx.ValidatorState = &validatorstest.State{
 		// TODO: test both Primary Network / C-Chain and non-Primary Network
 		GetSubnetIDF: func(ctx context.Context, chainID ids.ID) (ids.ID, error) {
 			return ids.Empty, nil
@@ -425,7 +426,7 @@ func TestReceiveWarpMessage(t *testing.T) {
 	minimumValidPChainHeight := uint64(10)
 	getValidatorSetTestErr := errors.New("can't get validator set test error")
 
-	vm.ctx.ValidatorState = &validators.TestState{
+	vm.ctx.ValidatorState = &validatorstest.State{
 		GetSubnetIDF: func(ctx context.Context, chainID ids.ID) (ids.ID, error) {
 			return ids.Empty, nil
 		},

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	agoUtils "github.com/ava-labs/avalanchego/utils"
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -197,7 +198,7 @@ func createSnowCtx(validatorRanges []validatorRange) *snow.Context {
 	}
 
 	snowCtx := utils.TestSnowContext()
-	state := &validators.TestState{
+	state := &validatorstest.State{
 		GetSubnetIDF: func(ctx context.Context, chainID ids.ID) (ids.ID, error) {
 			return sourceSubnetID, nil
 		},
@@ -266,7 +267,7 @@ func TestWarpMessageFromPrimaryNetwork(t *testing.T) {
 	snowCtx.ChainID = ids.GenerateTestID()
 	snowCtx.CChainID = cChainID
 	snowCtx.NetworkID = networkID
-	snowCtx.ValidatorState = &validators.TestState{
+	snowCtx.ValidatorState = &validatorstest.State{
 		GetSubnetIDF: func(ctx context.Context, chainID ids.ID) (ids.ID, error) {
 			require.Equal(chainID, cChainID)
 			return constants.PrimaryNetworkID, nil // Return Primary Network SubnetID
@@ -666,7 +667,7 @@ func initWarpPredicateTests() {
 
 		snowCtx := utils.TestSnowContext()
 		snowCtx.NetworkID = networkID
-		state := &validators.TestState{
+		state := &validatorstest.State{
 			GetSubnetIDF: func(ctx context.Context, chainID ids.ID) (ids.ID, error) {
 				return sourceSubnetID, nil
 			},

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'v1.11.10-prerelease'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'7e985b530beff5afe03967f5fa94a2eee998cb7a'}

--- a/utils/snow.go
+++ b/utils/snow.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/validators"
+	"github.com/ava-labs/avalanchego/snow/validators/statetest"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
@@ -28,6 +28,6 @@ func TestSnowContext() *snow.Context {
 		BCLookup:       ids.NewAliaser(),
 		Metrics:        metrics.NewMultiGatherer(),
 		ChainDataDir:   "",
-		ValidatorState: &validators.TestState{},
+		ValidatorState: &statetest.TestState{},
 	}
 }

--- a/utils/snow.go
+++ b/utils/snow.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ava-labs/avalanchego/api/metrics"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow"
-	"github.com/ava-labs/avalanchego/snow/validators/statetest"
+	"github.com/ava-labs/avalanchego/snow/validators/validatorstest"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
 	"github.com/ava-labs/avalanchego/utils/logging"
 )
@@ -28,6 +28,6 @@ func TestSnowContext() *snow.Context {
 		BCLookup:       ids.NewAliaser(),
 		Metrics:        metrics.NewMultiGatherer(),
 		ChainDataDir:   "",
-		ValidatorState: &statetest.TestState{},
+		ValidatorState: &validatorstest.TestState{},
 	}
 }

--- a/utils/snow.go
+++ b/utils/snow.go
@@ -28,6 +28,6 @@ func TestSnowContext() *snow.Context {
 		BCLookup:       ids.NewAliaser(),
 		Metrics:        metrics.NewMultiGatherer(),
 		ChainDataDir:   "",
-		ValidatorState: &validatorstest.TestState{},
+		ValidatorState: &validatorstest.State{},
 	}
 }


### PR DESCRIPTION
## Why this should be merged

`avalanchego` was refactored and is already depending on one of the commits in this branch.

## How this works

Magic 🧙 Also _Find and Replace_, but mostly magic.

## How this was tested

Existing tests
