### PR TITLE
ci: fix windows flake test detection

### DIFF
--- a/scripts/build_test.sh
+++ b/scripts/build_test.sh
@@ -41,7 +41,7 @@ do
     unexpected_failures=$(
         # First grep pattern corresponds to test failures, second pattern corresponds to test panics due to timeouts
         (grep "^--- FAIL" test.out | awk '{print $3}' || grep -E '^\s+Test.+ \(' test.out | awk '{print $1}') |
-        sort -u | comm -23 - ./scripts/known_flakes.txt
+        sort -u | comm -23 -  <(sed 's/\r$//' ./scripts/known_flakes.txt)
     )
     if [ -n "${unexpected_failures}" ]; then
         echo "Unexpected test failures: ${unexpected_failures}"


### PR DESCRIPTION
Fixes handling \r correctly in windows.
Already fixed in subnet-evm