### PR TITLE
Remove eth_getAssetBalance API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,7 +1,7 @@
 # Release Notes
 
 ## [v0.14.1](https://github.com/ava-labs/coreth/releases/tag/v0.14.1)
-- TBD
+- Remove API eth_getAssetBalance that was used to query ANT balances (deprecated since v0.10.0)
 
 ## [v0.14.0](https://github.com/ava-labs/coreth/releases/tag/v0.14.0)
 - Minor version update to correspond to avalanchego v1.12.0 / Etna.

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -34,7 +34,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/coreth/accounts/abi/bind"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/interfaces"
@@ -90,7 +89,6 @@ type Client interface {
 	SubscribeNewHead(context.Context, chan<- *types.Header) (interfaces.Subscription, error)
 	NetworkID(context.Context) (*big.Int, error)
 	BalanceAt(context.Context, common.Address, *big.Int) (*big.Int, error)
-	AssetBalanceAt(context.Context, common.Address, ids.ID, *big.Int) (*big.Int, error)
 	BalanceAtHash(ctx context.Context, account common.Address, blockHash common.Hash) (*big.Int, error)
 	StorageAt(context.Context, common.Address, common.Hash, *big.Int) ([]byte, error)
 	StorageAtHash(ctx context.Context, account common.Address, key common.Hash, blockHash common.Hash) ([]byte, error)

--- a/ethclient/ethclient.go
+++ b/ethclient/ethclient.go
@@ -467,14 +467,6 @@ func (ec *client) BalanceAt(ctx context.Context, account common.Address, blockNu
 	return (*big.Int)(&result), err
 }
 
-// AssetBalanceAt returns the [assetID] balance of the given account
-// The block number can be nil, in which case the balance is taken from the latest known block.
-func (ec *client) AssetBalanceAt(ctx context.Context, account common.Address, assetID ids.ID, blockNumber *big.Int) (*big.Int, error) {
-	var result hexutil.Big
-	err := ec.c.CallContext(ctx, &result, "eth_getAssetBalance", account, ToBlockNumArg(blockNumber), assetID)
-	return (*big.Int)(&result), err
-}
-
 // BalanceAtHash returns the wei balance of the given account.
 func (ec *client) BalanceAtHash(ctx context.Context, account common.Address, blockHash common.Hash) (*big.Int, error) {
 	var result hexutil.Big

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -35,7 +35,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/coreth/accounts"
 	"github.com/ava-labs/coreth/accounts/keystore"
 	"github.com/ava-labs/coreth/accounts/scwallet"
@@ -644,17 +643,6 @@ func (s *BlockChainAPI) GetBalance(ctx context.Context, address common.Address, 
 	}
 	b := state.GetBalance(address).ToBig()
 	return (*hexutil.Big)(b), state.Error()
-}
-
-// GetAssetBalance returns the amount of [assetID] for the given address in the state of the
-// given block number. The rpc.LatestBlockNumber, rpc.PendingBlockNumber, and
-// rpc.AcceptedBlockNumber meta block numbers are also allowed.
-func (s *BlockChainAPI) GetAssetBalance(ctx context.Context, address common.Address, blockNrOrHash rpc.BlockNumberOrHash, assetID ids.ID) (*hexutil.Big, error) {
-	state, _, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
-	if state == nil || err != nil {
-		return nil, err
-	}
-	return (*hexutil.Big)(state.GetBalanceMultiCoin(address, common.Hash(assetID))), state.Error()
 }
 
 // AccountResult structs for GetProof


### PR DESCRIPTION
## Why this should be merged
ANT (avalanche native tokens) precompiles have been disabled since v0.10.0, and there is no intention to re-enable them in the future.
We should remove these API calls to simplify the codebase.

## How this works
Removes code

## How this was tested
CI

## Need to be documented?
docs PR https://github.com/ava-labs/avalanche-docs/pull/1979

## Need to update RELEASES.md?
done