### PR TITLE
Allow local chains to specify their own config

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -458,9 +458,6 @@ func (vm *VM) Initialize(
 		config := *params.AvalancheFujiChainConfig
 		g.Config = &config
 		extDataHashes = fujiExtDataHashes
-	case g.Config.ChainID.Cmp(params.AvalancheLocalChainID) == 0:
-		config := *params.AvalancheLocalChainConfig
-		g.Config = &config
 	}
 	// If the Durango is activated, activate the Warp Precompile at the same time
 	if g.Config.DurangoBlockTimestamp != nil {


### PR DESCRIPTION
Seems that local chains should be able to specify a chain config, without that being overwritten by `vm.Initialize()`

Corresponding avalanchego passing CI https://github.com/ava-labs/avalanchego/actions/runs/10292198882/job/28486105916?pr=3278