### PR TITLE
 avoid import of params from plugin/evm/atomic 

### DIFF
--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -6,7 +6,6 @@ package params
 import (
 	"math/big"
 
-	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/coreth/predicate"
 )
 
@@ -16,8 +15,6 @@ const (
 	// transaction to be valid, measured in wei
 	LaunchMinGasPrice        int64 = 470 * GWei
 	ApricotPhase1MinGasPrice int64 = 225 * GWei
-
-	AvalancheAtomicTxFee = units.MilliAvax
 
 	ApricotPhase1GasLimit uint64 = 8_000_000
 	CortinaGasLimit       uint64 = 15_000_000
@@ -37,9 +34,6 @@ const (
 	// After Durango, the extra data past the dynamic fee rollup window represents predicate results.
 	DynamicFeeExtraDataSize        = predicate.DynamicFeeExtraDataSize
 	RollupWindow            uint64 = 10
-
-	// The base cost to charge per atomic transaction. Added in Apricot Phase 5.
-	AtomicTxBaseCost uint64 = 10_000
 )
 
 // The atomic gas limit specifies the maximum amount of gas that can be consumed by the atomic

--- a/plugin/evm/atomic/export_tx.go
+++ b/plugin/evm/atomic/export_tx.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/holiman/uint256"
 
@@ -143,7 +142,7 @@ func (utx *UnsignedExportTx) GasUsed(fixedFee bool) (uint64, error) {
 		return 0, err
 	}
 	if fixedFee {
-		cost, err = math.Add64(cost, params.AtomicTxBaseCost)
+		cost, err = math.Add64(cost, AtomicTxBaseCost)
 		if err != nil {
 			return 0, err
 		}
@@ -208,7 +207,7 @@ func (utx *UnsignedExportTx) SemanticVerify(
 		fc.Produce(ctx.AVAXAssetID, txFee)
 	// Apply fees to export transactions before Apricot Phase 3
 	default:
-		fc.Produce(ctx.AVAXAssetID, params.AvalancheAtomicTxFee)
+		fc.Produce(ctx.AVAXAssetID, AvalancheAtomicTxFee)
 	}
 	for _, out := range utx.ExportedOutputs {
 		fc.Produce(out.AssetID(), out.Output().Amount())
@@ -347,7 +346,7 @@ func NewExportTx(
 		avaxIns, avaxSigners, err = GetSpendableAVAXWithFee(ctx, state, keys, avaxNeeded, cost, baseFee)
 	default:
 		var newAvaxNeeded uint64
-		newAvaxNeeded, err = math.Add64(avaxNeeded, params.AvalancheAtomicTxFee)
+		newAvaxNeeded, err = math.Add64(avaxNeeded, AvalancheAtomicTxFee)
 		if err != nil {
 			return nil, errOverflowExport
 		}

--- a/plugin/evm/atomic/import_tx.go
+++ b/plugin/evm/atomic/import_tx.go
@@ -10,7 +10,6 @@ import (
 	"math/big"
 	"slices"
 
-	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/holiman/uint256"
 
@@ -151,7 +150,7 @@ func (utx *UnsignedImportTx) GasUsed(fixedFee bool) (uint64, error) {
 		}
 	}
 	if fixedFee {
-		cost, err = math.Add64(cost, params.AtomicTxBaseCost)
+		cost, err = math.Add64(cost, AtomicTxBaseCost)
 		if err != nil {
 			return 0, err
 		}
@@ -216,7 +215,7 @@ func (utx *UnsignedImportTx) SemanticVerify(
 
 	// Apply fees to import transactions as of Apricot Phase 2
 	case rules.IsApricotPhase2:
-		fc.Produce(ctx.AVAXAssetID, params.AvalancheAtomicTxFee)
+		fc.Produce(ctx.AVAXAssetID, AvalancheAtomicTxFee)
 	}
 	for _, out := range utx.Outs {
 		fc.Produce(out.AssetID, out.Amount)
@@ -378,8 +377,8 @@ func NewImportTx(
 			return nil, err
 		}
 	case rules.IsApricotPhase2:
-		txFeeWithoutChange = params.AvalancheAtomicTxFee
-		txFeeWithChange = params.AvalancheAtomicTxFee
+		txFeeWithoutChange = AvalancheAtomicTxFee
+		txFeeWithChange = AvalancheAtomicTxFee
 	}
 
 	// AVAX output

--- a/plugin/evm/atomic/params.go
+++ b/plugin/evm/atomic/params.go
@@ -1,0 +1,13 @@
+// (c) 2025 Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package atomic
+
+import "github.com/ava-labs/avalanchego/utils/units"
+
+const (
+	AvalancheAtomicTxFee = units.MilliAvax
+
+	// The base cost to charge per atomic transaction. Added in Apricot Phase 5.
+	AtomicTxBaseCost uint64 = 10_000
+)

--- a/plugin/evm/import_tx_test.go
+++ b/plugin/evm/import_tx_test.go
@@ -105,7 +105,7 @@ func TestImportTxVerify(t *testing.T) {
 		Outs: []atomic.EVMOutput{
 			{
 				Address: testEthAddrs[0],
-				Amount:  importAmount - params.AvalancheAtomicTxFee,
+				Amount:  importAmount - atomic.AvalancheAtomicTxFee,
 				AssetID: ctx.AVAXAssetID,
 			},
 			{

--- a/plugin/evm/imports_test.go
+++ b/plugin/evm/imports_test.go
@@ -54,9 +54,9 @@ func TestMustNotImport(t *testing.T) {
 		// Importing these packages configures libevm globally and it is not
 		// possible to do so for both coreth and subnet-evm, where the client may
 		// wish to connect to multiple chains.
-		"plugin/evm/atomic": {"core", "core/vm"},
-		"plugin/evm/client": {"core", "core/vm"},
-		"plugin/evm/config": {"core", "core/vm"},
+		"plugin/evm/atomic": {"core", "core/vm", "params"},
+		"plugin/evm/client": {"core", "core/vm", "params"},
+		"plugin/evm/config": {"core", "core/vm", "params"},
 	}
 
 	for packageName, forbiddenImports := range mustNotImport {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -644,7 +644,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal("Expected logs to be non-nil")
 	}
 
-	exportTx, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-(2*params.AvalancheAtomicTxFee), vm.ctx.XChainID, testShortIDAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
+	exportTx, err := vm.newExportTx(vm.ctx.AVAXAssetID, importAmount-(2*atomic.AvalancheAtomicTxFee), vm.ctx.XChainID, testShortIDAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
The params package will trigger one-time libevm type registrations so we should not import them in the client / shared types packages with avalanchego/wallets.