### PR TITLE
chore(lint): cleanup config and enable default linters for our code

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56
+          version: v1.63
           working-directory: .
           args: --timeout 3m
           skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,6 @@
 run:
   timeout: 10m
   tests: true
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-  # Include non-test files tagged as test-only.
-  # Context: https://github.com/ava-labs/avalanchego/pull/3173
 
 linters:
   disable-all: true
@@ -18,8 +13,19 @@ linters:
     - ineffassign
     - misspell
     - unconvert
+    - typecheck
     - unused
+    # - staticcheck
+    - bidichk
+    - durationcheck
+    - copyloopvar
     - whitespace
+    # - revive # only certain checks enabled
+    - durationcheck
+    - gocheckcompilerdirectives
+    - reassign
+    - mirror
+    - tenv
 
 linters-settings:
   gofmt:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -25,8 +25,3 @@ linters:
     - reassign
     - mirror
     - tenv
-
-linters-settings:
-  goconst:
-    min-occurrences: 6 # minimum number of occurrences
-    ignore-tests: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,7 +14,7 @@ linters:
     - unconvert
     - typecheck
     - unused
-    # - staticcheck
+    - staticcheck
     - bidichk
     - durationcheck
     - copyloopvar
@@ -25,3 +25,18 @@ linters:
     - reassign
     - mirror
     - tenv
+    - errcheck
+
+issues:
+  exclude-rules:
+    - path: "_test\\.go"
+      text: "SA1019: rand\\.(Seed|Read) has been deprecated since Go 1\\.20"
+      linters:
+        - staticcheck
+
+    - path-except: "(plugin\\/.+\\.go|.+_ext\\.go)"
+      linters:
+        - errcheck
+        - gosimple
+        - govet
+        - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -26,6 +26,11 @@ linters:
     - mirror
     - tenv
     - errcheck
+    - errorlint
+
+linters-settings:
+  errorlint:
+    errorf: false
 
 issues:
   exclude-rules:
@@ -37,6 +42,7 @@ issues:
     - path-except: "(plugin\\/.+\\.go|.+_ext\\.go)"
       linters:
         - errcheck
+        - errorlint
         - gosimple
         - govet
         - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,8 +27,6 @@ linters:
     - tenv
 
 linters-settings:
-  gofmt:
-    simplify: true
   goconst:
     min-len: 3 # minimum length of string constant
     min-occurrences: 6 # minimum number of occurrences

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,6 @@
 
 run:
   timeout: 10m
-  tests: true
 
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,6 +28,5 @@ linters:
 
 linters-settings:
   goconst:
-    min-len: 3 # minimum length of string constant
     min-occurrences: 6 # minimum number of occurrences
     ignore-tests: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,8 +38,7 @@ issues:
       text: "SA1019: rand\\.(Seed|Read) has been deprecated since Go 1\\.20"
       linters:
         - staticcheck
-
-    - path-except: "(plugin\\/.+\\.go|.+_ext\\.go)"
+    - path-except: "(_ext|plugin\\/.+|libevm.*)\\.go"
       linters:
         - errcheck
         - errorlint

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,8 @@
 # Release Notes
 
 ## Pending Release
