### PR TITLE
use DBOverride to specify backends

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -178,18 +178,18 @@ type CacheConfig struct {
 func (c *CacheConfig) triedbConfig() *triedb.Config {
 	config := &triedb.Config{Preimages: c.Preimages}
 	if c.StateScheme == rawdb.HashScheme || c.StateScheme == "" {
-		config.HashDB = &hashdb.Config{
+		config.DBOverride = hashdb.Config{
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,
 			StatsPrefix:    trieCleanCacheStatsNamespace,
 			ReferenceRoot:  true, // Automatically reference root nodes when an update is made
-		}
+		}.BackendConstructor
 	}
 	if c.StateScheme == rawdb.PathScheme {
-		config.PathDB = &pathdb.Config{
+		config.DBOverride = pathdb.Config{
 			StateHistory:   c.StateHistory,
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,
 			DirtyCacheSize: c.TrieDirtyLimit * 1024 * 1024,
-		}
+		}.BackendConstructor
 	}
 	return config
 }

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -219,8 +219,8 @@ func (g *Genesis) trieConfig() *triedb.Config {
 		return nil
 	}
 	return &triedb.Config{
-		PathDB:   pathdb.Defaults,
-		IsVerkle: true,
+		DBOverride: pathdb.Defaults.BackendConstructor,
+		IsVerkle:   true,
 	}
 }
 

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -285,7 +285,7 @@ func newDbConfig(scheme string) *triedb.Config {
 	if scheme == rawdb.HashScheme {
 		return triedb.HashDefaults
 	}
-	return &triedb.Config{PathDB: pathdb.Defaults}
+	return &triedb.Config{DBOverride: pathdb.Defaults.BackendConstructor}
 }
 
 func TestVerkleGenesisCommit(t *testing.T) {
@@ -325,7 +325,7 @@ func TestVerkleGenesisCommit(t *testing.T) {
 	}
 
 	db := rawdb.NewMemoryDatabase()
-	triedb := triedb.NewDatabase(db, &triedb.Config{IsVerkle: true, PathDB: pathdb.Defaults})
+	triedb := triedb.NewDatabase(db, &triedb.Config{IsVerkle: true, DBOverride: pathdb.Defaults.BackendConstructor})
 	block := genesis.MustCommit(db, triedb)
 	if !bytes.Equal(block.Root().Bytes(), expected) {
 		t.Fatalf("invalid genesis state root, expected %x, got %x", expected, got)

--- a/core/state/snapshot/generate_test.go
+++ b/core/state/snapshot/generate_test.go
@@ -176,9 +176,9 @@ func newHelper(scheme string) *testHelper {
 	diskdb := rawdb.NewMemoryDatabase()
 	config := &triedb.Config{}
 	if scheme == rawdb.PathScheme {
-		config.PathDB = &pathdb.Config{} // disable caching
+		config.DBOverride = pathdb.Config{}.BackendConstructor // disable caching
 	} else {
-		config.HashDB = &hashdb.Config{} // disable caching
+		config.DBOverride = hashdb.Config{}.BackendConstructor // disable caching
 	}
 	triedb := triedb.NewDatabase(diskdb, config)
 	accTrie, _ := trie.NewStateTrie(trie.StateTrieID(types.EmptyRootHash), triedb)

--- a/core/state/statedb_fuzz_test.go
+++ b/core/state/statedb_fuzz_test.go
@@ -192,7 +192,7 @@ func (test *stateTest) run() bool {
 			storageList = append(storageList, copy2DSet(states.Storages))
 		}
 		disk      = rawdb.NewMemoryDatabase()
-		tdb       = triedb.NewDatabase(disk, &triedb.Config{PathDB: pathdb.Defaults})
+		tdb       = triedb.NewDatabase(disk, &triedb.Config{DBOverride: pathdb.Defaults.BackendConstructor})
 		sdb       = NewDatabaseWithNodeDB(disk, tdb)
 		byzantium = rand.Intn(2) == 0
 	)

--- a/core/state/statedb_test.go
+++ b/core/state/statedb_test.go
@@ -814,14 +814,14 @@ func testMissingTrieNodes(t *testing.T, scheme string) {
 		memDb = rawdb.NewMemoryDatabase()
 	)
 	if scheme == rawdb.PathScheme {
-		tdb = triedb.NewDatabase(memDb, &triedb.Config{PathDB: &pathdb.Config{
+		tdb = triedb.NewDatabase(memDb, &triedb.Config{DBOverride: pathdb.Config{
 			CleanCacheSize: 0,
 			DirtyCacheSize: 0,
-		}}) // disable caching
+		}.BackendConstructor}) // disable caching
 	} else {
-		tdb = triedb.NewDatabase(memDb, &triedb.Config{HashDB: &hashdb.Config{
+		tdb = triedb.NewDatabase(memDb, &triedb.Config{DBOverride: hashdb.Config{
 			CleanCacheSize: 0,
-		}}) // disable caching
+		}.BackendConstructor}) // disable caching
 	}
 	db := NewDatabaseWithNodeDB(memDb, tdb)
 

--- a/core/state/sync_test.go
+++ b/core/state/sync_test.go
@@ -43,9 +43,9 @@ func makeTestState(scheme string) (ethdb.Database, Database, *triedb.Database, c
 	// Create an empty state
 	config := &triedb.Config{Preimages: true}
 	if scheme == rawdb.PathScheme {
-		config.PathDB = pathdb.Defaults
+		config.DBOverride = pathdb.Defaults.BackendConstructor
 	} else {
-		config.HashDB = hashdb.Defaults
+		config.DBOverride = hashdb.Defaults.BackendConstructor
 	}
 	db := rawdb.NewMemoryDatabase()
 	nodeDb := triedb.NewDatabase(db, config)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195
-	github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f
+	github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.22.8
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195
-	github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241112221300-1910a11a6552
+	github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195 h1:dyf52xlqlA/9SaiCv29oqbitRAYu7L890zK774xDNrE=
 github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195/go.mod h1:eZ/UmH4rDhhgL/FLqtJZYJ7ka73m88RmLrOoAyZFgD4=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f h1:dDA/gHdXHBFD7Bu8ZT7pmtjtnXi9xVeKVieTWPCBPwk=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
+github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e h1:WwDl/jyHr4oJ1VYUi+PEu6l05Vcl4rZv1xXJ0vVP1gI=
+github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195 h1:dyf52xlqlA/9SaiCv29oqbitRAYu7L890zK774xDNrE=
 github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195/go.mod h1:eZ/UmH4rDhhgL/FLqtJZYJ7ka73m88RmLrOoAyZFgD4=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241112221300-1910a11a6552 h1:qmw7gBeJCTm4XHxGaTv7AEKdHp6nY86RbrA3nzzewuM=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241112221300-1910a11a6552/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
+github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f h1:dDA/gHdXHBFD7Bu8ZT7pmtjtnXi9xVeKVieTWPCBPwk=
+github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241113200655-753d1f5dff5f/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -154,9 +154,9 @@ func newAtomicTrie(
 	trieDB := triedb.NewDatabase(
 		rawdb.NewDatabase(Database{atomicTrieDB}),
 		&triedb.Config{
-			HashDB: &hashdb.Config{
+			DBOverride: hashdb.Config{
 				CleanCacheSize: 64 * units.MiB, // Allocate 64MB of memory for clean cache
-			},
+			}.BackendConstructor,
 		},
 	)
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1289,9 +1289,9 @@ func (vm *VM) setAppRequestHandlers() {
 	evmTrieDB := triedb.NewDatabase(
 		vm.chaindb,
 		&triedb.Config{
-			HashDB: &hashdb.Config{
+			DBOverride: hashdb.Config{
 				CleanCacheSize: vm.config.StateSyncServerTrieCache * units.MiB,
-			},
+			}.BackendConstructor,
 		},
 	)
 	networkHandler := newNetworkHandler(

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -50,9 +50,9 @@ type StateTestState struct {
 func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bool, scheme string) StateTestState {
 	tconf := &triedb.Config{Preimages: true}
 	if scheme == rawdb.HashScheme {
-		tconf.HashDB = hashdb.Defaults
+		tconf.DBOverride = hashdb.Defaults.BackendConstructor
 	} else {
-		tconf.PathDB = pathdb.Defaults
+		tconf.DBOverride = pathdb.Defaults.BackendConstructor
 	}
 	triedb := triedb.NewDatabase(db, tconf)
 	sdb := state.NewDatabaseWithNodeDB(db, triedb)

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -104,7 +104,7 @@ type Config struct {
 	ReferenceRoot  bool   // Whether to reference the root node on update
 }
 
-func (c Config) BackendConstructor(diskdb ethdb.Database, config *triedb.Config) triedb.BackendOverride {
+func (c Config) BackendConstructor(diskdb ethdb.Database, config *triedb.Config) triedb.DBOverride {
 	var resolver ChildResolver
 	if config.IsVerkle {
 		// TODO define verkle resolver

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -41,8 +41,10 @@ import (
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/rlp"
+	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
 	"github.com/ava-labs/libevm/triedb/database"
 	ethhashdb "github.com/ava-labs/libevm/triedb/hashdb"
 )
@@ -102,8 +104,15 @@ type Config struct {
 	ReferenceRoot  bool   // Whether to reference the root node on update
 }
 
-func (c *Config) New(diskdb ethdb.Database, resolver ChildResolver) database.HashBackend {
-	return New(diskdb, c, resolver)
+func (c Config) BackendConstructor(diskdb ethdb.Database, config *triedb.Config) triedb.BackendOverride {
+	var resolver ChildResolver
+	if config.IsVerkle {
+		// TODO define verkle resolver
+		log.Crit("Verkle node resolver is not defined")
+	} else {
+		resolver = trie.MerkleResolver{}
+	}
+	return New(diskdb, &c, resolver)
 }
 
 // Defaults is the default setting for database if it's not specified.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -40,6 +40,7 @@ import (
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
 	"github.com/ava-labs/libevm/triedb/database"
 )
 
@@ -102,8 +103,8 @@ type Config struct {
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
 }
 
-func (c *Config) New(diskdb ethdb.Database) database.PathBackend {
-	return New(diskdb, c)
+func (c Config) BackendConstructor(diskdb ethdb.Database, _ *triedb.Config) triedb.BackendOverride {
+	return New(diskdb, &c)
 }
 
 // sanitize checks the provided user configurations and changes anything that's

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -103,7 +103,7 @@ type Config struct {
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
 }
 
-func (c Config) BackendConstructor(diskdb ethdb.Database, _ *triedb.Config) triedb.BackendOverride {
+func (c Config) BackendConstructor(diskdb ethdb.Database, _ *triedb.Config) triedb.DBOverride {
 	return New(diskdb, &c)
 }
 


### PR DESCRIPTION
This pull request includes several changes to the `triedb` package and its usage across different files to replace specific database configurations (`HashDB` and `PathDB`) with a more generalized `DBOverride` using `BackendConstructor`. Additionally, there are some dependency updates in the `go.mod` file.
