### PR TITLE
chore: fix some function names

### DIFF
--- a/core/vm/jump_table.go
+++ b/core/vm/jump_table.go
@@ -118,7 +118,7 @@ func newApricotPhase3InstructionSet() JumpTable {
 	return validate(instructionSet)
 }
 
-// newApricotPhase1InstructionSet returns the frontier,
+// newApricotPhase2InstructionSet returns the frontier,
 // homestead, byzantium, constantinople petersburg,
 // istanbul, and apricotPhase1 instructions.
 func newApricotPhase2InstructionSet() JumpTable {

--- a/eth/filters/filter_system_test.go
+++ b/eth/filters/filter_system_test.go
@@ -467,7 +467,7 @@ func TestInvalidLogFilterCreation(t *testing.T) {
 	}
 }
 
-// TestLogFilterUninstall tests invalid getLogs requests
+// TestInvalidGetLogsRequest tests invalid getLogs requests
 func TestInvalidGetLogsRequest(t *testing.T) {
 	t.Parallel()
 

--- a/metrics/sample.go
+++ b/metrics/sample.go
@@ -148,7 +148,7 @@ func (NilSample) Clear()                   {}
 func (NilSample) Snapshot() SampleSnapshot { return (*emptySnapshot)(nil) }
 func (NilSample) Update(v int64)           {}
 
-// SamplePercentiles returns an arbitrary percentile of the slice of int64.
+// SamplePercentile returns an arbitrary percentile of the slice of int64.
 func SamplePercentile(values []int64, p float64) float64 {
 	return CalculatePercentiles(values, []float64{p})[0]
 }


### PR DESCRIPTION
## Why this should be merged

fix some function names

## How this works

## How this was tested
