### PR TITLE
chore(plugin/evm): remove `core.BoundedBuffer` from `atomicTrie`

### DIFF
--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -349,14 +349,6 @@ func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (hasCommitted b
 		hasCommitted = true
 	}
 
-	// The following dereferences, if any, the previously inserted root.
-	// This one can be dereferenced whether it has been:
-	// - committed, in which case the dereference is a no-op
-	// - not committted, in which case the current root we are inserting contains
-	//   references all the relevant data from the previous root, so the previous
-	//   root can be dereferenced.
-	a.trieDB.Dereference(a.lastAcceptedRoot)
-
 	// Commit this root if we have reached the [commitInterval].
 	if height%a.commitInterval == 0 {
 		if err := a.commit(height, root); err != nil {
@@ -365,6 +357,13 @@ func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (hasCommitted b
 		hasCommitted = true
 	}
 
+	// The following dereferences, if any, the previously inserted root.
+	// This one can be dereferenced whether it has been:
+	// - committed, in which case the dereference is a no-op
+	// - not committted, in which case the current root we are inserting contains
+	//   references to all the relevant data from the previous root, so the previous
+	//   root can be dereferenced.
+	a.trieDB.Dereference(a.lastAcceptedRoot)
 	a.lastAcceptedRoot = root
 	return hasCommitted, nil
 }

--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -14,7 +14,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/avalanchego/utils/wrappers"
 
-	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/rawdb"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
@@ -33,8 +32,7 @@ const (
 	atomicKeyLength            = wrappers.LongLen + common.HashLength
 	sharedMemoryApplyBatchSize = 10_000 // specifies the number of atomic operations to batch progress updates
 
-	atomicTrieTipBufferSize = 1 // No need to support a buffer of previously accepted tries for the atomic trie
-	atomicTrieMemoryCap     = 64 * units.MiB
+	atomicTrieMemoryCap = 64 * units.MiB
 )
 
 var (
@@ -126,7 +124,6 @@ type atomicTrie struct {
 	lastAcceptedRoot    common.Hash                // most recent trie root passed to accept trie or the root of the atomic trie on intialization.
 	codec               codec.Manager
 	memoryCap           common.StorageSize
-	tipBuffer           *core.BoundedBuffer[common.Hash]
 }
 
 // newAtomicTrie returns a new instance of a atomicTrie with a configurable commitHeightInterval, used in testing.
@@ -169,7 +166,6 @@ func newAtomicTrie(
 		codec:               codec,
 		lastCommittedRoot:   root,
 		lastCommittedHeight: height,
-		tipBuffer:           core.NewBoundedBuffer(atomicTrieTipBufferSize, trieDB.Dereference),
 		memoryCap:           atomicTrieMemoryCap,
 		// Initialize lastAcceptedRoot to the last committed root.
 		// If there were further blocks processed (ahead of the commit interval),
@@ -359,7 +355,7 @@ func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (hasCommitted b
 	// - not committted, in which case the current root we are inserting contains
 	//   references all the relevant data from the previous root, so the previous
 	//   root can be dereferenced.
-	a.tipBuffer.Insert(root)
+	a.trieDB.Dereference(a.lastAcceptedRoot)
 
 	// Commit this root if we have reached the [commitInterval].
 	if height%a.commitInterval == 0 {

--- a/plugin/evm/atomic_trie.go
+++ b/plugin/evm/atomic_trie.go
@@ -339,7 +339,8 @@ func (a *atomicTrie) InsertTrie(nodes *trienode.NodeSet, root common.Hash) error
 
 // AcceptTrie commits the triedb at [root] if needed and returns true if a commit
 // was performed.
-func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (hasCommitted bool, err error) {
+func (a *atomicTrie) AcceptTrie(height uint64, root common.Hash) (bool, error) {
+	hasCommitted := false
 	// Because we do not accept the trie at every height, we may need to
 	// populate roots at prior commit heights that were skipped.
 	for nextCommitHeight := a.lastCommittedHeight + a.commitInterval; nextCommitHeight < height; nextCommitHeight += a.commitInterval {

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -610,7 +610,6 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 		height                  uint64
 		root                    common.Hash
 		wantHasCommitted        bool
-		wantErr                 string
 		wantLastCommittedHeight uint64
 		wantLastCommittedRoot   common.Hash
 		wantLastAcceptedRoot    common.Hash
@@ -753,11 +752,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			atomicTrie.updateLastCommitted(testCase.lastCommittedRoot, testCase.lastCommittedHeight)
 
 			hasCommitted, err := atomicTrie.AcceptTrie(testCase.height, testCase.root)
-			if testCase.wantErr == "" {
-				require.NoError(t, err)
-			} else {
-				assert.EqualError(t, err, testCase.wantErr)
-			}
+			require.NoError(t, err)
 
 			assert.Equal(t, testCase.wantHasCommitted, hasCommitted)
 			assert.Equal(t, testCase.wantLastCommittedHeight, atomicTrie.lastCommittedHeight)

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -773,6 +773,9 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			for it.Next() {
 				keyValuePairs[hex.EncodeToString(it.Key())] = hex.EncodeToString(it.Value())
 			}
+			err = it.Error()
+			assert.NoError(t, err)
+			it.Release()
 			assert.Equal(t, testCase.wantKeyValuePairs, keyValuePairs)
 		})
 	}

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -719,6 +719,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 	}
 
 	for name, testCase := range testCases {
+		testCase := testCase // capture range variable for running tests with Go < 1.22
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -597,7 +597,7 @@ func TestApplyToSharedMemory(t *testing.T) {
 	}
 }
 
-func Test_atomicTrie_AcceptTrie(t *testing.T) {
+func TestAtomicTrie_AcceptTrie(t *testing.T) {
 	t.Parallel()
 
 	metadataHexPrefix := hex.EncodeToString(prefixdb.MakePrefix(atomicTrieMetaDBPrefix))

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -600,8 +600,6 @@ func TestApplyToSharedMemory(t *testing.T) {
 func TestAtomicTrie_AcceptTrie(t *testing.T) {
 	t.Parallel()
 
-	metadataHexPrefix := hex.EncodeToString(prefixdb.MakePrefix(atomicTrieMetaDBPrefix))
-
 	testCases := map[string]struct {
 		lastAcceptedRoot        common.Hash
 		lastCommittedRoot       common.Hash
@@ -614,7 +612,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 		wantLastCommittedRoot   common.Hash
 		wantLastAcceptedRoot    common.Hash
 		wantTipBufferRoot       common.Hash
-		wantKeyValuePairs       map[string]string
+		wantMetadataDBKVs       map[string]string
 	}{
 		"no_committing": {
 			lastAcceptedRoot:        types.EmptyRootHash,
@@ -627,10 +625,9 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantLastCommittedRoot:   common.Hash{2},
 			wantLastAcceptedRoot:    common.Hash{3},
 			wantTipBufferRoot:       common.Hash{3},
-			wantKeyValuePairs: map[string]string{
-				metadataHexPrefix + "0000000000000064":// height 100
-				hex.EncodeToString(common.Hash{2}.Bytes()),
-				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "0000000000000064", // height 100
+			wantMetadataDBKVs: map[string]string{
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
+				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
 			},
 		},
 		"no_committing_with_previous_root": {
@@ -644,10 +641,9 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantLastCommittedRoot:   common.Hash{2},
 			wantLastAcceptedRoot:    common.Hash{3},
 			wantTipBufferRoot:       common.Hash{3},
-			wantKeyValuePairs: map[string]string{
-				metadataHexPrefix + "0000000000000064":// height 100
-				hex.EncodeToString(common.Hash{2}.Bytes()),
-				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "0000000000000064", // height 100
+			wantMetadataDBKVs: map[string]string{
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
+				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
 			},
 		},
 		"commit_all_up_to_height_without_height": {
@@ -662,18 +658,13 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantLastCommittedRoot:   types.EmptyRootHash,
 			wantLastAcceptedRoot:    common.Hash{3},
 			wantTipBufferRoot:       common.Hash{3},
-			wantKeyValuePairs: map[string]string{
-				metadataHexPrefix + "000000000000003c":// height 60
-				hex.EncodeToString(common.Hash{2}.Bytes()),
-				metadataHexPrefix + "0000000000000046":// height 70
-				hex.EncodeToString(types.EmptyRootHash[:]),
-				metadataHexPrefix + "0000000000000050":// height 80
-				hex.EncodeToString(types.EmptyRootHash[:]),
-				metadataHexPrefix + "000000000000005a":// height 90
-				hex.EncodeToString(types.EmptyRootHash[:]),
-				metadataHexPrefix + "0000000000000064":// height 100
-				hex.EncodeToString(types.EmptyRootHash[:]),
-				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "0000000000000064", // height 100
+			wantMetadataDBKVs: map[string]string{
+				"000000000000003c":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 60
+				"0000000000000046":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 70
+				"0000000000000050":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 80
+				"000000000000005a":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 90
+				"0000000000000064":                   hex.EncodeToString(types.EmptyRootHash[:]), // height 100
+				hex.EncodeToString(lastCommittedKey): "0000000000000064",                         // height 100
 			},
 		},
 		"commit_root": {
@@ -688,12 +679,10 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantLastCommittedRoot:   common.Hash{3},
 			wantLastAcceptedRoot:    common.Hash{3},
 			wantTipBufferRoot:       common.Hash{3},
-			wantKeyValuePairs: map[string]string{
-				metadataHexPrefix + "0000000000000064":// height 100
-				hex.EncodeToString(common.Hash{2}.Bytes()),
-				metadataHexPrefix + "000000000000006e":// height 110
-				hex.EncodeToString(common.Hash{3}.Bytes()),
-				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "000000000000006e", // height 110
+			wantMetadataDBKVs: map[string]string{
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
+				"000000000000006e":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 110
+				hex.EncodeToString(lastCommittedKey): "000000000000006e",                         // height 110
 			},
 		},
 		"commit_root_with_previous_root": {
@@ -708,12 +697,10 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantLastCommittedRoot:   common.Hash{3},
 			wantLastAcceptedRoot:    common.Hash{3},
 			wantTipBufferRoot:       common.Hash{3},
-			wantKeyValuePairs: map[string]string{
-				metadataHexPrefix + "0000000000000064":// height 100
-				hex.EncodeToString(common.Hash{2}.Bytes()),
-				metadataHexPrefix + "000000000000006e":// height 110
-				hex.EncodeToString(common.Hash{3}.Bytes()),
-				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "000000000000006e", // height 110
+			wantMetadataDBKVs: map[string]string{
+				"0000000000000064":                   hex.EncodeToString(common.Hash{2}.Bytes()), // height 100
+				"000000000000006e":                   hex.EncodeToString(common.Hash{3}.Bytes()), // height 110
+				hex.EncodeToString(lastCommittedKey): "000000000000006e",                         // height 110
 			},
 		},
 	}
@@ -764,15 +751,15 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			_, storageSize, _ := atomicTrie.trieDB.Size()
 			assert.Zerof(t, storageSize, "storage size should be zero after accepting the trie due to the dirty nodes derefencing but is %s", storageSize)
 
-			keyValuePairs := make(map[string]string, len(testCase.wantKeyValuePairs))
-			it := versionDB.NewIterator()
+			keyValuePairs := make(map[string]string, len(testCase.wantMetadataDBKVs))
+			it := metadataDB.NewIterator()
 			for it.Next() {
 				keyValuePairs[hex.EncodeToString(it.Key())] = hex.EncodeToString(it.Value())
 			}
 			err = it.Error()
 			assert.NoError(t, err)
 			it.Release()
-			assert.Equal(t, testCase.wantKeyValuePairs, keyValuePairs)
+			assert.Equal(t, testCase.wantMetadataDBKVs, keyValuePairs)
 		})
 	}
 }

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -630,7 +630,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantTipBufferRoot:       common.Hash{3},
 			wantKeyValuePairs: map[string]string{
 				metadataHexPrefix + "0000000000000064":// height 100
-				"0200000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{2}.Bytes()),
 				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "0000000000000064", // height 100
 			},
 		},
@@ -647,7 +647,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantTipBufferRoot:       common.Hash{3},
 			wantKeyValuePairs: map[string]string{
 				metadataHexPrefix + "0000000000000064":// height 100
-				"0200000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{2}.Bytes()),
 				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "0000000000000064", // height 100
 			},
 		},
@@ -665,7 +665,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantTipBufferRoot:       common.Hash{3},
 			wantKeyValuePairs: map[string]string{
 				metadataHexPrefix + "000000000000003c":// height 60
-				"0200000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{2}.Bytes()),
 				metadataHexPrefix + "0000000000000046":// height 70
 				hex.EncodeToString(types.EmptyRootHash[:]),
 				metadataHexPrefix + "0000000000000050":// height 80
@@ -691,9 +691,9 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantTipBufferRoot:       common.Hash{3},
 			wantKeyValuePairs: map[string]string{
 				metadataHexPrefix + "0000000000000064":// height 100
-				"0200000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{2}.Bytes()),
 				metadataHexPrefix + "000000000000006e":// height 110
-				"0300000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{3}.Bytes()),
 				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "000000000000006e", // height 110
 			},
 		},
@@ -711,9 +711,9 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			wantTipBufferRoot:       common.Hash{3},
 			wantKeyValuePairs: map[string]string{
 				metadataHexPrefix + "0000000000000064":// height 100
-				"0200000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{2}.Bytes()),
 				metadataHexPrefix + "000000000000006e":// height 110
-				"0300000000000000000000000000000000000000000000000000000000000000",
+				hex.EncodeToString(common.Hash{3}.Bytes()),
 				metadataHexPrefix + hex.EncodeToString(lastCommittedKey): "000000000000006e", // height 110
 			},
 		},
@@ -729,6 +729,7 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 			const lastAcceptedHeight = 0 // no effect
 			atomicTrie, err := newAtomicTrie(atomicTrieDB, metadataDB, atomic.TestTxCodec,
 				lastAcceptedHeight, testCase.commitInterval)
+			require.NoError(t, err)
 			atomicTrie.lastAcceptedRoot = testCase.lastAcceptedRoot
 			if testCase.lastAcceptedRoot != types.EmptyRootHash {
 				// Generate trie node test blob
@@ -750,7 +751,6 @@ func TestAtomicTrie_AcceptTrie(t *testing.T) {
 				require.NotZero(t, storageSize, "there should be a dirty node taking up storage space")
 			}
 			atomicTrie.updateLastCommitted(testCase.lastCommittedRoot, testCase.lastCommittedHeight)
-			require.NoError(t, err)
 
 			hasCommitted, err := atomicTrie.AcceptTrie(testCase.height, testCase.root)
 			if testCase.wantErr == "" {

--- a/plugin/evm/atomic_trie_test.go
+++ b/plugin/evm/atomic_trie_test.go
@@ -731,8 +731,6 @@ func Test_atomicTrie_AcceptTrie(t *testing.T) {
 				lastAcceptedHeight, testCase.commitInterval)
 			atomicTrie.lastAcceptedRoot = testCase.lastAcceptedRoot
 			if testCase.lastAcceptedRoot != types.EmptyRootHash {
-				atomicTrie.tipBuffer.Insert(testCase.lastAcceptedRoot)
-
 				// Generate trie node test blob
 				encoder := rlp.NewEncoderBuffer(nil)
 				offset := encoder.List()
@@ -765,9 +763,6 @@ func Test_atomicTrie_AcceptTrie(t *testing.T) {
 			assert.Equal(t, testCase.wantLastCommittedHeight, atomicTrie.lastCommittedHeight)
 			assert.Equal(t, testCase.wantLastCommittedRoot, atomicTrie.lastCommittedRoot)
 			assert.Equal(t, testCase.wantLastAcceptedRoot, atomicTrie.lastAcceptedRoot)
-			tipBufferRoot, ok := atomicTrie.tipBuffer.Last()
-			require.True(t, ok)
-			assert.Equal(t, testCase.wantTipBufferRoot, tipBufferRoot)
 
 			// Check dereferencing previous dirty root inserted occurred
 			_, storageSize, _ := atomicTrie.trieDB.Size()


### PR DESCRIPTION
## Why this should be merged

- Removes the atomic trie dependency on the `core` package
- Unneeded use of a 1-length bounded buffer

## How this works

1. Add (deep) unit test for `atomicTrie.AcceptTrie`
   - Tests all happy code paths
   - Tests derefencing occurs by inserting a dirty node and checking the storage size goes back to zero
2. Remove `tipBuffer` field, and use the existing `lastAcceptedRoot` field with a direct call to `a.trieDB.Dereference` on the previous root.

## How this was tested

`Test_atomicTrie_AcceptTrie` with commit 1, 2 and 3.

## Need to be documented?

No

## Need to update RELEASES.md?

No