### PR TITLE
use libevm v1.13.14-0.1.0.rc-2

### DIFF
--- a/core/state/statedb_multicoin_test.go
+++ b/core/state/statedb_multicoin_test.go
@@ -150,8 +150,8 @@ func TestGenerateMultiCoinAccounts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if isMultiCoin := types.IsMultiCoin(snapAccount); !isMultiCoin {
-		t.Fatalf("Expected SnapAccount to return IsMultiCoin: true, found: %v", isMultiCoin)
+	if !types.IsMultiCoin(snapAccount) {
+		t.Fatalf("Expected SnapAccount to return IsMultiCoin: true, found: false")
 	}
 
 	NormalizeCoinID(&assetID)

--- a/core/state/statedb_multicoin_test.go
+++ b/core/state/statedb_multicoin_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/crypto"
-	"github.com/ava-labs/libevm/rlp"
 	"github.com/holiman/uint256"
 )
 
@@ -147,16 +146,12 @@ func TestGenerateMultiCoinAccounts(t *testing.T) {
 
 	// Get latest snapshot and make sure it has the correct account and storage
 	snap := snaps.Snapshot(root)
-	snapAccount, err := snap.AccountRLP(addrHash)
+	snapAccount, err := snap.Account(addrHash)
 	if err != nil {
 		t.Fatal(err)
 	}
-	account := new(types.StateAccount)
-	if err := rlp.DecodeBytes(snapAccount, account); err != nil {
-		t.Fatal(err)
-	}
-	if !types.IsMultiCoin(account) {
-		t.Fatalf("Expected SnapAccount to return IsMultiCoin: true, found: %v", types.IsMultiCoin(account))
+	if isMultiCoin := types.IsMultiCoin(snapAccount); !isMultiCoin {
+		t.Fatalf("Expected SnapAccount to return IsMultiCoin: true, found: %v", isMultiCoin)
 	}
 
 	NormalizeCoinID(&assetID)

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -48,6 +48,6 @@ type isMultiCoin bool
 
 var IsMultiCoinPayloads = ethtypes.RegisterExtras[isMultiCoin]()
 
-func IsMultiCoin(a *SlimAccount) bool {
+func IsMultiCoin(a ethtypes.ExtraPayloadCarrier) bool {
 	return bool(IsMultiCoinPayloads.FromPayloadCarrier(a))
 }

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -48,6 +48,6 @@ type isMultiCoin bool
 
 var IsMultiCoinPayloads = ethtypes.RegisterExtras[isMultiCoin]()
 
-func IsMultiCoin(a *StateAccount) bool {
-	return bool(IsMultiCoinPayloads.FromStateAccount(a))
+func IsMultiCoin(a *SlimAccount) bool {
+	return bool(IsMultiCoinPayloads.FromPayloadCarrier(a))
 }

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.22.8
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195
-	github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e
+	github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241129191047-0a4ba1bb7045
+	github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,10 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195 h1:dyf52xlqlA/9SaiCv29oqbitRAYu7L890zK774xDNrE=
-github.com/ava-labs/avalanchego v1.11.13-0.20241106174551-4fb3f3c6b195/go.mod h1:eZ/UmH4rDhhgL/FLqtJZYJ7ka73m88RmLrOoAyZFgD4=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e h1:WwDl/jyHr4oJ1VYUi+PEu6l05Vcl4rZv1xXJ0vVP1gI=
-github.com/ava-labs/libevm v1.13.14-0.1.0-rc.1.0.20241126163706-cd51330a5e2e/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
+github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241129191047-0a4ba1bb7045 h1:oOR9jYAlNm3FgWWatjCZIeOslLlmmbnCrqAErQDHngk=
+github.com/ava-labs/avalanchego v1.12.0-initial-poc.9.0.20241129191047-0a4ba1bb7045/go.mod h1:tubX8cWRjtVe6s6sm/2xeljfuhEISuJiVzvOiPiXSuI=
+github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2 h1:CVbn0hSsPCl6gCkTCnqwuN4vtJgdVbkCqLXzYAE7qF8=
+github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'4fb3f3c6'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'0a4ba1bb'}


### PR DESCRIPTION
### Dependency Updates:
* Updated `github.com/ava-labs/avalanchego` and `github.com/ava-labs/libevm` to newer versions in `go.mod`.

### Account Handling Improvements:
* Modified `IsMultiCoin` function to use `SlimAccount` instead of `StateAccount` in `core/types/state_account.go`.
* Simplified the `TestGenerateMultiCoinAccounts` function by removing the RLP decoding step and directly checking the `IsMultiCoin` status in `core/state/statedb_multicoin_test.go`.

### Import Cleanup:
* Removed the unused `rlp` import from `core/state/statedb_multicoin_test.go`.