### PR TITLE
chore(core/types): `Header` libevm `PostCopy` hook (5)

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -126,53 +126,6 @@ func NewBlock(
 	return b
 }
 
-// CopyHeader creates a deep copy of a block header.
-func CopyHeader(h *Header) *Header {
-	cpy := *h
-	hExtra := GetHeaderExtra(h)
-	cpyExtra := &HeaderExtra{
-		ExtDataHash: hExtra.ExtDataHash,
-	}
-	SetHeaderExtra(&cpy, cpyExtra)
-
-	if cpy.Difficulty = new(big.Int); h.Difficulty != nil {
-		cpy.Difficulty.Set(h.Difficulty)
-	}
-	if cpy.Number = new(big.Int); h.Number != nil {
-		cpy.Number.Set(h.Number)
-	}
-	if h.BaseFee != nil {
-		cpy.BaseFee = new(big.Int).Set(h.BaseFee)
-	}
-	if hExtra.ExtDataGasUsed != nil {
-		cpyExtra.ExtDataGasUsed = new(big.Int).Set(hExtra.ExtDataGasUsed)
-	}
-	if hExtra.BlockGasCost != nil {
-		cpyExtra.BlockGasCost = new(big.Int).Set(hExtra.BlockGasCost)
-	}
-	if len(h.Extra) > 0 {
-		cpy.Extra = make([]byte, len(h.Extra))
-		copy(cpy.Extra, h.Extra)
-	}
-	if h.WithdrawalsHash != nil {
-		cpy.WithdrawalsHash = new(common.Hash)
-		*cpy.WithdrawalsHash = *h.WithdrawalsHash
-	}
-	if h.ExcessBlobGas != nil {
-		cpy.ExcessBlobGas = new(uint64)
-		*cpy.ExcessBlobGas = *h.ExcessBlobGas
-	}
-	if h.BlobGasUsed != nil {
-		cpy.BlobGasUsed = new(uint64)
-		*cpy.BlobGasUsed = *h.BlobGasUsed
-	}
-	if h.ParentBeaconRoot != nil {
-		cpy.ParentBeaconRoot = new(common.Hash)
-		*cpy.ParentBeaconRoot = *h.ParentBeaconRoot
-	}
-	return &cpy
-}
-
 // DecodeRLP decodes a block from RLP.
 func (b *Block) DecodeRLP(s *rlp.Stream) error {
 	var eb extblock

--- a/core/types/header_ext.go
+++ b/core/types/header_ext.go
@@ -84,21 +84,16 @@ func (h *HeaderExtra) DecodeJSON(eth *ethtypes.Header, input []byte) error {
 }
 
 func (h *HeaderExtra) PostCopy(dst *ethtypes.Header) {
-	extraCopy := &HeaderExtra{
+	cp := &HeaderExtra{
 		ExtDataHash: h.ExtDataHash,
 	}
-
 	if h.BlockGasCost != nil {
-		extraCopy.BlockGasCost = big.NewInt(0)
-		extraCopy.BlockGasCost.SetBytes(h.BlockGasCost.Bytes())
+		cp.BlockGasCost = new(big.Int).Set(h.BlockGasCost)
 	}
-
 	if h.ExtDataGasUsed != nil {
-		extraCopy.ExtDataGasUsed = big.NewInt(0)
-		extraCopy.ExtDataGasUsed.SetBytes(h.ExtDataGasUsed.Bytes())
+		cp.ExtDataGasUsed = new(big.Int).Set(h.ExtDataGasUsed)
 	}
-
-	SetHeaderExtra(dst, extraCopy)
+	SetHeaderExtra(dst, cp)
 }
 
 func (h *HeaderSerializable) updateFromEth(eth *ethtypes.Header) {

--- a/core/types/header_ext.go
+++ b/core/types/header_ext.go
@@ -84,7 +84,21 @@ func (h *HeaderExtra) DecodeJSON(eth *ethtypes.Header, input []byte) error {
 }
 
 func (h *HeaderExtra) PostCopy(dst *ethtypes.Header) {
-	panic("not implemented")
+	extraCopy := &HeaderExtra{
+		ExtDataHash: h.ExtDataHash,
+	}
+
+	if h.BlockGasCost != nil {
+		extraCopy.BlockGasCost = big.NewInt(0)
+		extraCopy.BlockGasCost.SetBytes(h.BlockGasCost.Bytes())
+	}
+
+	if h.ExtDataGasUsed != nil {
+		extraCopy.ExtDataGasUsed = big.NewInt(0)
+		extraCopy.ExtDataGasUsed.SetBytes(h.ExtDataGasUsed.Bytes())
+	}
+
+	SetHeaderExtra(dst, extraCopy)
 }
 
 func (h *HeaderSerializable) updateFromEth(eth *ethtypes.Header) {

--- a/core/types/header_ext_test.go
+++ b/core/types/header_ext_test.go
@@ -168,56 +168,6 @@ func assertNonZero[T interface {
 	}
 }
 
-func TestHeaderExtraPostCopy(t *testing.T) {
-	t.Parallel()
-
-	t.Run("empty_extra", func(t *testing.T) {
-		t.Parallel()
-
-		got := &ethtypes.Header{
-			ParentHash: common.Hash{1},
-		}
-		extra := &HeaderExtra{}
-
-		extra.PostCopy(got)
-
-		want := &ethtypes.Header{
-			ParentHash: common.Hash{1},
-		}
-		wantExtra := &HeaderExtra{}
-		SetHeaderExtra(want, wantExtra)
-
-		assert.Equal(t, want, got)
-		gotExtra := GetHeaderExtra(got)
-		assert.Equal(t, wantExtra, gotExtra)
-	})
-
-	t.Run("filled_extra", func(t *testing.T) {
-		got := &ethtypes.Header{
-			ParentHash: common.Hash{1},
-		}
-		extra := &HeaderExtra{
-			ExtDataHash:    common.Hash{2},
-			ExtDataGasUsed: big.NewInt(3),
-			BlockGasCost:   big.NewInt(4),
-		}
-
-		extra.PostCopy(got)
-
-		want := &ethtypes.Header{
-			ParentHash: common.Hash{1},
-		}
-		wantExtra := &HeaderExtra{
-			ExtDataHash:    common.Hash{2},
-			ExtDataGasUsed: big.NewInt(3),
-			BlockGasCost:   big.NewInt(4),
-		}
-		_ = WithHeaderExtra(want, wantExtra)
-
-		assert.Equal(t, want, got)
-		gotExtra := GetHeaderExtra(got)
-		assert.Equal(t, wantExtra, gotExtra)
-	})
-}
+// Note [TestCopyHeader] tests the [HeaderExtra.PostCopy] method.
 
 func ptrTo[T any](x T) *T { return &x }

--- a/core/types/header_ext_test.go
+++ b/core/types/header_ext_test.go
@@ -168,4 +168,56 @@ func assertNonZero[T interface {
 	}
 }
 
+func TestHeaderExtraPostCopy(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty_extra", func(t *testing.T) {
+		t.Parallel()
+
+		got := &ethtypes.Header{
+			ParentHash: common.Hash{1},
+		}
+		extra := &HeaderExtra{}
+
+		extra.PostCopy(got)
+
+		want := &ethtypes.Header{
+			ParentHash: common.Hash{1},
+		}
+		wantExtra := &HeaderExtra{}
+		SetHeaderExtra(want, wantExtra)
+
+		assert.Equal(t, want, got)
+		gotExtra := GetHeaderExtra(got)
+		assert.Equal(t, wantExtra, gotExtra)
+	})
+
+	t.Run("filled_extra", func(t *testing.T) {
+		got := &ethtypes.Header{
+			ParentHash: common.Hash{1},
+		}
+		extra := &HeaderExtra{
+			ExtDataHash:    common.Hash{2},
+			ExtDataGasUsed: big.NewInt(3),
+			BlockGasCost:   big.NewInt(4),
+		}
+
+		extra.PostCopy(got)
+
+		want := &ethtypes.Header{
+			ParentHash: common.Hash{1},
+		}
+		wantExtra := &HeaderExtra{
+			ExtDataHash:    common.Hash{2},
+			ExtDataGasUsed: big.NewInt(3),
+			BlockGasCost:   big.NewInt(4),
+		}
+		_ = WithHeaderExtra(want, wantExtra)
+
+		assert.Equal(t, want, got)
+		gotExtra := GetHeaderExtra(got)
+		assert.Equal(t, wantExtra, gotExtra)
+	})
+}
+
 func ptrTo[T any](x T) *T { return &x }

--- a/core/types/imports.go
+++ b/core/types/imports.go
@@ -51,6 +51,7 @@ const (
 var (
 	BloomLookup          = ethtypes.BloomLookup
 	BytesToBloom         = ethtypes.BytesToBloom
+	CopyHeader           = ethtypes.CopyHeader
 	CreateBloom          = ethtypes.CreateBloom
 	EncodeNonce          = ethtypes.EncodeNonce
 	FullAccount          = ethtypes.FullAccount


### PR DESCRIPTION
- Implement `PostCopy` header hook
- Remove `CopyHeader` and use imported one from libevm

➡️  [header copy hooks libevm PR](https://github.com/ava-labs/libevm/pull/106/files)