+- Bump golang version to v1.23.6
+- Bump golangci-lint to v1.63 and add linters
 
 ## [v0.14.1](https://github.com/ava-labs/coreth/releases/tag/v0.14.1)
 

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1210,7 +1210,6 @@ func TestUnpackRevert(t *testing.T) {
 		{"4e487b7100000000000000000000000000000000000000000000000000000000000000ff", "unknown panic code: 0xff", nil},
 	}
 	for index, c := range cases {
-		index, c := index, c
 		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
 			t.Parallel()
 			got, err := UnpackRevert(common.Hex2Bytes(c.input))

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -262,7 +262,7 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 		}
 		// Parse library references.
 		for pattern, name := range libs {
-			matched, err := regexp.Match("__\\$"+pattern+"\\$__", []byte(contracts[types[i]].InputBin))
+			matched, err := regexp.MatchString("__\\$"+pattern+"\\$__", contracts[types[i]].InputBin)
 			if err != nil {
 				log.Error("Could not search for pattern", "pattern", pattern, "contract", contracts[types[i]], "err", err)
 			}

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -341,7 +341,6 @@ func TestEventTupleUnpack(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert := assert.New(t)
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := unpackTestEventData(tc.dest, tc.data, tc.jsonLog, assert)
 			if tc.error == "" {

--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -44,7 +44,6 @@ import (
 func TestPack(t *testing.T) {
 	t.Parallel()
 	for i, test := range packUnpackTests {
-		i, test := i, test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			encb, err := hex.DecodeString(test.packed)

--- a/accounts/abi/reflect_test.go
+++ b/accounts/abi/reflect_test.go
@@ -182,7 +182,6 @@ var reflectTests = []reflectTest{
 func TestReflectNameToStruct(t *testing.T) {
 	t.Parallel()
 	for _, test := range reflectTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			m, err := mapArgNamesToStructFields(test.args, reflect.ValueOf(test.struc))

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -147,7 +147,6 @@ func TestMakeTopics(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := MakeTopics(tt.args.query...)
@@ -383,7 +382,6 @@ func TestParseTopics(t *testing.T) {
 	tests := setupTopicsTests()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			createObj := tt.args.createObj()
@@ -403,7 +401,6 @@ func TestParseTopicsIntoMap(t *testing.T) {
 	tests := setupTopicsTests()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			outMap := make(map[string]interface{})

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -399,7 +399,6 @@ func TestMethodMultiReturn(t *testing.T) {
 		"Can not unpack into a slice with wrong types",
 	}}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			err := abi.UnpackIntoInterface(tc.dest, "multi", data)
@@ -957,7 +956,7 @@ func TestOOMMaliciousInput(t *testing.T) {
 		}
 		encb, err := hex.DecodeString(test.enc)
 		if err != nil {
-			t.Fatalf("invalid hex: %s" + test.enc)
+			t.Fatalf("invalid hex: %s", test.enc)
 		}
 		_, err = abi.Methods["method"].Outputs.UnpackValues(encb)
 		if err == nil {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -290,7 +290,6 @@ func TestBlockChainOfflinePruningUngracefulShutdown(t *testing.T) {
 		return createBlockChain(db, pruningConfig, gspec, lastAcceptedHash)
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.testFunc(t, create)

--- a/core/predicate_check_test.go
+++ b/core/predicate_check_test.go
@@ -293,7 +293,6 @@ func TestCheckPredicate(t *testing.T) {
 			expectedErr: ErrIntrinsicGas,
 		},
 	} {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 			// Create the rules from TestChainConfig and update the predicates based on the test params

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -291,10 +291,10 @@ func TestBlockReceiptStorage(t *testing.T) {
 	// Insert the receipt slice into the database and check presence
 	WriteReceipts(db, hash, 0, receipts)
 	if rs := ReadReceipts(db, hash, 0, 0, params.TestChainConfig); len(rs) == 0 {
-		t.Fatalf("no receipts returned")
+		t.Fatal("no receipts returned")
 	} else {
 		if err := checkReceiptsRLP(rs, receipts); err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		}
 	}
 	// Delete the body and ensure that the receipts are no longer returned (metadata can't be recomputed)
@@ -308,7 +308,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	}
 	// Ensure that receipts without metadata can be returned without the block body too
 	if err := checkReceiptsRLP(ReadRawReceipts(db, hash, 0), receipts); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	// Sanity check that body and header alone without the receipt is a full purge
 	WriteHeader(db, header)

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -520,9 +520,7 @@ func TestYParityJSONUnmarshalling(t *testing.T) {
 		DynamicFeeTxType,
 		BlobTxType,
 	} {
-		txType := txType
 		for _, test := range tests {
-			test := test
 			t.Run(fmt.Sprintf("txType=%d: %s", txType, test.name), func(t *testing.T) {
 				// Copy the base json
 				testJson := make(map[string]interface{})

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -350,7 +350,6 @@ func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subsc
 			select {
 			case logs := <-matchedLogs:
 				for _, log := range logs {
-					log := log
 					notifier.Notify(rpcSub.ID, &log)
 				}
 			case <-rpcSub.Err(): // client send an unsubscribe request

--- a/eth/tracers/internal/tracetest/calltrace_test.go
+++ b/eth/tracers/internal/tracetest/calltrace_test.go
@@ -113,7 +113,6 @@ func testCallTracer(tracerName string, dirPath string, t *testing.T) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(t *testing.T) {
 			t.Parallel()
 
@@ -205,7 +204,6 @@ func BenchmarkTracers(b *testing.B) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		b.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(b *testing.B) {
 			blob, err := os.ReadFile(filepath.Join("testdata", "call_tracer", file.Name()))
 			if err != nil {

--- a/eth/tracers/internal/tracetest/flat_calltrace_test.go
+++ b/eth/tracers/internal/tracetest/flat_calltrace_test.go
@@ -167,7 +167,6 @@ func testFlatCallTracer(tracerName string, dirPath string, t *testing.T) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(t *testing.T) {
 			t.Parallel()
 

--- a/eth/tracers/internal/tracetest/prestate_test.go
+++ b/eth/tracers/internal/tracetest/prestate_test.go
@@ -83,7 +83,6 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(t *testing.T) {
 			t.Parallel()
 

--- a/eth/tracers/logger/logger.go
+++ b/eth/tracers/logger/logger.go
@@ -446,7 +446,7 @@ func formatLogs(logs []StructLog) []StructLogRes {
 			}
 			formatted[index].Stack = &stack
 		}
-		if trace.ReturnData != nil && len(trace.ReturnData) > 0 {
+		if len(trace.ReturnData) > 0 {
 			formatted[index].ReturnData = hexutil.Bytes(trace.ReturnData).String()
 		}
 		if trace.Memory != nil {

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/ava-labs/coreth
 
-go 1.22.8
+go 1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf
+	github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf h1:4aq9V24PsH92vDSQTBx+uhm60BTeaNcXg/7FreQ8Q3M=
-github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf/go.mod h1:PkpeGfEdsTccz87SDHidto21U5+BSBGZ+BNPW6Zplbc=
+github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1 h1:bp+RMUpgUX2HL22FnArOMkhg9IaGjA7xHExAH3zy3Og=
+github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1/go.mod h1:kjz2dtxgb9UiSzCDMon8AqFpsRPb9SGGW9F6tsKwufc=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/plugin/evm/atomic/export_tx.go
+++ b/plugin/evm/atomic/export_tx.go
@@ -133,16 +133,16 @@ func (utx *UnsignedExportTx) Verify(
 func (utx *UnsignedExportTx) GasUsed(fixedFee bool) (uint64, error) {
 	byteCost := calcBytesCost(len(utx.Bytes()))
 	numSigs := uint64(len(utx.Ins))
-	sigCost, err := math.Mul64(numSigs, secp256k1fx.CostPerSignature)
+	sigCost, err := math.Mul(numSigs, secp256k1fx.CostPerSignature)
 	if err != nil {
 		return 0, err
 	}
-	cost, err := math.Add64(byteCost, sigCost)
+	cost, err := math.Add(byteCost, sigCost)
 	if err != nil {
 		return 0, err
 	}
 	if fixedFee {
-		cost, err = math.Add64(cost, params.AtomicTxBaseCost)
+		cost, err = math.Add(cost, params.AtomicTxBaseCost)
 		if err != nil {
 			return 0, err
 		}
@@ -160,7 +160,7 @@ func (utx *UnsignedExportTx) Burned(assetID ids.ID) (uint64, error) {
 	)
 	for _, out := range utx.ExportedOutputs {
 		if out.AssetID() == assetID {
-			spent, err = math.Add64(spent, out.Output().Amount())
+			spent, err = math.Add(spent, out.Output().Amount())
 			if err != nil {
 				return 0, err
 			}
@@ -168,7 +168,7 @@ func (utx *UnsignedExportTx) Burned(assetID ids.ID) (uint64, error) {
 	}
 	for _, in := range utx.Ins {
 		if in.AssetID == assetID {
-			input, err = math.Add64(input, in.Amount)
+			input, err = math.Add(input, in.Amount)
 			if err != nil {
 				return 0, err
 			}
@@ -346,7 +346,7 @@ func NewExportTx(
 		avaxIns, avaxSigners, err = GetSpendableAVAXWithFee(ctx, state, keys, avaxNeeded, cost, baseFee)
 	default:
 		var newAvaxNeeded uint64
-		newAvaxNeeded, err = math.Add64(avaxNeeded, params.AvalancheAtomicTxFee)
+		newAvaxNeeded, err = math.Add(avaxNeeded, params.AvalancheAtomicTxFee)
 		if err != nil {
 			return nil, errOverflowExport
 		}
@@ -486,7 +486,7 @@ func GetSpendableAVAXWithFee(
 		return nil, nil, err
 	}
 
-	newAmount, err := math.Add64(amount, initialFee)
+	newAmount, err := math.Add(amount, initialFee)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -527,7 +527,7 @@ func GetSpendableAVAXWithFee(
 		// Update the cost for the next iteration
 		cost = newCost
 
-		newAmount, err := math.Add64(amount, additionalFee)
+		newAmount, err := math.Add(amount, additionalFee)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/plugin/evm/atomic/import_tx.go
+++ b/plugin/evm/atomic/import_tx.go
@@ -144,13 +144,13 @@ func (utx *UnsignedImportTx) GasUsed(fixedFee bool) (uint64, error) {
 		if err != nil {
 			return 0, err
 		}
-		cost, err = math.Add64(cost, inCost)
+		cost, err = math.Add(cost, inCost)
 		if err != nil {
 			return 0, err
 		}
 	}
 	if fixedFee {
-		cost, err = math.Add64(cost, params.AtomicTxBaseCost)
+		cost, err = math.Add(cost, params.AtomicTxBaseCost)
 		if err != nil {
 			return 0, err
 		}
@@ -167,7 +167,7 @@ func (utx *UnsignedImportTx) Burned(assetID ids.ID) (uint64, error) {
 	)
 	for _, out := range utx.Outs {
 		if out.AssetID == assetID {
-			spent, err = math.Add64(spent, out.Amount)
+			spent, err = math.Add(spent, out.Amount)
 			if err != nil {
 				return 0, err
 			}
@@ -175,7 +175,7 @@ func (utx *UnsignedImportTx) Burned(assetID ids.ID) (uint64, error) {
 	}
 	for _, in := range utx.ImportedInputs {
 		if in.AssetID() == assetID {
-			input, err = math.Add64(input, in.Input().Amount())
+			input, err = math.Add(input, in.Input().Amount())
 			if err != nil {
 				return 0, err
 			}
@@ -311,7 +311,7 @@ func NewImportTx(
 			continue
 		}
 		aid := utxo.AssetID()
-		importedAmount[aid], err = math.Add64(importedAmount[aid], input.Amount())
+		importedAmount[aid], err = math.Add(importedAmount[aid], input.Amount())
 		if err != nil {
 			return nil, err
 		}

--- a/plugin/evm/atomic_backend.go
+++ b/plugin/evm/atomic_backend.go
@@ -5,6 +5,7 @@ package evm
 
 import (
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"time"
 
@@ -226,7 +227,7 @@ func (a *atomicBackend) initialize(lastAcceptedHeight uint64) error {
 // the range of operations that were added to the trie without being executed on shared memory.
 func (a *atomicBackend) ApplyToSharedMemory(lastAcceptedBlock uint64) error {
 	sharedMemoryCursor, err := a.metadataDB.Get(appliedSharedMemoryCursorKey)
-	if err == database.ErrNotFound {
+	if errors.Is(err, database.ErrNotFound) {
 		return nil
 	} else if err != nil {
 		return err

--- a/plugin/evm/atomic_syncer_test.go
+++ b/plugin/evm/atomic_syncer_test.go
@@ -7,10 +7,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
@@ -80,7 +80,9 @@ func testAtomicSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight 
 			return leafsResponse, nil
 		}
 
-		syncer.Start(ctx)
+		err = syncer.Start(ctx)
+		require.NoError(t, err)
+
 		if err := <-syncer.Done(); err == nil {
 			t.Fatalf("Expected syncer to fail at checkpoint with numLeaves %d", numLeaves)
 		}
@@ -104,7 +106,9 @@ func testAtomicSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight 
 		return leafsResponse, nil
 	}
 
-	syncer.Start(ctx)
+	err = syncer.Start(ctx)
+	require.NoError(t, err)
+
 	if err := <-syncer.Done(); err != nil {
 		t.Fatalf("Expected syncer to finish successfully but failed due to %s", err)
 	}
@@ -153,7 +157,6 @@ func testAtomicSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight 
 }
 
 func TestAtomicSyncer(t *testing.T) {
-	rand.Seed(1)
 	targetHeight := 10 * uint64(commitInterval)
 	serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 	root, _, _ := syncutils.GenerateTrie(t, serverTrieDB, int(targetHeight), atomicKeyLength)
@@ -162,7 +165,6 @@ func TestAtomicSyncer(t *testing.T) {
 }
 
 func TestAtomicSyncerResume(t *testing.T) {
-	rand.Seed(1)
 	targetHeight := 10 * uint64(commitInterval)
 	serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 	numTrieKeys := int(targetHeight) - 1 // no atomic ops for genesis
@@ -179,7 +181,6 @@ func TestAtomicSyncerResume(t *testing.T) {
 }
 
 func TestAtomicSyncerResumeNewRootCheckpoint(t *testing.T) {
-	rand.Seed(1)
 	targetHeight1 := 10 * uint64(commitInterval)
 	serverTrieDB := triedb.NewDatabase(rawdb.NewMemoryDatabase(), nil)
 	numTrieKeys1 := int(targetHeight1) - 1 // no atomic ops for genesis

--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -4,6 +4,7 @@
 package evm
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -183,7 +184,7 @@ func lastCommittedRootIfExists(db avalanchedatabase.Database) (common.Hash, uint
 	// read the last committed entry if it exists and set the root hash
 	lastCommittedHeightBytes, err := db.Get(lastCommittedKey)
 	switch {
-	case err == avalanchedatabase.ErrNotFound:
+	case errors.Is(err, avalanchedatabase.ErrNotFound):
 		return common.Hash{}, 0, nil
 	case err != nil:
 		return common.Hash{}, 0, err
@@ -305,7 +306,7 @@ func getRoot(metadataDB avalanchedatabase.Database, height uint64) (common.Hash,
 	heightBytes := avalanchedatabase.PackUInt64(height)
 	hash, err := metadataDB.Get(heightBytes)
 	switch {
-	case err == avalanchedatabase.ErrNotFound:
+	case errors.Is(err, avalanchedatabase.ErrNotFound):
 		return common.Hash{}, nil
 	case err != nil:
 		return common.Hash{}, err

--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -323,7 +323,11 @@ func (a *atomicTrie) InsertTrie(nodes *trienode.NodeSet, root common.Hash) error
 			return err
 		}
 	}
-	a.trieDB.Reference(root, common.Hash{})
+
+	err := a.trieDB.Reference(root, common.Hash{})
+	if err != nil {
+		return fmt.Errorf("referencing root: %w", err)
+	}
 
 	// The use of [Cap] in [insertTrie] prevents exceeding the configured memory
 	// limit (and OOM) in case there is a large backlog of processing (unaccepted) blocks.
@@ -364,12 +368,19 @@ func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (bool, error) {
 	// - not committted, in which case the current root we are inserting contains
 	//   references to all the relevant data from the previous root, so the previous
 	//   root can be dereferenced.
-	a.trieDB.Dereference(a.lastAcceptedRoot)
+	err := a.trieDB.Dereference(a.lastAcceptedRoot)
+	if err != nil {
+		return false, fmt.Errorf("dereferencing last accepted root: %w", err)
+	}
+
 	a.lastAcceptedRoot = root
 	return hasCommitted, nil
 }
 
 func (a *atomicTrie) RejectTrie(root common.Hash) error {
-	a.trieDB.Dereference(root)
+	err := a.trieDB.Dereference(root)
+	if err != nil {
+		return fmt.Errorf("dereferencing root from trie database: %w", err)
+	}
 	return nil
 }

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -706,7 +706,6 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
-		testCase := testCase // capture range variable for running tests with Go < 1.22
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -387,8 +387,6 @@ func TestIndexingNilShouldNotImpactTrie(t *testing.T) {
 			if err := indexAtomicTxs(a1, i, ops[i]); err != nil {
 				t.Fatal(err)
 			}
-		} else {
-			// do nothing
 		}
 	}
 
@@ -575,7 +573,7 @@ func TestApplyToSharedMemory(t *testing.T) {
 			assert.NoError(t, err)
 			assert.False(t, hasMarker)
 			// reinitialize the atomic trie
-			backend, err = NewAtomicBackend(
+			_, err = NewAtomicBackend(
 				db, sharedMemories.thisChain, nil, repo, test.lastAcceptedHeight, common.Hash{}, test.commitInterval,
 			)
 			assert.NoError(t, err)
@@ -736,7 +734,8 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 				_, storageSize, _ := atomicTrie.trieDB.Size()
 				require.NotZero(t, storageSize, "there should be a dirty node taking up storage space")
 			}
-			atomicTrie.updateLastCommitted(testCase.lastCommittedRoot, testCase.lastCommittedHeight)
+			err = atomicTrie.updateLastCommitted(testCase.lastCommittedRoot, testCase.lastCommittedHeight)
+			require.NoError(t, err)
 
 			hasCommitted, err := atomicTrie.AcceptTrie(testCase.height, testCase.root)
 			require.NoError(t, err)

--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -215,7 +215,7 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 			if err != nil {
 				return err
 			}
-			totalGasUsed, err = safemath.Add64(totalGasUsed, gasUsed)
+			totalGasUsed, err = safemath.Add(totalGasUsed, gasUsed)
 			if err != nil {
 				return err
 			}

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -1704,7 +1704,6 @@ func TestNewExportTx(t *testing.T) {
 				}
 			}()
 
-			parent := vm.LastAcceptedBlockInternal().(*Block)
 			importAmount := uint64(50000000)
 			utxoID := avax.UTXOID{TxID: ids.GenerateTestID()}
 
@@ -1764,7 +1763,7 @@ func TestNewExportTx(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			parent = vm.LastAcceptedBlockInternal().(*Block)
+			parent := vm.LastAcceptedBlockInternal().(*Block)
 			exportAmount := uint64(5000000)
 
 			state, err := vm.blockChain.State()
@@ -1877,7 +1876,6 @@ func TestNewExportTxMulticoin(t *testing.T) {
 				}
 			}()
 
-			parent := vm.LastAcceptedBlockInternal().(*Block)
 			importAmount := uint64(50000000)
 			utxoID := avax.UTXOID{TxID: ids.GenerateTestID()}
 
@@ -1967,7 +1965,7 @@ func TestNewExportTxMulticoin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			parent = vm.LastAcceptedBlockInternal().(*Block)
+			parent := vm.LastAcceptedBlockInternal().(*Block)
 			exportAmount := uint64(5000000)
 
 			testKeys0Addr := testKeys[0].EthAddress()

--- a/plugin/evm/gossiper_atomic_gossiping_test.go
+++ b/plugin/evm/gossiper_atomic_gossiping_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/avalanchego/proto/pb/sdk"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
@@ -147,7 +148,9 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	tx, conflictingTx := importTxs[0], importTxs[1]
 	txID := tx.ID()
 
-	mempool.AddRemoteTx(tx)
+	err := mempool.AddRemoteTx(tx)
+	require.NoError(t, err)
+
 	mempool.NextTx()
 	mempool.DiscardCurrentTx(txID)
 
@@ -184,7 +187,9 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	// Conflicting tx must be submitted over the API to be included in push gossip.
 	// (i.e., txs received via p2p are not included in push gossip)
 	// This test adds it directly to the mempool + gossiper to simulate that.
-	vm.mempool.AddRemoteTx(conflictingTx)
+	err = vm.mempool.AddRemoteTx(conflictingTx)
+	require.NoError(t, err)
+
 	vm.atomicTxPushGossiper.Add(&atomic.GossipAtomicTx{Tx: conflictingTx})
 	time.Sleep(500 * time.Millisecond)
 

--- a/plugin/evm/prestate_tracer_test.go
+++ b/plugin/evm/prestate_tracer_test.go
@@ -37,7 +37,6 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(t *testing.T) {
 			t.Parallel()
 

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -51,9 +52,7 @@ func TestCalculateDynamicFee(t *testing.T) {
 				t.Fatalf("Expected value: %d, found: %d", test.expectedValue, cost)
 			}
 		} else {
-			if err != test.expectedErr {
-				t.Fatalf("Expected error: %s, found error: %s", test.expectedErr, err)
-			}
+			assert.ErrorIs(t, err, test.expectedErr)
 		}
 	}
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1523,7 +1523,7 @@ func (vm *VM) CreateStaticHandlers(context.Context) (map[string]http.Handler, er
 func (vm *VM) getAtomicTx(txID ids.ID) (*atomic.Tx, atomic.Status, uint64, error) {
 	if tx, height, err := vm.atomicTxRepository.GetByTxID(txID); err == nil {
 		return tx, atomic.Accepted, height, nil
-	} else if err != database.ErrNotFound {
+	} else if !errors.Is(err, database.ErrNotFound) {
 		return nil, atomic.Unknown, 0, err
 	}
 	tx, dropped, found := vm.mempool.GetTx(txID)
@@ -1752,7 +1752,7 @@ func (vm *VM) readLastAccepted() (common.Hash, uint64, error) {
 	// initialize state with the genesis block.
 	lastAcceptedBytes, lastAcceptedErr := vm.acceptedBlockDB.Get(lastAcceptedKey)
 	switch {
-	case lastAcceptedErr == database.ErrNotFound:
+	case errors.Is(lastAcceptedErr, database.ErrNotFound):
 		// If there is nothing in the database, return the genesis block hash and height
 		return vm.genesisHash, 0, nil
 	case lastAcceptedErr != nil:

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -611,7 +611,10 @@ func (vm *VM) Initialize(
 
 	// Add p2p warp message warpHandler
 	warpHandler := acp118.NewCachedHandler(meteredCache, vm.warpBackend, vm.ctx.WarpSigner)
-	vm.Network.AddHandler(p2p.SignatureRequestHandlerID, warpHandler)
+	err = vm.Network.AddHandler(p2p.SignatureRequestHandlerID, warpHandler)
+	if err != nil {
+		return fmt.Errorf("adding network handler: %w", err)
+	}
 
 	vm.setAppRequestHandlers()
 
@@ -1257,7 +1260,12 @@ func (vm *VM) Shutdown(context.Context) error {
 	for _, handler := range vm.rpcHandlers {
 		handler.Stop()
 	}
-	vm.eth.Stop()
+
+	err := vm.eth.Stop()
+	if err != nil {
+		return fmt.Errorf("stopping eth: %w", err)
+	}
+
 	vm.shutdownWg.Wait()
 	return nil
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1821,9 +1821,8 @@ func TestNonCanonicalAccept(t *testing.T) {
 		t.Fatalf("Block failed verification on VM1: %s", err)
 	}
 
-	if _, err := vm1.GetBlockIDAtHeight(context.Background(), vm1BlkA.Height()); err != database.ErrNotFound {
-		t.Fatalf("Expected unaccepted block not to be indexed by height, but found %s", err)
-	}
+	_, err = vm1.GetBlockIDAtHeight(context.Background(), vm1BlkA.Height())
+	assert.ErrorIs(t, err, database.ErrNotFound, "Expected unaccepted block not to be indexed by height")
 
 	if err := vm1.SetPreference(context.Background(), vm1BlkA.ID()); err != nil {
 		t.Fatal(err)
@@ -1836,9 +1835,8 @@ func TestNonCanonicalAccept(t *testing.T) {
 	if err := vm2BlkA.Verify(context.Background()); err != nil {
 		t.Fatalf("Block failed verification on VM2: %s", err)
 	}
-	if _, err := vm2.GetBlockIDAtHeight(context.Background(), vm2BlkA.Height()); err != database.ErrNotFound {
-		t.Fatalf("Expected unaccepted block not to be indexed by height, but found %s", err)
-	}
+	_, err = vm2.GetBlockIDAtHeight(context.Background(), vm2BlkA.Height())
+	assert.ErrorIs(t, err, database.ErrNotFound, "Expected unaccepted block not to be indexed by height")
 	if err := vm2.SetPreference(context.Background(), vm2BlkA.ID()); err != nil {
 		t.Fatal(err)
 	}
@@ -1902,9 +1900,8 @@ func TestNonCanonicalAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := vm1.GetBlockIDAtHeight(context.Background(), vm1BlkB.Height()); err != database.ErrNotFound {
-		t.Fatalf("Expected unaccepted block not to be indexed by height, but found %s", err)
-	}
+	_, err = vm1.GetBlockIDAtHeight(context.Background(), vm1BlkB.Height())
+	assert.ErrorIs(t, err, database.ErrNotFound, "Expected unaccepted block not to be indexed by height")
 
 	if err := vm1.SetPreference(context.Background(), vm1BlkB.ID()); err != nil {
 		t.Fatal(err)
@@ -1940,9 +1937,8 @@ func TestNonCanonicalAccept(t *testing.T) {
 		t.Fatalf("Block failed verification on VM1: %s", err)
 	}
 
-	if _, err := vm1.GetBlockIDAtHeight(context.Background(), vm1BlkC.Height()); err != database.ErrNotFound {
-		t.Fatalf("Expected unaccepted block not to be indexed by height, but found %s", err)
-	}
+	_, err = vm1.GetBlockIDAtHeight(context.Background(), vm1BlkC.Height())
+	assert.ErrorIs(t, err, database.ErrNotFound, "Expected unaccepted block not to be indexed by height")
 
 	if err := vm1BlkC.Accept(context.Background()); err != nil {
 		t.Fatalf("VM1 failed to accept block: %s", err)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1136,7 +1136,6 @@ func TestConflictingImportTxsAcrossBlocks(t *testing.T) {
 		"apricotPhase4": genesisJSONApricotPhase4,
 		"apricotPhase5": genesisJSONApricotPhase5,
 	} {
-		genesis := genesis
 		t.Run(name, func(t *testing.T) {
 			testConflictingImportTxs(t, genesis)
 		})

--- a/plugin/main.go
+++ b/plugin/main.go
@@ -30,5 +30,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	rpcchainvm.Serve(context.Background(), &evm.VM{IsPlugin: true})
+	err = rpcchainvm.Serve(context.Background(), &evm.VM{IsPlugin: true})
+	if err != nil {
+		fmt.Printf("failed serving RPC: %s", err)
+		os.Exit(1)
+	}
+	os.Exit(0)
 }

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -723,7 +723,6 @@ func TestClientHTTP(t *testing.T) {
 	)
 	defer client.Close()
 	for i := range results {
-		i := i
 		go func() {
 			errc <- client.Call(&results[i], "test_echo", wantResult.String, wantResult.Int, wantResult.Args)
 		}()

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -145,7 +145,6 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		{"earliest", int64(EarliestBlockNumber)},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			bnh := BlockNumberOrHashWithNumber(BlockNumber(test.number))
 			marshalled, err := json.Marshal(bnh)


### PR DESCRIPTION
## Why this should be merged

Enable default linters (errcheck, staticcheck, gosimple and staticcheck were missing) + `errorlint`  for **our code only**:

- `./plugin/*.go` files
- `*libevm*.go` files
- `_ext.go` files
- More suggestions are welcome

More [linters](https://golangci-lint.run/usage/linters/) can be added subsequently, but this PR fixes already quite a few errors already coming from enabling the default linters and errorlint in **our** code

## How this works

- [x] Remove unused and unneeded configuration options
- [x] Existing geth code uses the same linters as before
- [x] No golangci-lint upgrade, wait for geth sync to upgrade the linter and get upstream lint error fixes
- [x] Our code is linted with more linters (default ones+errorlint)

## How this was tested

- [x] Linter passing locally
- [x] CI passing

## Need to be documented?

No

## Need to update RELEASES.md?

No