### PR TITLE
Reduce magic numbers in dynamic fees

### DIFF
--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
 // Minimum Gas Price
@@ -32,8 +33,8 @@ const (
 	ApricotPhase5BaseFeeChangeDenominator uint64 = 36
 	EtnaMinBaseFee                        int64  = GWei
 
-	DynamicFeeExtraDataSize        = 80
-	RollupWindow            uint64 = 10
+	RollupWindow            = 10 // in seconds
+	DynamicFeeExtraDataSize = wrappers.LongLen * RollupWindow
 
 	// The base cost to charge per atomic transaction. Added in Apricot Phase 5.
 	AtomicTxBaseCost uint64 = 10_000


### PR DESCRIPTION
## Why this should be merged

1. `rollupWindow` is currently defined twice and `1 > 2` 😉.
2. The relationship between `DynamicFeeExtraDataSize` and `RollupWindow` is clarified.

## How this works

- Doesn't introduce any new dependencies on the `params` package.
- Is a pure refactor.

## How this was tested

CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.