### PR TITLE
Update avalanchego version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1
+	github.com/ava-labs/avalanchego v1.12.3-0.20250219170725-be165bd5e80a
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1 h1:bp+RMUpgUX2HL22FnArOMkhg9IaGjA7xHExAH3zy3Og=
-github.com/ava-labs/avalanchego v1.12.3-0.20250216200402-d76684b684f1/go.mod h1:kjz2dtxgb9UiSzCDMon8AqFpsRPb9SGGW9F6tsKwufc=
+github.com/ava-labs/avalanchego v1.12.3-0.20250219170725-be165bd5e80a h1:ZIvqIatLxwUUVahiYUtSCa/2UWHVNWb7lbKsVSRQOGI=
+github.com/ava-labs/avalanchego v1.12.3-0.20250219170725-be165bd5e80a/go.mod h1:5Xkid/6ekMkywDDStA0K0Srt0S3FK6pyOtgcmpZMXhw=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -269,13 +269,15 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 	blsSecretKey1, err := localsigner.New()
 	require.NoError(err)
 	blsPublicKey1 := blsSecretKey1.PublicKey()
-	blsSignature1 := blsSecretKey1.Sign(unsignedMessage.Bytes())
+	blsSignature1, err := blsSecretKey1.Sign(unsignedMessage.Bytes())
+	require.NoError(err)
 
 	nodeID2 := ids.GenerateTestNodeID()
 	blsSecretKey2, err := localsigner.New()
 	require.NoError(err)
 	blsPublicKey2 := blsSecretKey2.PublicKey()
-	blsSignature2 := blsSecretKey2.Sign(unsignedMessage.Bytes())
+	blsSignature2, err := blsSecretKey2.Sign(unsignedMessage.Bytes())
+	require.NoError(err)
 
 	blsAggregatedSignature, err := bls.AggregateSignatures([]*bls.Signature{blsSignature1, blsSignature2})
 	require.NoError(err)
