### PR TITLE
prepare release cycle v0.14.1

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## [v0.14.1](https://github.com/ava-labs/coreth/releases/tag/v0.14.1)
+- TBD
+
 ## [v0.14.0](https://github.com/ava-labs/coreth/releases/tag/v0.14.0)
 - Minor version update to correspond to avalanchego v1.12.0 / Etna.
 - Remove unused historical opcodes CALLEX, BALANCEMC

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -11,7 +11,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.14.0"
+	Version string = "v0.14.1"
 )
 
 func init() {


### PR DESCRIPTION
Should start the release cycle so the rc's can be appropriately tagged when needed.