### PR TITLE
Cleanup dynamic fee windower logic

### DIFF
--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -15,6 +15,11 @@ import (
 
 var ErrInsufficientDynamicFeeWindowLength = errors.New("insufficient length for dynamic fee window")
 
+// DynamicFeeWindow is a window of the last [params.RollupWindow] seconds of gas
+// usage.
+//
+// Index 0 is the oldest entry, and [params.RollupWindow-1] is the current
+// entry.
 type DynamicFeeWindow [params.RollupWindow]uint64
 
 func ParseDynamicFeeWindow(bytes []byte) (DynamicFeeWindow, error) {

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -1,0 +1,87 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dummy
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/utils/wrappers"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ethereum/go-ethereum/common/math"
+)
+
+var ErrInsufficientDynamicFeeWindowLength = errors.New("insufficient length for dynamic fee window")
+
+type DynamicFeeWindow [params.RollupWindow]uint64
+
+func ParseDynamicFeeWindow(bytes []byte) (DynamicFeeWindow, error) {
+	if len(bytes) < params.DynamicFeeExtraDataSize {
+		return DynamicFeeWindow{}, fmt.Errorf("%w expected at least %d, but found %d",
+			ErrInsufficientDynamicFeeWindowLength,
+			params.DynamicFeeExtraDataSize,
+			len(bytes),
+		)
+	}
+
+	var window DynamicFeeWindow
+	for i := range window {
+		offset := i * wrappers.LongLen
+		window[i] = binary.BigEndian.Uint64(bytes[offset:])
+	}
+	return window, nil
+}
+
+// Add adds the amount to the most recent entry in the window.
+//
+// If the most recent entry overflows, it is set to [math.MaxUint64].
+func (w *DynamicFeeWindow) Add(amount uint64) {
+	const lastIndex uint = params.RollupWindow - 1
+	(*w)[lastIndex] = add(w[lastIndex], amount)
+}
+
+// Shift removes the oldest amount entries from the window and adds amount new
+// empty entries.
+func (w *DynamicFeeWindow) Shift(amount uint64) {
+	if amount >= params.RollupWindow {
+		*w = DynamicFeeWindow{}
+		return
+	}
+
+	var newWindow DynamicFeeWindow
+	copy(newWindow[:], w[amount:])
+	*w = newWindow
+}
+
+// Sum returns the sum of all the entries in the window.
+//
+// If the sum overflows, [math.MaxUint64] is returned.
+func (w *DynamicFeeWindow) Sum() uint64 {
+	var sum uint64
+	for _, v := range w {
+		sum = add(sum, v)
+	}
+	return sum
+}
+
+func (w *DynamicFeeWindow) Bytes() []byte {
+	bytes := make([]byte, len(w)*wrappers.LongLen)
+	for i, v := range w {
+		offset := i * wrappers.LongLen
+		binary.BigEndian.PutUint64(bytes[offset:], v)
+	}
+	return bytes
+}
+
+func add(sum uint64, values ...uint64) uint64 {
+	var overflow bool
+	for _, v := range values {
+		sum, overflow = math.SafeAdd(sum, v)
+		if overflow {
+			return math.MaxUint64
+		}
+	}
+	return sum
+}

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -47,16 +47,16 @@ func (w *DynamicFeeWindow) Add(amounts ...uint64) {
 	w[lastIndex] = add(w[lastIndex], amounts...)
 }
 
-// Shift removes the oldest amount entries from the window and adds amount new
-// empty entries.
-func (w *DynamicFeeWindow) Shift(amount uint64) {
-	if amount >= params.RollupWindow {
+// Shift removes the oldest n entries from the window and adds n new empty
+// entries.
+func (w *DynamicFeeWindow) Shift(n uint64) {
+	if n >= params.RollupWindow {
 		*w = DynamicFeeWindow{}
 		return
 	}
 
 	var newWindow DynamicFeeWindow
-	copy(newWindow[:], w[amount:])
+	copy(newWindow[:], w[n:])
 	*w = newWindow
 }
 

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -18,7 +18,7 @@ var ErrInsufficientDynamicFeeWindowLength = errors.New("insufficient length for 
 // DynamicFeeWindow is a window of the last [params.RollupWindow] seconds of gas
 // usage.
 //
-// Index 0 is the oldest entry, and [params.RollupWindow-1] is the current
+// Index 0 is the oldest entry, and [params.RollupWindow]-1 is the current
 // entry.
 type DynamicFeeWindow [params.RollupWindow]uint64
 

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -72,7 +72,7 @@ func (w *DynamicFeeWindow) Sum() uint64 {
 }
 
 func (w *DynamicFeeWindow) Bytes() []byte {
-	bytes := make([]byte, len(w)*wrappers.LongLen)
+	bytes := make([]byte, params.DynamicFeeExtraDataSize)
 	for i, v := range w {
 		offset := i * wrappers.LongLen
 		binary.BigEndian.PutUint64(bytes[offset:], v)

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -1,4 +1,4 @@
-// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// (c) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -39,12 +39,12 @@ func ParseDynamicFeeWindow(bytes []byte) (DynamicFeeWindow, error) {
 	return window, nil
 }
 
-// Add adds the amount to the most recent entry in the window.
+// Add adds the amounts to the most recent entry in the window.
 //
 // If the most recent entry overflows, it is set to [math.MaxUint64].
-func (w *DynamicFeeWindow) Add(amount uint64) {
+func (w *DynamicFeeWindow) Add(amounts ...uint64) {
 	const lastIndex uint = params.RollupWindow - 1
-	(*w)[lastIndex] = add(w[lastIndex], amount)
+	(*w)[lastIndex] = add(w[lastIndex], amounts...)
 }
 
 // Shift removes the oldest amount entries from the window and adds amount new

--- a/consensus/dummy/dynamic_fee_window.go
+++ b/consensus/dummy/dynamic_fee_window.go
@@ -1,4 +1,4 @@
-// (c) 2019-2025, Ava Labs, Inc. All rights reserved.
+// (c) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy
@@ -13,7 +13,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/math"
 )
 
-var ErrInsufficientDynamicFeeWindowLength = errors.New("insufficient length for dynamic fee window")
+var ErrDynamicFeeWindowInsufficientLength = errors.New("insufficient length for dynamic fee window")
 
 // DynamicFeeWindow is a window of the last [params.RollupWindow] seconds of gas
 // usage.
@@ -24,8 +24,8 @@ type DynamicFeeWindow [params.RollupWindow]uint64
 
 func ParseDynamicFeeWindow(bytes []byte) (DynamicFeeWindow, error) {
 	if len(bytes) < params.DynamicFeeExtraDataSize {
-		return DynamicFeeWindow{}, fmt.Errorf("%w expected at least %d, but found %d",
-			ErrInsufficientDynamicFeeWindowLength,
+		return DynamicFeeWindow{}, fmt.Errorf("%w: expected at least %d bytes but got %d bytes",
+			ErrDynamicFeeWindowInsufficientLength,
 			params.DynamicFeeExtraDataSize,
 			len(bytes),
 		)
@@ -44,7 +44,7 @@ func ParseDynamicFeeWindow(bytes []byte) (DynamicFeeWindow, error) {
 // If the most recent entry overflows, it is set to [math.MaxUint64].
 func (w *DynamicFeeWindow) Add(amounts ...uint64) {
 	const lastIndex uint = params.RollupWindow - 1
-	(*w)[lastIndex] = add(w[lastIndex], amounts...)
+	w[lastIndex] = add(w[lastIndex], amounts...)
 }
 
 // Shift removes the oldest amount entries from the window and adds amount new
@@ -64,11 +64,7 @@ func (w *DynamicFeeWindow) Shift(amount uint64) {
 //
 // If the sum overflows, [math.MaxUint64] is returned.
 func (w *DynamicFeeWindow) Sum() uint64 {
-	var sum uint64
-	for _, v := range w {
-		sum = add(sum, v)
-	}
-	return sum
+	return add(0, w[:]...)
 }
 
 func (w *DynamicFeeWindow) Bytes() []byte {

--- a/consensus/dummy/dynamic_fee_window_test.go
+++ b/consensus/dummy/dynamic_fee_window_test.go
@@ -63,80 +63,80 @@ func TestDynamicFeeWindow_Shift(t *testing.T) {
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 	}
 	tests := []struct {
-		amount   uint64
+		n        uint64
 		expected DynamicFeeWindow
 	}{
 		{
-			amount:   0,
+			n:        0,
 			expected: window,
 		},
 		{
-			amount: 1,
+			n: 1,
 			expected: DynamicFeeWindow{
 				2, 3, 4, 5, 6, 7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 2,
+			n: 2,
 			expected: DynamicFeeWindow{
 				3, 4, 5, 6, 7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 3,
+			n: 3,
 			expected: DynamicFeeWindow{
 				4, 5, 6, 7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 4,
+			n: 4,
 			expected: DynamicFeeWindow{
 				5, 6, 7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 5,
+			n: 5,
 			expected: DynamicFeeWindow{
 				6, 7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 6,
+			n: 6,
 			expected: DynamicFeeWindow{
 				7, 8, 9, 10,
 			},
 		},
 		{
-			amount: 7,
+			n: 7,
 			expected: DynamicFeeWindow{
 				8, 9, 10,
 			},
 		},
 		{
-			amount: 8,
+			n: 8,
 			expected: DynamicFeeWindow{
 				9, 10,
 			},
 		},
 		{
-			amount: 9,
+			n: 9,
 			expected: DynamicFeeWindow{
 				10,
 			},
 		},
 		{
-			amount:   params.RollupWindow,
+			n:        10,
 			expected: DynamicFeeWindow{},
 		},
 		{
-			amount:   100,
+			n:        100,
 			expected: DynamicFeeWindow{},
 		},
 	}
 	for _, test := range tests {
-		t.Run(strconv.FormatUint(test.amount, 10), func(t *testing.T) {
+		t.Run(strconv.FormatUint(test.n, 10), func(t *testing.T) {
 			window := window
-			window.Shift(test.amount)
+			window.Shift(test.n)
 			require.Equal(t, test.expected, window)
 		})
 	}

--- a/consensus/dummy/dynamic_fee_window_test.go
+++ b/consensus/dummy/dynamic_fee_window_test.go
@@ -1,4 +1,4 @@
-// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// (c) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy

--- a/consensus/dummy/dynamic_fee_window_test.go
+++ b/consensus/dummy/dynamic_fee_window_test.go
@@ -1,4 +1,4 @@
-// (c) 2019-2025, Ava Labs, Inc. All rights reserved.
+// (c) 2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
 package dummy
@@ -20,7 +20,7 @@ func TestDynamicFeeWindow_Add(t *testing.T) {
 		expected DynamicFeeWindow
 	}{
 		{
-			name: "normal addition",
+			name: "normal_addition",
 			window: DynamicFeeWindow{
 				1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 			},
@@ -30,7 +30,7 @@ func TestDynamicFeeWindow_Add(t *testing.T) {
 			},
 		},
 		{
-			name: "amount overflow",
+			name: "amount_overflow",
 			window: DynamicFeeWindow{
 				1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 			},
@@ -40,7 +40,7 @@ func TestDynamicFeeWindow_Add(t *testing.T) {
 			},
 		},
 		{
-			name: "window overflow",
+			name: "window_overflow",
 			window: DynamicFeeWindow{
 				1, 2, 3, 4, 5, 6, 7, 8, 9, math.MaxUint64,
 			},
@@ -183,24 +183,24 @@ func TestDynamicFeeWindow_Bytes(t *testing.T) {
 		parseErr error
 	}{
 		{
-			name:     "insufficient length",
+			name:     "insufficient_length",
 			bytes:    make([]byte, params.DynamicFeeExtraDataSize-1),
-			parseErr: ErrInsufficientDynamicFeeWindowLength,
+			parseErr: ErrDynamicFeeWindowInsufficientLength,
 		},
 		{
-			name:   "zero window",
+			name:   "zero_window",
 			bytes:  make([]byte, params.DynamicFeeExtraDataSize),
 			window: DynamicFeeWindow{},
 		},
 		{
-			name: "truncate bytes",
+			name: "truncate_bytes",
 			bytes: []byte{
 				params.DynamicFeeExtraDataSize: 1,
 			},
 			window: DynamicFeeWindow{},
 		},
 		{
-			name: "non-zero",
+			name: "endianess",
 			bytes: []byte{
 				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
 				0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,

--- a/consensus/dummy/dynamic_fee_window_test.go
+++ b/consensus/dummy/dynamic_fee_window_test.go
@@ -12,76 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestDynamicFeeWindowBytes(t *testing.T) {
-	tests := []struct {
-		name     string
-		bytes    []byte
-		window   DynamicFeeWindow
-		parseErr error
-	}{
-		{
-			name:     "insufficient length",
-			bytes:    make([]byte, params.DynamicFeeExtraDataSize-1),
-			parseErr: ErrInsufficientDynamicFeeWindowLength,
-		},
-		{
-			name:   "zero window",
-			bytes:  make([]byte, params.DynamicFeeExtraDataSize),
-			window: DynamicFeeWindow{},
-		},
-		{
-			name: "truncate bytes",
-			bytes: []byte{
-				params.DynamicFeeExtraDataSize: 1,
-			},
-			window: DynamicFeeWindow{},
-		},
-		{
-			name: "non-zero",
-			bytes: []byte{
-				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
-				0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
-				0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
-				0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
-				0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
-				0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
-				0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
-				0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
-				0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
-				0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98,
-			},
-			window: DynamicFeeWindow{
-				0x0102030405060708,
-				0x1112131415161718,
-				0x2122232425262728,
-				0x3132333435363738,
-				0x4142434445464748,
-				0x5152535455565758,
-				0x6162636465666768,
-				0x7172737475767778,
-				0x8182838485868788,
-				0x9192939495969798,
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			require := require.New(t)
-
-			window, err := ParseDynamicFeeWindow(test.bytes)
-			require.Equal(test.window, window)
-			require.ErrorIs(err, test.parseErr)
-			if test.parseErr != nil {
-				return
-			}
-
-			expectedBytes := test.bytes[:params.DynamicFeeExtraDataSize]
-			bytes := window.Bytes()
-			require.Equal(expectedBytes, bytes)
-		})
-	}
-}
-
 func TestDynamicFeeWindow_Add(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -128,7 +58,7 @@ func TestDynamicFeeWindow_Add(t *testing.T) {
 	}
 }
 
-func TestShiftDynamicFeeWindow(t *testing.T) {
+func TestDynamicFeeWindow_Shift(t *testing.T) {
 	window := DynamicFeeWindow{
 		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
 	}
@@ -212,7 +142,7 @@ func TestShiftDynamicFeeWindow(t *testing.T) {
 	}
 }
 
-func TestSumDynamicFeeWindow(t *testing.T) {
+func TestDynamicFeeWindow_Sum(t *testing.T) {
 	tests := []struct {
 		name     string
 		window   DynamicFeeWindow
@@ -241,6 +171,76 @@ func TestSumDynamicFeeWindow(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			require.Equal(t, test.expected, test.window.Sum())
+		})
+	}
+}
+
+func TestDynamicFeeWindow_Bytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    []byte
+		window   DynamicFeeWindow
+		parseErr error
+	}{
+		{
+			name:     "insufficient length",
+			bytes:    make([]byte, params.DynamicFeeExtraDataSize-1),
+			parseErr: ErrInsufficientDynamicFeeWindowLength,
+		},
+		{
+			name:   "zero window",
+			bytes:  make([]byte, params.DynamicFeeExtraDataSize),
+			window: DynamicFeeWindow{},
+		},
+		{
+			name: "truncate bytes",
+			bytes: []byte{
+				params.DynamicFeeExtraDataSize: 1,
+			},
+			window: DynamicFeeWindow{},
+		},
+		{
+			name: "non-zero",
+			bytes: []byte{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+				0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+				0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+				0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+				0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+				0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+				0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+				0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
+				0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98,
+			},
+			window: DynamicFeeWindow{
+				0x0102030405060708,
+				0x1112131415161718,
+				0x2122232425262728,
+				0x3132333435363738,
+				0x4142434445464748,
+				0x5152535455565758,
+				0x6162636465666768,
+				0x7172737475767778,
+				0x8182838485868788,
+				0x9192939495969798,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			window, err := ParseDynamicFeeWindow(test.bytes)
+			require.Equal(test.window, window)
+			require.ErrorIs(err, test.parseErr)
+			if test.parseErr != nil {
+				return
+			}
+
+			expectedBytes := test.bytes[:params.DynamicFeeExtraDataSize]
+			bytes := window.Bytes()
+			require.Equal(expectedBytes, bytes)
 		})
 	}
 }

--- a/consensus/dummy/dynamic_fee_window_test.go
+++ b/consensus/dummy/dynamic_fee_window_test.go
@@ -1,0 +1,246 @@
+// (c) 2019-2020, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package dummy
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/ava-labs/coreth/params"
+	"github.com/ethereum/go-ethereum/common/math"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDynamicFeeWindowBytes(t *testing.T) {
+	tests := []struct {
+		name     string
+		bytes    []byte
+		window   DynamicFeeWindow
+		parseErr error
+	}{
+		{
+			name:     "insufficient length",
+			bytes:    make([]byte, params.DynamicFeeExtraDataSize-1),
+			parseErr: ErrInsufficientDynamicFeeWindowLength,
+		},
+		{
+			name:   "zero window",
+			bytes:  make([]byte, params.DynamicFeeExtraDataSize),
+			window: DynamicFeeWindow{},
+		},
+		{
+			name: "truncate bytes",
+			bytes: []byte{
+				params.DynamicFeeExtraDataSize: 1,
+			},
+			window: DynamicFeeWindow{},
+		},
+		{
+			name: "non-zero",
+			bytes: []byte{
+				0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+				0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+				0x21, 0x22, 0x23, 0x24, 0x25, 0x26, 0x27, 0x28,
+				0x31, 0x32, 0x33, 0x34, 0x35, 0x36, 0x37, 0x38,
+				0x41, 0x42, 0x43, 0x44, 0x45, 0x46, 0x47, 0x48,
+				0x51, 0x52, 0x53, 0x54, 0x55, 0x56, 0x57, 0x58,
+				0x61, 0x62, 0x63, 0x64, 0x65, 0x66, 0x67, 0x68,
+				0x71, 0x72, 0x73, 0x74, 0x75, 0x76, 0x77, 0x78,
+				0x81, 0x82, 0x83, 0x84, 0x85, 0x86, 0x87, 0x88,
+				0x91, 0x92, 0x93, 0x94, 0x95, 0x96, 0x97, 0x98,
+			},
+			window: DynamicFeeWindow{
+				0x0102030405060708,
+				0x1112131415161718,
+				0x2122232425262728,
+				0x3132333435363738,
+				0x4142434445464748,
+				0x5152535455565758,
+				0x6162636465666768,
+				0x7172737475767778,
+				0x8182838485868788,
+				0x9192939495969798,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			window, err := ParseDynamicFeeWindow(test.bytes)
+			require.Equal(test.window, window)
+			require.ErrorIs(err, test.parseErr)
+			if test.parseErr != nil {
+				return
+			}
+
+			expectedBytes := test.bytes[:params.DynamicFeeExtraDataSize]
+			bytes := window.Bytes()
+			require.Equal(expectedBytes, bytes)
+		})
+	}
+}
+
+func TestDynamicFeeWindow_Add(t *testing.T) {
+	tests := []struct {
+		name     string
+		window   DynamicFeeWindow
+		amount   uint64
+		expected DynamicFeeWindow
+	}{
+		{
+			name: "normal addition",
+			window: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			},
+			amount: 5,
+			expected: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 15,
+			},
+		},
+		{
+			name: "amount overflow",
+			window: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			},
+			amount: math.MaxUint64,
+			expected: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, math.MaxUint64,
+			},
+		},
+		{
+			name: "window overflow",
+			window: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, math.MaxUint64,
+			},
+			amount: 5,
+			expected: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, math.MaxUint64,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			test.window.Add(test.amount)
+			require.Equal(t, test.expected, test.window)
+		})
+	}
+}
+
+func TestShiftDynamicFeeWindow(t *testing.T) {
+	window := DynamicFeeWindow{
+		1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+	}
+	tests := []struct {
+		amount   uint64
+		expected DynamicFeeWindow
+	}{
+		{
+			amount:   0,
+			expected: window,
+		},
+		{
+			amount: 1,
+			expected: DynamicFeeWindow{
+				2, 3, 4, 5, 6, 7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 2,
+			expected: DynamicFeeWindow{
+				3, 4, 5, 6, 7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 3,
+			expected: DynamicFeeWindow{
+				4, 5, 6, 7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 4,
+			expected: DynamicFeeWindow{
+				5, 6, 7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 5,
+			expected: DynamicFeeWindow{
+				6, 7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 6,
+			expected: DynamicFeeWindow{
+				7, 8, 9, 10,
+			},
+		},
+		{
+			amount: 7,
+			expected: DynamicFeeWindow{
+				8, 9, 10,
+			},
+		},
+		{
+			amount: 8,
+			expected: DynamicFeeWindow{
+				9, 10,
+			},
+		},
+		{
+			amount: 9,
+			expected: DynamicFeeWindow{
+				10,
+			},
+		},
+		{
+			amount:   params.RollupWindow,
+			expected: DynamicFeeWindow{},
+		},
+		{
+			amount:   100,
+			expected: DynamicFeeWindow{},
+		},
+	}
+	for _, test := range tests {
+		t.Run(strconv.FormatUint(test.amount, 10), func(t *testing.T) {
+			window := window
+			window.Shift(test.amount)
+			require.Equal(t, test.expected, window)
+		})
+	}
+}
+
+func TestSumDynamicFeeWindow(t *testing.T) {
+	tests := []struct {
+		name     string
+		window   DynamicFeeWindow
+		expected uint64
+	}{
+		{
+			name:     "empty",
+			window:   DynamicFeeWindow{},
+			expected: 0,
+		},
+		{
+			name: "full",
+			window: DynamicFeeWindow{
+				1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			},
+			expected: 55,
+		},
+		{
+			name: "overflow",
+			window: DynamicFeeWindow{
+				math.MaxUint64, 2, 3, 4, 5, 6, 7, 8, 9, 10,
+			},
+			expected: math.MaxUint64,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require.Equal(t, test.expected, test.window.Sum())
+		})
+	}
+}

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -56,7 +56,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 		return nil, nil, err
 	}
 
-	// If AP5, use a less responsive [BaseFeeChangeDenominator] and a higher gas
+	// If AP5, use a less responsive BaseFeeChangeDenominator and a higher gas
 	// block limit
 	var (
 		baseFee                  = new(big.Int).Set(parent.BaseFee)
@@ -73,16 +73,16 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	var blockGasCost, parentExtraStateGasUsed uint64
 	switch {
 	case isApricotPhase5:
-		// [blockGasCost] has been removed in AP5, so it is left as 0.
+		// blockGasCost has been removed in AP5, so it is left as 0.
 
 		// At the start of a new network, the parent
-		// may not have a populated [ExtDataGasUsed].
+		// may not have a populated ExtDataGasUsed.
 		if parent.ExtDataGasUsed != nil {
 			parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
 		}
 	case isApricotPhase4:
-		// The [blockGasCost] is paid by the effective tips in the block using
-		// the block's value of [baseFee].
+		// The blockGasCost is paid by the effective tips in the block using
+		// the block's value of baseFee.
 		blockGasCost = calcBlockGasCost(
 			ApricotPhase4TargetBlockRate,
 			ApricotPhase4MinBlockGasCost,
@@ -92,8 +92,8 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 			parent.Time, timestamp,
 		).Uint64()
 
-		// On the boundary of AP3 and AP4 or at the start of a new network, the parent
-		// may not have a populated [ExtDataGasUsed].
+		// On the boundary of AP3 and AP4 or at the start of a new network, the
+		// parent may not have a populated ExtDataGasUsed.
 		if parent.ExtDataGasUsed != nil {
 			parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
 		}
@@ -105,7 +105,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	dynamicFeeWindow.Add(parent.GasUsed, parentExtraStateGasUsed, blockGasCost)
 
 	if timestamp < parent.Time {
-		return nil, nil, fmt.Errorf("cannot calculate base fee for timestamp (%d) prior to parent timestamp (%d)", timestamp, parent.Time)
+		return nil, nil, fmt.Errorf("cannot calculate base fee for timestamp %d prior to parent timestamp %d", timestamp, parent.Time)
 	}
 	roll := timestamp - parent.Time
 

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -102,8 +102,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	}
 
 	// Compute the new state of the gas rolling window.
-	addedGas := add(parent.GasUsed, parentExtraStateGasUsed, blockGasCost)
-	dynamicFeeWindow.Add(addedGas)
+	dynamicFeeWindow.Add(parent.GasUsed, parentExtraStateGasUsed, blockGasCost)
 
 	if timestamp < parent.Time {
 		return nil, nil, fmt.Errorf("cannot calculate base fee for timestamp (%d) prior to parent timestamp (%d)", timestamp, parent.Time)

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -4,11 +4,9 @@
 package dummy
 
 import (
-	"encoding/binary"
 	"fmt"
 	"math/big"
 
-	"github.com/ava-labs/avalanchego/utils/wrappers"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ethereum/go-ethereum/common"
@@ -48,24 +46,12 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 		isEtna          = config.IsEtna(parent.Time)
 	)
 	if !isApricotPhase3 || parent.Number.Cmp(common.Big0) == 0 {
-		initialSlice := make([]byte, params.DynamicFeeExtraDataSize)
+		initialSlice := (&DynamicFeeWindow{}).Bytes()
 		initialBaseFee := big.NewInt(params.ApricotPhase3InitialBaseFee)
 		return initialSlice, initialBaseFee, nil
 	}
 
-	if uint64(len(parent.Extra)) < params.DynamicFeeExtraDataSize {
-		return nil, nil, fmt.Errorf("expected length of parent extra data to be %d, but found %d", params.DynamicFeeExtraDataSize, len(parent.Extra))
-	}
-	dynamicFeeWindow := parent.Extra[:params.DynamicFeeExtraDataSize]
-
-	if timestamp < parent.Time {
-		return nil, nil, fmt.Errorf("cannot calculate base fee for timestamp (%d) prior to parent timestamp (%d)", timestamp, parent.Time)
-	}
-	roll := timestamp - parent.Time
-
-	// roll the window over by the difference between the timestamps to generate
-	// the new rollup window.
-	newRollupWindow, err := rollLongWindow(dynamicFeeWindow, int(roll))
+	dynamicFeeWindow, err := ParseDynamicFeeWindow(parent.Extra)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -83,65 +69,56 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	}
 	parentGasTargetBig := new(big.Int).SetUint64(parentGasTarget)
 
-	// Add in the gas used by the parent block in the correct place
-	// If the parent consumed gas within the rollup window, add the consumed
-	// gas in.
-	if roll < params.RollupWindow {
-		var blockGasCost, parentExtraStateGasUsed uint64
-		switch {
-		case isApricotPhase5:
-			// [blockGasCost] has been removed in AP5, so it is left as 0.
+	// Add in parent's consumed gas
+	var blockGasCost, parentExtraStateGasUsed uint64
+	switch {
+	case isApricotPhase5:
+		// [blockGasCost] has been removed in AP5, so it is left as 0.
 
-			// At the start of a new network, the parent
-			// may not have a populated [ExtDataGasUsed].
-			if parent.ExtDataGasUsed != nil {
-				parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
-			}
-		case isApricotPhase4:
-			// The [blockGasCost] is paid by the effective tips in the block using
-			// the block's value of [baseFee].
-			blockGasCost = calcBlockGasCost(
-				ApricotPhase4TargetBlockRate,
-				ApricotPhase4MinBlockGasCost,
-				ApricotPhase4MaxBlockGasCost,
-				ApricotPhase4BlockGasCostStep,
-				parent.BlockGasCost,
-				parent.Time, timestamp,
-			).Uint64()
-
-			// On the boundary of AP3 and AP4 or at the start of a new network, the parent
-			// may not have a populated [ExtDataGasUsed].
-			if parent.ExtDataGasUsed != nil {
-				parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
-			}
-		default:
-			blockGasCost = ApricotPhase3BlockGasFee
+		// At the start of a new network, the parent
+		// may not have a populated [ExtDataGasUsed].
+		if parent.ExtDataGasUsed != nil {
+			parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
 		}
+	case isApricotPhase4:
+		// The [blockGasCost] is paid by the effective tips in the block using
+		// the block's value of [baseFee].
+		blockGasCost = calcBlockGasCost(
+			ApricotPhase4TargetBlockRate,
+			ApricotPhase4MinBlockGasCost,
+			ApricotPhase4MaxBlockGasCost,
+			ApricotPhase4BlockGasCostStep,
+			parent.BlockGasCost,
+			parent.Time, timestamp,
+		).Uint64()
 
-		// Compute the new state of the gas rolling window.
-		addedGas, overflow := math.SafeAdd(parent.GasUsed, parentExtraStateGasUsed)
-		if overflow {
-			addedGas = math.MaxUint64
+		// On the boundary of AP3 and AP4 or at the start of a new network, the parent
+		// may not have a populated [ExtDataGasUsed].
+		if parent.ExtDataGasUsed != nil {
+			parentExtraStateGasUsed = parent.ExtDataGasUsed.Uint64()
 		}
-
-		// Only add the [blockGasCost] to the gas used if it isn't AP5
-		if !isApricotPhase5 {
-			addedGas, overflow = math.SafeAdd(addedGas, blockGasCost)
-			if overflow {
-				addedGas = math.MaxUint64
-			}
-		}
-
-		slot := params.RollupWindow - 1 - roll
-		start := slot * wrappers.LongLen
-		updateLongWindow(newRollupWindow, start, addedGas)
+	default:
+		blockGasCost = ApricotPhase3BlockGasFee
 	}
 
-	// Calculate the amount of gas consumed within the rollup window.
-	totalGas := sumLongWindow(newRollupWindow, params.RollupWindow)
+	// Compute the new state of the gas rolling window.
+	addedGas := add(parent.GasUsed, parentExtraStateGasUsed, blockGasCost)
+	dynamicFeeWindow.Add(addedGas)
 
+	if timestamp < parent.Time {
+		return nil, nil, fmt.Errorf("cannot calculate base fee for timestamp (%d) prior to parent timestamp (%d)", timestamp, parent.Time)
+	}
+	roll := timestamp - parent.Time
+
+	// roll the window over by the difference between the timestamps to generate
+	// the new rollup window.
+	dynamicFeeWindow.Shift(roll)
+	dynamicFeeWindowBytes := dynamicFeeWindow.Bytes()
+
+	// Calculate the amount of gas consumed within the rollup window.
+	totalGas := dynamicFeeWindow.Sum()
 	if totalGas == parentGasTarget {
-		return newRollupWindow, baseFee, nil
+		return dynamicFeeWindowBytes, baseFee, nil
 	}
 
 	num := new(big.Int)
@@ -185,7 +162,7 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 		baseFee = selectBigWithinBounds(ApricotPhase3MinBaseFee, baseFee, ApricotPhase3MaxBaseFee)
 	}
 
-	return newRollupWindow, baseFee, nil
+	return dynamicFeeWindowBytes, baseFee, nil
 }
 
 // EstimateNextBaseFee attempts to estimate the next base fee based on a block with [parent] being built at
@@ -212,76 +189,6 @@ func selectBigWithinBounds(lowerBound, value, upperBound *big.Int) *big.Int {
 	default:
 		return value
 	}
-}
-
-// rollWindow rolls the longs within [consumptionWindow] over by [roll] places.
-// For example, if there are 4 longs encoded in a 32 byte slice, rollWindow would
-// have the following effect:
-// Original:
-// [1, 2, 3, 4]
-// Roll = 0
-// [1, 2, 3, 4]
-// Roll = 1
-// [2, 3, 4, 0]
-// Roll = 2
-// [3, 4, 0, 0]
-// Roll = 3
-// [4, 0, 0, 0]
-// Roll >= 4
-// [0, 0, 0, 0]
-// Assumes that [roll] is greater than or equal to 0
-func rollWindow(consumptionWindow []byte, size, roll int) ([]byte, error) {
-	if len(consumptionWindow)%size != 0 {
-		return nil, fmt.Errorf("expected consumption window length (%d) to be a multiple of size (%d)", len(consumptionWindow), size)
-	}
-
-	// Note: make allocates a zeroed array, so we are guaranteed
-	// that what we do not copy into, will be set to 0
-	res := make([]byte, len(consumptionWindow))
-	bound := roll * size
-	if bound > len(consumptionWindow) {
-		return res, nil
-	}
-	copy(res[:], consumptionWindow[roll*size:])
-	return res, nil
-}
-
-func rollLongWindow(consumptionWindow []byte, roll int) ([]byte, error) {
-	// Passes in [wrappers.LongLen] as the size of the individual value to be rolled over
-	// so that it can be used to roll an array of long values.
-	return rollWindow(consumptionWindow, wrappers.LongLen, roll)
-}
-
-// sumLongWindow sums [numLongs] encoded in [window]. Assumes that the length of [window]
-// is sufficient to contain [numLongs] or else this function panics.
-// If an overflow occurs, while summing the contents, the maximum uint64 value is returned.
-func sumLongWindow(window []byte, numLongs int) uint64 {
-	var (
-		sum      uint64 = 0
-		overflow bool
-	)
-	for i := 0; i < numLongs; i++ {
-		// If an overflow occurs while summing the elements of the window, return the maximum
-		// uint64 value immediately.
-		sum, overflow = math.SafeAdd(sum, binary.BigEndian.Uint64(window[wrappers.LongLen*i:]))
-		if overflow {
-			return math.MaxUint64
-		}
-	}
-	return sum
-}
-
-// updateLongWindow adds [gasConsumed] in at index within [window].
-// Assumes that [index] has already been validated.
-// If an overflow occurs, the maximum uint64 value is used.
-func updateLongWindow(window []byte, start uint64, gasConsumed uint64) {
-	prevGasConsumed := binary.BigEndian.Uint64(window[start:])
-
-	totalGasConsumed, overflow := math.SafeAdd(prevGasConsumed, gasConsumed)
-	if overflow {
-		totalGasConsumed = math.MaxUint64
-	}
-	binary.BigEndian.PutUint64(window[start:], totalGasConsumed)
 }
 
 // calcBlockGasCost calculates the required block gas cost. If [parentTime]

--- a/consensus/dummy/dynamic_fees_test.go
+++ b/consensus/dummy/dynamic_fees_test.go
@@ -4,7 +4,6 @@
 package dummy
 
 import (
-	"encoding/binary"
 	"math/big"
 	"testing"
 
@@ -16,83 +15,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func testRollup(t *testing.T, longs []uint64, roll int) {
-	slice := make([]byte, len(longs)*8)
-	numLongs := len(longs)
-	for i := 0; i < numLongs; i++ {
-		binary.BigEndian.PutUint64(slice[8*i:], longs[i])
-	}
-
-	newSlice, err := rollLongWindow(slice, roll)
-	if err != nil {
-		t.Fatal(err)
-	}
-	// numCopies is the number of longs that should have been copied over from the previous
-	// slice as opposed to being left empty.
-	numCopies := numLongs - roll
-	for i := 0; i < numLongs; i++ {
-		// Extract the long value that is encoded at position [i] in [newSlice]
-		num := binary.BigEndian.Uint64(newSlice[8*i:])
-		// If the current index is past the point where we should have copied the value
-		// over from the previous slice, assert that the value encoded in [newSlice]
-		// is 0
-		if i >= numCopies {
-			if num != 0 {
-				t.Errorf("Expected num encoded in newSlice at position %d to be 0, but found %d", i, num)
-			}
-		} else {
-			// Otherwise, check that the value was copied over correctly
-			prevIndex := i + roll
-			prevNum := longs[prevIndex]
-			if prevNum != num {
-				t.Errorf("Expected num encoded in new slice at position %d to be %d, but found %d", i, prevNum, num)
-			}
-		}
-	}
-}
-
-func TestRollupWindow(t *testing.T) {
-	type test struct {
-		longs []uint64
-		roll  int
-	}
-
-	var tests []test = []test{
-		{
-			[]uint64{1, 2, 3, 4},
-			0,
-		},
-		{
-			[]uint64{1, 2, 3, 4},
-			1,
-		},
-		{
-			[]uint64{1, 2, 3, 4},
-			2,
-		},
-		{
-			[]uint64{1, 2, 3, 4},
-			3,
-		},
-		{
-			[]uint64{1, 2, 3, 4},
-			4,
-		},
-		{
-			[]uint64{1, 2, 3, 4},
-			5,
-		},
-		{
-			[]uint64{121, 232, 432},
-			2,
-		},
-	}
-
-	for _, test := range tests {
-		testRollup(t, test.longs, test.roll)
-	}
-}
 
 type blockDefinition struct {
 	timestamp      uint64
@@ -223,53 +145,6 @@ func testDynamicFeesStaysWithinRange(t *testing.T, test test) {
 			Number:  big.NewInt(int64(index) + 1),
 			BaseFee: nextBaseFee,
 			Extra:   nextExtraData,
-		}
-	}
-}
-
-func TestLongWindow(t *testing.T) {
-	longs := []uint64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}
-	sumLongs := uint64(0)
-	longWindow := make([]byte, 10*8)
-	for i, long := range longs {
-		sumLongs = sumLongs + long
-		binary.BigEndian.PutUint64(longWindow[i*8:], long)
-	}
-
-	sum := sumLongWindow(longWindow, 10)
-	if sum != sumLongs {
-		t.Fatalf("Expected sum to be %d but found %d", sumLongs, sum)
-	}
-
-	for i := uint64(0); i < 10; i++ {
-		updateLongWindow(longWindow, i*8, i)
-		sum = sumLongWindow(longWindow, 10)
-		sumLongs += i
-
-		if sum != sumLongs {
-			t.Fatalf("Expected sum to be %d but found %d (iteration: %d)", sumLongs, sum, i)
-		}
-	}
-}
-
-func TestLongWindowOverflow(t *testing.T) {
-	longs := []uint64{0, 0, 0, 0, 0, 0, 0, 0, 2, math.MaxUint64 - 1}
-	longWindow := make([]byte, 10*8)
-	for i, long := range longs {
-		binary.BigEndian.PutUint64(longWindow[i*8:], long)
-	}
-
-	sum := sumLongWindow(longWindow, 10)
-	if sum != math.MaxUint64 {
-		t.Fatalf("Expected sum to be maxUint64 (%d), but found %d", uint64(math.MaxUint64), sum)
-	}
-
-	for i := uint64(0); i < 10; i++ {
-		updateLongWindow(longWindow, i*8, i)
-		sum = sumLongWindow(longWindow, 10)
-
-		if sum != math.MaxUint64 {
-			t.Fatalf("Expected sum to be maxUint64 (%d), but found %d", uint64(math.MaxUint64), sum)
 		}
 	}
 }

--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/utils/wrappers"
 )
 
 // Minimum Gas Price
@@ -32,8 +33,8 @@ const (
 	ApricotPhase5BaseFeeChangeDenominator uint64 = 36
 	EtnaMinBaseFee                        int64  = GWei
 
-	DynamicFeeExtraDataSize        = 80
-	RollupWindow            uint64 = 10
+	RollupWindow            = 10 // in seconds
+	DynamicFeeExtraDataSize = wrappers.LongLen * RollupWindow
 
 	// The base cost to charge per atomic transaction. Added in Apricot Phase 5.
 	AtomicTxBaseCost uint64 = 10_000


### PR DESCRIPTION
## Why this should be merged

The existing windowing logic is overly complex.

1. The format of the window is baked into `CalcBaseFee`.
2. The implementation supports arbitrary sized window elements even though we never use this. Specifically how we have `rollWindow` and `rollLongWindow` even though all we ever use are `uint64`s.

## How this works

Moves all the windower logic into a new type `DynamicFeeWindow`

## How this was tested

Expanded unit tests (and existing dynamic fees tests)

## Need to be documented?

no.

## Need to update RELEASES.md?

no.