@@ -531,11 +533,14 @@ func testReceiveWarpMessage(
 	newSigner := func(networkID ids.ID, weight uint64) signer {
 		secret, err := localsigner.New()
 		require.NoError(err)
+		sig, err := secret.Sign(unsignedMessage.Bytes())
+		require.NoError(err)
+
 		return signer{
 			networkID: networkID,
 			nodeID:    ids.GenerateTestNodeID(),
 			secret:    secret,
-			signature: secret.Sign(unsignedMessage.Bytes()),
+			signature: sig,
 			weight:    weight,
 		}
 	}

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -94,7 +94,10 @@ func init() {
 	}
 
 	for _, testVdr := range testVdrs {
-		blsSignature := testVdr.sk.Sign(unsignedMsg.Bytes())
+		blsSignature, err := testVdr.sk.Sign(unsignedMsg.Bytes())
+		if err != nil {
+			panic(err)
+		}
 		blsSignatures = append(blsSignatures, blsSignature)
 	}
 
@@ -235,13 +238,16 @@ func testWarpMessageFromPrimaryNetwork(t *testing.T, requirePrimaryNetworkSigner
 	getValidatorsOutput := make(map[ids.NodeID]*validators.GetValidatorOutput)
 	blsSignatures := make([]*bls.Signature, 0, numKeys)
 	for i := 0; i < numKeys; i++ {
+		sig, err := testVdrs[i].sk.Sign(unsignedMsg.Bytes())
+		require.NoError(err)
+
 		validatorOutput := &validators.GetValidatorOutput{
 			NodeID:    testVdrs[i].nodeID,
 			Weight:    20,
 			PublicKey: testVdrs[i].vdr.PublicKey,
 		}
 		getValidatorsOutput[testVdrs[i].nodeID] = validatorOutput
-		blsSignatures = append(blsSignatures, testVdrs[i].sk.Sign(unsignedMsg.Bytes()))
+		blsSignatures = append(blsSignatures, sig)
 	}
 	aggregateSignature, err := bls.AggregateSignatures(blsSignatures)
 	require.NoError(err)

--- a/precompile/contracts/warp/signature_verification_test.go
+++ b/precompile/contracts/warp/signature_verification_test.go
@@ -213,8 +213,10 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(1)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr0Sig := testVdrs[0].sk.Sign(unsignedBytes)
-				vdr1Sig := testVdrs[1].sk.Sign(unsignedBytes)
+				vdr0Sig, err := testVdrs[0].sk.Sign(unsignedBytes)
+				require.NoError(err)
+				vdr1Sig, err := testVdrs[1].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr0Sig, vdr1Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -285,7 +287,8 @@ func TestSignatureVerification(t *testing.T) {
 				require.NoError(err)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr0Sig := testVdrs[0].sk.Sign(unsignedBytes)
+				vdr0Sig, err := testVdrs[0].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
 				copy(aggSigBytes[:], bls.SignatureToBytes(vdr0Sig))
 
@@ -324,10 +327,12 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(1)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr0Sig := testVdrs[0].sk.Sign(unsignedBytes)
+				vdr0Sig, err := testVdrs[0].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				// Give sig from vdr[2] even though the bit vector says it
 				// should be from vdr[1]
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr0Sig, vdr2Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -368,7 +373,8 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(1)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr0Sig := testVdrs[0].sk.Sign(unsignedBytes)
+				vdr0Sig, err := testVdrs[0].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				// Don't give the sig from vdr[1]
 				aggSigBytes := [bls.SignatureLen]byte{}
 				copy(aggSigBytes[:], bls.SignatureToBytes(vdr0Sig))
@@ -408,11 +414,14 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(1)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr0Sig := testVdrs[0].sk.Sign(unsignedBytes)
-				vdr1Sig := testVdrs[1].sk.Sign(unsignedBytes)
+				vdr0Sig, err := testVdrs[0].sk.Sign(unsignedBytes)
+				require.NoError(err)
+				vdr1Sig, err := testVdrs[1].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				// Give sig from vdr[2] even though the bit vector doesn't have
 				// it
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr0Sig, vdr1Sig, vdr2Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -455,8 +464,10 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(2)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr1Sig := testVdrs[1].sk.Sign(unsignedBytes)
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr1Sig, err := testVdrs[1].sk.Sign(unsignedBytes)
+				require.NoError(err)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr1Sig, vdr2Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -499,8 +510,10 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(2)
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr1Sig := testVdrs[1].sk.Sign(unsignedBytes)
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr1Sig, err := testVdrs[1].sk.Sign(unsignedBytes)
+				require.NoError(err)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr1Sig, vdr2Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -560,8 +573,10 @@ func TestSignatureVerification(t *testing.T) {
 				signers.Add(1) // vdr[2]
 
 				unsignedBytes := unsignedMsg.Bytes()
-				vdr1Sig := testVdrs[1].sk.Sign(unsignedBytes)
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr1Sig, err := testVdrs[1].sk.Sign(unsignedBytes)
+				require.NoError(err)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSig, err := bls.AggregateSignatures([]*bls.Signature{vdr1Sig, vdr2Sig})
 				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
@@ -622,7 +637,8 @@ func TestSignatureVerification(t *testing.T) {
 
 				unsignedBytes := unsignedMsg.Bytes()
 				// Because vdr[1] and vdr[2] share a key, only one of them sign.
-				vdr2Sig := testVdrs[2].sk.Sign(unsignedBytes)
+				vdr2Sig, err := testVdrs[2].sk.Sign(unsignedBytes)
+				require.NoError(err)
 				aggSigBytes := [bls.SignatureLen]byte{}
 				copy(aggSigBytes[:], bls.SignatureToBytes(vdr2Sig))
 

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'df1bf8c8'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'be165bd5'}

--- a/warp/aggregator/aggregator_test.go
+++ b/warp/aggregator/aggregator_test.go
@@ -44,9 +44,12 @@ func TestAggregateSignatures(t *testing.T) {
 	vdr1sk, vdr1 := newValidator(t, vdrWeight)
 	vdr2sk, vdr2 := newValidator(t, vdrWeight+1)
 	vdr3sk, vdr3 := newValidator(t, vdrWeight-1)
-	sig1 := vdr1sk.Sign(unsignedMsg.Bytes())
-	sig2 := vdr2sk.Sign(unsignedMsg.Bytes())
-	sig3 := vdr3sk.Sign(unsignedMsg.Bytes())
+	sig1, err := vdr1sk.Sign(unsignedMsg.Bytes())
+	require.NoError(t, err)
+	sig2, err := vdr2sk.Sign(unsignedMsg.Bytes())
+	require.NoError(t, err)
+	sig3, err := vdr3sk.Sign(unsignedMsg.Bytes())
+	require.NoError(t, err)
 	vdrToSig := map[*avalancheWarp.Validator]*bls.Signature{
 		vdr1: sig1,
 		vdr2: sig2,
@@ -54,7 +57,8 @@ func TestAggregateSignatures(t *testing.T) {
 	}
 	nonVdrSk, err := localsigner.New()
 	require.NoError(t, err)
-	nonVdrSig := nonVdrSk.Sign(unsignedMsg.Bytes())
+	nonVdrSig, err := nonVdrSk.Sign(unsignedMsg.Bytes())
+	require.NoError(t, err)
 	vdrs := []*avalancheWarp.Validator{
 		{
 			PublicKey: vdr1.PublicKey,


### PR DESCRIPTION
Use fallible bls.Signer api

## Why this should be merged

The `bls.Signer` api is changing

## How this works

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
