### PR TITLE
chore(ci): remove `check-latest: true` to ensure the specified Go version is used

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "~1.22.8"
-          check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -74,7 +73,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "~1.22.8"
-          check-latest: true
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -113,7 +111,6 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "~1.22.8"
-          check-latest: true
       - name: Run e2e tests
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
         shell: bash

--- a/.github/workflows/sync-subnet-evm-branch.yml
+++ b/.github/workflows/sync-subnet-evm-branch.yml
@@ -17,4 +17,3 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "~1.22.8"
-          check-latest: true


### PR DESCRIPTION
## Why this should be merged

So we use the Go version specified, not the latest one.
See https://github.com/actions/setup-go?tab=readme-ov-file#check-latest-version

## How this works

Removed `check-latest: true` in Go setup action

## How this was tested

CI passing

## Need to be documented?

No

## Need to update RELEASES.md?

No