### PR TITLE
get upgrade configs from context

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.12
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1
+	github.com/ava-labs/avalanchego v1.11.11-0.20240813180138-7520071656af
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.21.12
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef
+	github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef h1:w0N/YXgNoXjDUwdFHGpWYq41uHxvBneHaJ+X0BxSj2w=
 github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
+github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1 h1:h/09vEeKWELnlHr2Da2cXawD8Qg/9RyHy5SrODt0kkU=
+github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,6 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef h1:w0N/YXgNoXjDUwdFHGpWYq41uHxvBneHaJ+X0BxSj2w=
-github.com/ava-labs/avalanchego v1.11.11-0.20240805141503-7e985b530bef/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
 github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1 h1:h/09vEeKWELnlHr2Da2cXawD8Qg/9RyHy5SrODt0kkU=
 github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -56,6 +56,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1 h1:h/09vEeKWELnlHr2Da2cXawD8Qg/9RyHy5SrODt0kkU=
 github.com/ava-labs/avalanchego v1.11.11-0.20240809105844-da3256302ab1/go.mod h1:9e0UPXJboybmgFjeTj+SFbK4ugbrdG4t68VdiUW5oQ8=
+github.com/ava-labs/avalanchego v1.11.11-0.20240813180138-7520071656af h1:BpAUJHH+QerXi2dMaHbaOzZHCiQAdqS+75Bqzd1alt8=
+github.com/ava-labs/avalanchego v1.11.11-0.20240813180138-7520071656af/go.mod h1:8pnf2At/q0LRq5dvYJYn3CkhKzZNHRd5pjARC9psu+g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/params/config.go
+++ b/params/config.go
@@ -59,10 +59,10 @@ var (
 	AvalancheMainnetChainConfig = GetChainConfig(upgrade.GetConfig(constants.MainnetID), AvalancheMainnetChainID)
 
 	// AvalancheFujiChainConfig is the configuration for the Fuji Test Network
-	AvalancheFujiChainConfig = GetChainConfig(upgrade.GetConfig(constants.FujiID), AvalancheMainnetChainID)
+	AvalancheFujiChainConfig = GetChainConfig(upgrade.GetConfig(constants.FujiID), AvalancheFujiChainID)
 
 	// AvalancheLocalChainConfig is the configuration for the Avalanche Local Network
-	AvalancheLocalChainConfig = GetChainConfig(upgrade.GetConfig(constants.LocalID), AvalancheMainnetChainID)
+	AvalancheLocalChainConfig = GetChainConfig(upgrade.GetConfig(constants.LocalID), AvalancheLocalChainID)
 
 	TestChainConfig = &ChainConfig{
 		AvalancheContext:                AvalancheContext{utils.TestSnowContext()},

--- a/params/config.go
+++ b/params/config.go
@@ -56,13 +56,13 @@ var (
 
 var (
 	// AvalancheMainnetChainConfig is the configuration for Avalanche Main Network
-	AvalancheMainnetChainConfig = getChainConfig(constants.MainnetID, AvalancheMainnetChainID)
+	AvalancheMainnetChainConfig = GetChainConfig(upgrade.GetConfig(constants.MainnetID), AvalancheMainnetChainID)
 
 	// AvalancheFujiChainConfig is the configuration for the Fuji Test Network
-	AvalancheFujiChainConfig = getChainConfig(constants.FujiID, AvalancheFujiChainID)
+	AvalancheFujiChainConfig = GetChainConfig(upgrade.GetConfig(constants.FujiID), AvalancheMainnetChainID)
 
 	// AvalancheLocalChainConfig is the configuration for the Avalanche Local Network
-	AvalancheLocalChainConfig = getChainConfig(constants.LocalID, AvalancheLocalChainID)
+	AvalancheLocalChainConfig = GetChainConfig(upgrade.GetConfig(constants.LocalID), AvalancheMainnetChainID)
 
 	TestChainConfig = &ChainConfig{
 		AvalancheContext:                AvalancheContext{utils.TestSnowContext()},
@@ -459,8 +459,7 @@ var (
 	TestRules = TestChainConfig.Rules(new(big.Int), 0)
 )
 
-func getChainConfig(networkID uint32, chainID *big.Int) *ChainConfig {
-	agoUpgrade := upgrade.GetConfig(networkID)
+func GetChainConfig(agoUpgrade upgrade.Config, chainID *big.Int) *ChainConfig {
 	return &ChainConfig{
 		ChainID:                         chainID,
 		HomesteadBlock:                  big.NewInt(0),

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -464,8 +464,8 @@ func (vm *VM) Initialize(
 	default:
 		// TODO: This overrides the chain config in the given genesis (in genesisBytes)
 		// Do we want to do this?
-		config := params.GetChainConfig(chainCtx.NetworkUpgrades, new(big.Int).Set(g.Config.ChainID))
-		g.Config = config
+		// config := params.GetChainConfig(chainCtx.NetworkUpgrades, new(big.Int).Set(g.Config.ChainID))
+		// g.Config = config
 	}
 	// If the Durango is activated, activate the Warp Precompile at the same time
 	if g.Config.DurangoBlockTimestamp != nil {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -474,8 +474,6 @@ func (vm *VM) Initialize(
 		})
 	}
 
-	js, _ := g.Config.MarshalJSON()
-	log.Warn("Chain config", "config", js)
 	// Set the Avalanche Context on the ChainConfig
 	g.Config.AvalancheContext = params.AvalancheContext{
 		SnowCtx: chainCtx,

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -475,8 +475,8 @@ func (vm *VM) Initialize(
 	}
 	vm.syntacticBlockValidator = NewBlockValidator(extDataHashes)
 
-	// Ensure that non-standard commit interval is only allowed for the local network
-	if g.Config.ChainID.Cmp(params.AvalancheLocalChainID) != 0 {
+	// Ensure that non-standard commit interval is not allowed for production networks
+	if avalanchegoConstants.ProductionNetworkIDs.Contains(chainCtx.NetworkID) {
 		if vm.config.CommitInterval != defaultCommitInterval {
 			return fmt.Errorf("cannot start non-local network with commit interval %d", vm.config.CommitInterval)
 		}
@@ -623,7 +623,7 @@ func (vm *VM) Initialize(
 	var (
 		bonusBlockHeights map[uint64]ids.ID
 	)
-	if vm.chainID.Cmp(params.AvalancheMainnetChainID) == 0 {
+	if vm.ctx.NetworkID == avalanchegoConstants.MainnetID {
 		bonusBlockHeights, err = readMainnetBonusBlocks()
 		if err != nil {
 			return fmt.Errorf("failed to read mainnet bonus blocks: %w", err)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -461,11 +461,6 @@ func (vm *VM) Initialize(
 	case avalanchegoConstants.LocalID:
 		config := *params.AvalancheLocalChainConfig
 		g.Config = &config
-	default:
-		// TODO: This overrides the chain config in the given genesis (in genesisBytes)
-		// Do we want to do this?
-		// config := params.GetChainConfig(chainCtx.NetworkUpgrades, new(big.Int).Set(g.Config.ChainID))
-		// g.Config = config
 	}
 	// If the Durango is activated, activate the Warp Precompile at the same time
 	if g.Config.DurangoBlockTimestamp != nil {

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -458,9 +458,6 @@ func (vm *VM) Initialize(
 		config := *params.AvalancheFujiChainConfig
 		g.Config = &config
 		extDataHashes = fujiExtDataHashes
-	case g.Config.ChainID.Cmp(params.AvalancheLocalChainID) == 0:
-		config := *params.AvalancheLocalChainConfig
-		g.Config = &config
 	}
 	// If the Durango is activated, activate the Warp Precompile at the same time
 	if g.Config.DurangoBlockTimestamp != nil {

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'7e985b530beff5afe03967f5fa94a2eee998cb7a'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'da3256302ab1'}

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'da3256302ab1'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'7520071656af'}


### PR DESCRIPTION
## Why this should be merged

AvalancheGo added upgrade config to snow context

Related AvalancheGo PR https://github.com/ava-labs/avalanchego/pull/3283

However we don't really need to change anything in Coreth since upgrades were written to chainConfig in genesis thus we have other source of information rather than upgrade configs in avalanchego/snow.Context. 

## How this works

* uses network ID rather than chain ID in config selection

## How this was tested

e2e should mostly cover this. I also did a local network testing with avalanchego to test out if network upgrades are passed correctly (but we don't actually use them)
