### PR TITLE
fix test generator

### DIFF
--- a/triedb/pathdb/database_test.go
+++ b/triedb/pathdb/database_test.go
@@ -228,7 +228,11 @@ func (t *tester) generate(parent common.Hash) (common.Hash, *trienode.MergedNode
 		dirties = make(map[common.Hash]struct{})
 	)
 	for i := 0; i < 20; i++ {
-		switch rand.Intn(opLen) {
+		op := createAccountOp
+		if i > 0 {
+			op = rand.Intn(opLen)
+		}
+		switch op {
 		case createAccountOp:
 			// account creation
 			addr := testutil.RandomAddress()


### PR DESCRIPTION
## Why this should be merged

Fixes the flaky test generator

## How this works

This pull request includes a change to the `generate` function in the `triedb/pathdb/database_test.go` file. The modification ensures that the `createAccountOp` operation is always selected for the first iteration, and a random operation is chosen for subsequent iterations.

* [`triedb/pathdb/database_test.go`](diffhunk://#diff-aa0965b61dc78a72ef175bc83cacadd7e5f29613ea543f86242a459b7259ccb9L231-R235): Modified the `generate` function to always select `createAccountOp` for the first iteration and randomize the operation for subsequent iterations.

## How this was tested

It's fix to the test

## Need to be documented?

No

## Need to update RELEASES.md?

 No
