### PR TITLE
Simplify txpool min base fee code (post etna cleanup)

### DIFF
--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -115,12 +115,6 @@ var (
 		return &cpy
 	}
 
-	activateEtna = func(cfg *params.ChainConfig, etnaTime uint64) *params.ChainConfig {
-		cpy := *cfg
-		cpy.EtnaTimestamp = &etnaTime
-		return &cpy
-	}
-
 	genesisJSONApricotPhase0     = genesisJSON(params.TestLaunchConfig)
 	genesisJSONApricotPhase1     = genesisJSON(params.TestApricotPhase1Config)
 	genesisJSONApricotPhase2     = genesisJSON(params.TestApricotPhase2Config)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3987,25 +3987,3 @@ func TestNoBlobsAllowed(t *testing.T) {
 	err = vmBlock.Verify(ctx)
 	require.ErrorContains(err, "blobs not enabled on avalanche networks")
 }
-
-func TestMinFeeSetAtEtna(t *testing.T) {
-	require := require.New(t)
-	now := time.Now()
-	etnaTime := uint64(now.Add(1 * time.Second).Unix())
-
-	genesis := genesisJSON(
-		activateEtna(params.TestEtnaChainConfig, etnaTime),
-	)
-	clock := mockable.Clock{}
-	clock.Set(now)
-
-	_, vm, _, _, _ := GenesisVMWithClock(t, false, genesis, "", "", clock)
-	initial := vm.txPool.MinFee()
-	require.Equal(params.ApricotPhase4MinBaseFee, initial.Int64())
-
-	require.Eventually(
-		func() bool { return params.EtnaMinBaseFee == vm.txPool.MinFee().Int64() },
-		5*time.Second,
-		1*time.Second,
-	)
-}


### PR DESCRIPTION
## Why this should be merged
Since Etna is active the code that adjusts the tx pool min base fee via a delayed timer is not needed anymore.

## How this works
Simplifies the code.

## How this was tested
CI

## Need to be documented?
No

## Need to update RELEASES.md?
No