### PR TITLE
remove pre-AP2 handling of genesis contract

### DIFF
--- a/core/vm/interpreter.go
+++ b/core/vm/interpreter.go
@@ -34,11 +34,6 @@ import (
 	"github.com/ethereum/go-ethereum/log"
 )
 
-var BuiltinAddr = common.Address{
-	1, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-	0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-}
-
 // Config are the configuration options for the Interpreter
 type Config struct {
 	Tracer                  EVMLogger // Opcode logger
@@ -121,18 +116,6 @@ func NewEVMInterpreter(evm *EVM) *EVMInterpreter {
 // considered a revert-and-consume-all-gas operation except for
 // ErrExecutionReverted which means revert-and-keep-gas-left.
 func (in *EVMInterpreter) Run(contract *Contract, input []byte, readOnly bool) (ret []byte, err error) {
-	// Deprecate special handling of [BuiltinAddr] as of ApricotPhase2.
-	// In ApricotPhase2, the contract deployed in the genesis is overridden by a deprecated precompiled
-	// contract which will return an error immediately if its ever called. Therefore, this function should
-	// never be called after ApricotPhase2 with [BuiltinAddr] as the contract address.
-	if !in.evm.chainRules.IsApricotPhase2 && contract.Address() == BuiltinAddr {
-		self := AccountRef(contract.Caller())
-		if _, ok := contract.caller.(*Contract); ok {
-			contract = contract.AsDelegate()
-		}
-		contract.self = self
-	}
-
 	// Increment the call depth which is restricted to 1024
 	in.evm.depth++
 	defer func() { in.evm.depth-- }()


### PR DESCRIPTION
## Why this should be merged
This code is disabled and does not impact execution pre AP2 (tested on fuji, mainnet)

## How this works
Deletes code

## How this was tested
CI, reprocessing blocks from genesis to AP2