### PR TITLE
params: add BerlinBlock, LondonBlock, ShanghaiTime

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -708,6 +708,9 @@ func TestCreateThenDeletePreByzantium(t *testing.T) {
 	config.PetersburgBlock = nil
 	config.IstanbulBlock = nil
 	config.MuirGlacierBlock = nil
+	config.BerlinBlock = nil
+	config.LondonBlock = nil
+
 	testCreateThenDelete(t, &config)
 }
 func TestCreateThenDeletePostByzantium(t *testing.T) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -301,6 +301,9 @@ func TestVerkleGenesisCommit(t *testing.T) {
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
+		ShanghaiTime:        &verkleTime,
 		CancunTime:          &verkleTime,
 		VerkleTime:          &verkleTime,
 	}

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -56,6 +56,7 @@ func u64(val uint64) *uint64 { return &val }
 func TestStateProcessorErrors(t *testing.T) {
 	cpcfg := *params.TestChainConfig
 	config := &cpcfg
+	config.ShanghaiTime = u64(0)
 	config.CancunTime = u64(0)
 
 	var (

--- a/internal/ethapi/api_test.go
+++ b/internal/ethapi/api_test.go
@@ -786,6 +786,7 @@ func TestEstimateGas(t *testing.T) {
 func TestCall(t *testing.T) {
 	// Enable BLOBHASH opcode in Cancun
 	cfg := *params.TestChainConfig
+	cfg.ShanghaiTime = utils.NewUint64(0)
 	cfg.CancunTime = utils.NewUint64(0)
 	t.Parallel()
 	// Initialize test accounts
@@ -1788,6 +1789,7 @@ func TestRPCGetBlockOrHeader(t *testing.T) {
 
 func setupReceiptBackend(t *testing.T, genBlocks int) (*testBackend, []common.Hash) {
 	config := *params.TestChainConfig
+	config.ShanghaiTime = new(uint64)
 	config.CancunTime = new(uint64)
 	var (
 		acc1Key, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")

--- a/params/config.go
+++ b/params/config.go
@@ -65,6 +65,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -155,6 +157,7 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -185,6 +188,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -215,6 +220,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -245,6 +252,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -275,6 +284,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -305,6 +316,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -335,6 +348,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -365,6 +380,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -395,6 +412,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -425,6 +444,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -455,6 +476,8 @@ var (
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: NetworkUpgrades{
 			ApricotPhase1BlockTimestamp:     utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp:     utils.NewUint64(0),
@@ -497,11 +520,14 @@ type ChainConfig struct {
 	PetersburgBlock     *big.Int `json:"petersburgBlock,omitempty"`     // Petersburg switch block (nil = same as Constantinople)
 	IstanbulBlock       *big.Int `json:"istanbulBlock,omitempty"`       // Istanbul switch block (nil = no fork, 0 = already on istanbul)
 	MuirGlacierBlock    *big.Int `json:"muirGlacierBlock,omitempty"`    // Eip-2384 (bomb delay) switch block (nil = no fork, 0 = already activated)
+	BerlinBlock         *big.Int `json:"berlinBlock,omitempty"`         // Berlin switch block (nil = no fork, 0 = already on berlin)
+	LondonBlock         *big.Int `json:"londonBlock,omitempty"`         // London switch block (nil = no fork, 0 = already on london)
 
 	// Fork scheduling was switched from blocks to timestamps here
 
-	CancunTime *uint64 `json:"cancunTime,omitempty"` // Cancun switch time (nil = no fork, 0 = already activated)
-	VerkleTime *uint64 `json:"verkleTime,omitempty"` // Verkle switch time (nil = no fork, 0 = already on verkle)
+	ShanghaiTime *uint64 `json:"shanghaiTime,omitempty"` // Shanghai switch time (nil = no fork, 0 = already on shanghai)
+	CancunTime   *uint64 `json:"cancunTime,omitempty"`   // Cancun switch time (nil = no fork, 0 = already activated)
+	VerkleTime   *uint64 `json:"verkleTime,omitempty"`   // Verkle switch time (nil = no fork, 0 = already on verkle)
 
 	NetworkUpgrades // Config for timestamps that enable network upgrades. Skip encoding/decoding directly into ChainConfig.
 
@@ -606,14 +632,29 @@ func (c *ChainConfig) IsIstanbul(num *big.Int) bool {
 	return isBlockForked(c.IstanbulBlock, num)
 }
 
-// IsCancun returns whether time is either equal to the Cancun fork time or greater.
-func (c *ChainConfig) IsCancun(num *big.Int, time uint64) bool {
-	return isTimestampForked(c.CancunTime, time)
+// IsBerlin returns whether num is either equal to the Berlin fork block or greater.
+func (c *ChainConfig) IsBerlin(num *big.Int) bool {
+	return isBlockForked(c.BerlinBlock, num)
 }
 
-// IsVerkle returns whether time is either equal to the Verkle fork time or greater.
+// IsLondon returns whether num is either equal to the London fork block or greater.
+func (c *ChainConfig) IsLondon(num *big.Int) bool {
+	return isBlockForked(c.LondonBlock, num)
+}
+
+// IsShanghai returns whether time is either equal to the Shanghai fork time or greater.
+func (c *ChainConfig) IsShanghai(num *big.Int, time uint64) bool {
+	return c.IsLondon(num) && isTimestampForked(c.ShanghaiTime, time)
+}
+
+// IsCancun returns whether num is either equal to the Cancun fork time or greater.
+func (c *ChainConfig) IsCancun(num *big.Int, time uint64) bool {
+	return c.IsLondon(num) && isTimestampForked(c.CancunTime, time)
+}
+
+// IsVerkle returns whether num is either equal to the Verkle fork time or greater.
 func (c *ChainConfig) IsVerkle(num *big.Int, time uint64) bool {
-	return isTimestampForked(c.VerkleTime, time)
+	return c.IsLondon(num) && isTimestampForked(c.VerkleTime, time)
 }
 
 // CheckCompatible checks whether scheduled fork transitions have been imported
@@ -662,6 +703,9 @@ func (c *ChainConfig) CheckConfigForkOrder() error {
 		{name: "petersburgBlock", block: c.PetersburgBlock},
 		{name: "istanbulBlock", block: c.IstanbulBlock},
 		{name: "muirGlacierBlock", block: c.MuirGlacierBlock, optional: true},
+		{name: "berlinBlock", block: c.BerlinBlock},
+		{name: "londonBlock", block: c.LondonBlock},
+		{name: "shanghaiTime", timestamp: c.ShanghaiTime},
 		{name: "cancunTime", timestamp: c.CancunTime, optional: true},
 		{name: "verkleTime", timestamp: c.VerkleTime, optional: true},
 	}
@@ -774,6 +818,15 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	}
 	if isForkBlockIncompatible(c.MuirGlacierBlock, newcfg.MuirGlacierBlock, headNumber) {
 		return newBlockCompatError("Muir Glacier fork block", c.MuirGlacierBlock, newcfg.MuirGlacierBlock)
+	}
+	if isForkBlockIncompatible(c.BerlinBlock, newcfg.BerlinBlock, headNumber) {
+		return newBlockCompatError("Berlin fork block", c.BerlinBlock, newcfg.BerlinBlock)
+	}
+	if isForkBlockIncompatible(c.LondonBlock, newcfg.LondonBlock, headNumber) {
+		return newBlockCompatError("London fork block", c.LondonBlock, newcfg.LondonBlock)
+	}
+	if isForkTimestampIncompatible(c.ShanghaiTime, newcfg.ShanghaiTime, headTimestamp) {
+		return newTimestampCompatError("Shanghai fork timestamp", c.ShanghaiTime, newcfg.ShanghaiTime)
 	}
 	if isForkTimestampIncompatible(c.CancunTime, newcfg.CancunTime, headTimestamp) {
 		return newTimestampCompatError("Cancun fork timestamp", c.CancunTime, newcfg.CancunTime)

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -40,23 +40,6 @@ type AvalancheContext struct {
 // code in place of their Ethereum counterparts. The original Ethereum names
 // should be restored for maintainability.
 func (c *ChainConfig) SetEthUpgrades() {
-	if AvalancheFujiChainID.Cmp(c.ChainID) == 0 {
-		c.BerlinBlock = big.NewInt(184985) // https://testnet.snowtrace.io/block/184985?chainid=43113, AP2 activation block
-		c.LondonBlock = big.NewInt(805078) // https://testnet.snowtrace.io/block/805078?chainid=43113, AP3 activation block
-	} else if AvalancheMainnetChainID.Cmp(c.ChainID) == 0 {
-		c.BerlinBlock = big.NewInt(1640340) // https://snowtrace.io/block/1640340?chainid=43114, AP2 activation block
-		c.LondonBlock = big.NewInt(3308552) // https://snowtrace.io/block/3308552?chainid=43114, AP3 activation block
-	} else {
-		// In testing or local networks, we only support enabling Berlin and London at timestamp 0.
-		// This is likely to correspond to an intended block number of 0 as well.
-		if c.ApricotPhase2BlockTimestamp != nil && *c.ApricotPhase2BlockTimestamp == 0 && c.BerlinBlock == nil {
-			c.BerlinBlock = big.NewInt(0)
-		}
-		if c.ApricotPhase3BlockTimestamp != nil && *c.ApricotPhase3BlockTimestamp == 0 && c.LondonBlock == nil {
-			c.LondonBlock = big.NewInt(0)
-		}
-	}
-
 	if c.DurangoBlockTimestamp != nil {
 		c.ShanghaiTime = utils.NewUint64(*c.DurangoBlockTimestamp)
 	}
@@ -178,7 +161,7 @@ func (c *ChainConfig) ToWithUpgradesJSON() *ChainConfigWithUpgradesJSON {
 }
 
 func GetChainConfig(agoUpgrade upgrade.Config, chainID *big.Int) *ChainConfig {
-	return &ChainConfig{
+	c := &ChainConfig{
 		ChainID:             chainID,
 		HomesteadBlock:      big.NewInt(0),
 		DAOForkBlock:        big.NewInt(0),
@@ -193,6 +176,25 @@ func GetChainConfig(agoUpgrade upgrade.Config, chainID *big.Int) *ChainConfig {
 		MuirGlacierBlock:    big.NewInt(0),
 		NetworkUpgrades:     getNetworkUpgrades(agoUpgrade),
 	}
+	if AvalancheFujiChainID.Cmp(c.ChainID) == 0 {
+		c.BerlinBlock = big.NewInt(184985) // https://testnet.snowtrace.io/block/184985?chainid=43113, AP2 activation block
+		c.LondonBlock = big.NewInt(805078) // https://testnet.snowtrace.io/block/805078?chainid=43113, AP3 activation block
+	} else if AvalancheMainnetChainID.Cmp(c.ChainID) == 0 {
+		c.BerlinBlock = big.NewInt(1640340) // https://snowtrace.io/block/1640340?chainid=43114, AP2 activation block
+		c.LondonBlock = big.NewInt(3308552) // https://snowtrace.io/block/3308552?chainid=43114, AP3 activation block
+	} else {
+		// In testing or local networks, we only support enabling Berlin and London prior
+		// to the initially active time. This is likely to correspond to an intended block
+		// number of 0 as well.
+		initiallyActive := uint64(upgrade.InitiallyActiveTime.Unix())
+		if c.ApricotPhase2BlockTimestamp != nil && *c.ApricotPhase2BlockTimestamp <= initiallyActive && c.BerlinBlock == nil {
+			c.BerlinBlock = big.NewInt(0)
+		}
+		if c.ApricotPhase3BlockTimestamp != nil && *c.ApricotPhase3BlockTimestamp <= initiallyActive && c.LondonBlock == nil {
+			c.LondonBlock = big.NewInt(0)
+		}
+	}
+	return c
 }
 
 func (r *Rules) PredicatersExist() bool {

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -40,6 +40,26 @@ type AvalancheContext struct {
 // code in place of their Ethereum counterparts. The original Ethereum names
 // should be restored for maintainability.
 func (c *ChainConfig) SetEthUpgrades() {
+	if AvalancheFujiChainID.Cmp(c.ChainID) == 0 {
+		c.BerlinBlock = big.NewInt(184985) // https://testnet.snowtrace.io/block/184985?chainid=43113, AP2 activation block
+		c.LondonBlock = big.NewInt(805078) // https://testnet.snowtrace.io/block/805078?chainid=43113, AP3 activation block
+	} else if AvalancheMainnetChainID.Cmp(c.ChainID) == 0 {
+		c.BerlinBlock = big.NewInt(1640340) // https://snowtrace.io/block/1640340?chainid=43114, AP2 activation block
+		c.LondonBlock = big.NewInt(3308552) // https://snowtrace.io/block/3308552?chainid=43114, AP3 activation block
+	} else {
+		// In testing or local networks, we only support enabling Berlin and London at timestamp 0.
+		// This is likely to correspond to an intended block number of 0 as well.
+		if c.ApricotPhase2BlockTimestamp != nil && *c.ApricotPhase2BlockTimestamp == 0 && c.BerlinBlock == nil {
+			c.BerlinBlock = big.NewInt(0)
+		}
+		if c.ApricotPhase3BlockTimestamp != nil && *c.ApricotPhase3BlockTimestamp == 0 && c.LondonBlock == nil {
+			c.LondonBlock = big.NewInt(0)
+		}
+	}
+
+	if c.DurangoBlockTimestamp != nil {
+		c.ShanghaiTime = utils.NewUint64(*c.DurangoBlockTimestamp)
+	}
 	if c.EtnaTimestamp != nil {
 		c.CancunTime = utils.NewUint64(*c.EtnaTimestamp)
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -110,6 +110,7 @@ var (
 
 	activateCancun = func(cfg *params.ChainConfig) *params.ChainConfig {
 		cpy := *cfg
+		cpy.ShanghaiTime = utils.NewUint64(0)
 		cpy.CancunTime = utils.NewUint64(0)
 		return &cpy
 	}

--- a/tests/init.go
+++ b/tests/init.go
@@ -190,6 +190,7 @@ var Forks = map[string]*params.ChainConfig{
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -206,6 +207,8 @@ var Forks = map[string]*params.ChainConfig{
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -223,6 +226,8 @@ var Forks = map[string]*params.ChainConfig{
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
 		MuirGlacierBlock:    big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -240,6 +245,8 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -258,6 +265,8 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -277,6 +286,8 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -297,6 +308,8 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),
 			ApricotPhase2BlockTimestamp: utils.NewUint64(0),
@@ -318,6 +331,8 @@ var Forks = map[string]*params.ChainConfig{
 		ConstantinopleBlock: big.NewInt(0),
 		PetersburgBlock:     big.NewInt(0),
 		IstanbulBlock:       big.NewInt(0),
+		BerlinBlock:         big.NewInt(0),
+		LondonBlock:         big.NewInt(0),
 		CancunTime:          utils.NewUint64(0),
 		NetworkUpgrades: params.NetworkUpgrades{
 			ApricotPhase1BlockTimestamp: utils.NewUint64(0),


### PR DESCRIPTION
## Why this should be merged
Adds back BerlinBlock, LondonBlock, ShanghaiTime upgrades from upstream.
This is towards using more upstream packages and activating the desired behaviors via setting the Eth upgrade, instead of directly referencing the Avalanche upgrade names from predominantly upstream code.

This PR does not include modifying any of the Avalanche upgrade to the Eth upgrade, it only prepares the appropriate fields in the chain config.

## How this works
In Avalanche AP2 & AP3 upgrades were enabled by timestamp however the corresponding Eth upgrade (Berlin, London) enable via block number. Since these upgrades already occurred, we can use their block numbers for canonical chains and use 0 in tests.

## How this was tested
CI. (Note there is no behavioral changes for execution in this PR)