### PR TITLE
chore(core): split our code from state_processor.go in state_processor_ext.go

### DIFF
--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -89,9 +89,11 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 		vmenv   = vm.NewEVM(context, vm.TxContext{}, statedb, p.config, cfg)
 		signer  = types.MakeSigner(p.config, header.Number, header.Time)
 	)
+
 	if beaconRoot := block.BeaconRoot(); beaconRoot != nil {
 		ProcessBeaconBlockRoot(*beaconRoot, vmenv, statedb)
 	}
+
 	// Iterate over and process the individual transactions
 	for i, tx := range block.Transactions() {
 		msg, err := TransactionToMessage(tx, signer, header.BaseFee)
@@ -99,6 +101,7 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
 		}
 		statedb.SetTxContext(tx.Hash(), i)
+
 		receipt, err := applyTransaction(msg, p.config, gp, statedb, blockNumber, blockHash, tx, usedGas, vmenv)
 		if err != nil {
 			return nil, nil, 0, fmt.Errorf("could not apply tx %d [%v]: %w", i, tx.Hash().Hex(), err)
@@ -106,6 +109,7 @@ func (p *StateProcessor) Process(block *types.Block, parent *types.Header, state
 		receipts = append(receipts, receipt)
 		allLogs = append(allLogs, receipt.Logs...)
 	}
+
 	// Finalize the block, applying any consensus engine specific extras (e.g. block rewards)
 	if err := p.engine.Finalize(p.bc, block, parent, statedb, receipts); err != nil {
 		return nil, nil, 0, fmt.Errorf("engine finalization check failed: %w", err)
@@ -124,7 +128,6 @@ func applyTransaction(msg *Message, config *params.ChainConfig, gp *GasPool, sta
 	if err != nil {
 		return nil, err
 	}
-
 	// Update the state with pending changes.
 	var root []byte
 	if config.IsByzantium(blockNumber) {
@@ -181,7 +184,7 @@ func ApplyTransaction(config *params.ChainConfig, bc ChainContext, blockContext 
 
 // ProcessBeaconBlockRoot applies the EIP-4788 system call to the beacon block root
 // contract. This method is exported to be used in tests.
-func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *state.StateDB) {
+func ProcessBeaconBlockRoot(beaconRoot common.Hash, evm *vm.EVM, statedb *state.StateDB) {
 	// If EIP-4788 is enabled, we need to invoke the beaconroot storage contract with
 	// the new root
 	msg := &Message{
@@ -193,8 +196,8 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *stat
 		To:        &params.BeaconRootsStorageAddress,
 		Data:      beaconRoot[:],
 	}
-	vmenv.Reset(NewEVMTxContext(msg), statedb)
+	evm.Reset(NewEVMTxContext(msg), statedb)
 	statedb.AddAddressToAccessList(params.BeaconRootsStorageAddress)
-	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
+	_, _, _ = evm.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
 }

--- a/core/state_processor.go
+++ b/core/state_processor.go
@@ -27,17 +27,13 @@
 package core
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 
 	"github.com/ava-labs/coreth/consensus"
-	"github.com/ava-labs/coreth/core/extstate"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
-	"github.com/ava-labs/coreth/precompile/contract"
-	"github.com/ava-labs/coreth/precompile/modules"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
@@ -201,65 +197,4 @@ func ProcessBeaconBlockRoot(beaconRoot common.Hash, vmenv *vm.EVM, statedb *stat
 	statedb.AddAddressToAccessList(params.BeaconRootsStorageAddress)
 	_, _, _ = vmenv.Call(vm.AccountRef(msg.From), *msg.To, msg.Data, 30_000_000, common.U2560)
 	statedb.Finalise(true)
-}
-
-// ApplyPrecompileActivations checks if any of the precompiles specified by the chain config are enabled or disabled by the block
-// transition from [parentTimestamp] to the timestamp set in [blockContext]. If this is the case, it calls [Configure]
-// to apply the necessary state transitions for the upgrade.
-// This function is called within genesis setup to configure the starting state for precompiles enabled at genesis.
-// In block processing and building, ApplyUpgrades is called instead which also applies state upgrades.
-func ApplyPrecompileActivations(c *params.ChainConfig, parentTimestamp *uint64, blockContext contract.ConfigurationBlockContext, statedb *state.StateDB) error {
-	blockTimestamp := blockContext.Timestamp()
-	// Note: RegisteredModules returns precompiles sorted by module addresses.
-	// This ensures that the order we call Configure for each precompile is consistent.
-	// This ensures even if precompiles read/write state other than their own they will observe
-	// an identical global state in a deterministic order when they are configured.
-	extra := params.GetExtra(c)
-	for _, module := range modules.RegisteredModules() {
-		for _, activatingConfig := range extra.GetActivatingPrecompileConfigs(module.Address, parentTimestamp, blockTimestamp, extra.PrecompileUpgrades) {
-			// If this transition activates the upgrade, configure the stateful precompile.
-			// (or deconfigure it if it is being disabled.)
-			if activatingConfig.IsDisabled() {
-				log.Info("Disabling precompile", "name", module.ConfigKey)
-				statedb.SelfDestruct(module.Address)
-				// Calling Finalise here effectively commits Suicide call and wipes the contract state.
-				// This enables re-configuration of the same contract state in the same block.
-				// Without an immediate Finalise call after the Suicide, a reconfigured precompiled state can be wiped out
-				// since Suicide will be committed after the reconfiguration.
-				statedb.Finalise(true)
-			} else {
-				var printIntf interface{}
-				marshalled, err := json.Marshal(activatingConfig)
-				if err == nil {
-					printIntf = string(marshalled)
-				} else {
-					printIntf = activatingConfig
-				}
-
-				log.Info("Activating new precompile", "name", module.ConfigKey, "config", printIntf)
-				// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
-				// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
-				statedb.SetNonce(module.Address, 1)
-				// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
-				// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
-				// that it does not attempt to invoke a non-existent contract.
-				statedb.SetCode(module.Address, []byte{0x1})
-				extstatedb := &extstate.StateDB{VmStateDB: statedb}
-				if err := module.Configure(params.GetExtra(c), activatingConfig, extstatedb, blockContext); err != nil {
-					return fmt.Errorf("could not configure precompile, name: %s, reason: %w", module.ConfigKey, err)
-				}
-			}
-		}
-	}
-	return nil
-}
-
-// ApplyUpgrades checks if any of the precompile or state upgrades specified by the chain config are activated by the block
-// transition from [parentTimestamp] to the timestamp set in [header]. If this is the case, it calls [Configure]
-// to apply the necessary state transitions for the upgrade.
-// This function is called:
-// - in block processing to update the state when processing a block.
-// - in the miner to apply the state upgrades when producing a block.
-func ApplyUpgrades(c *params.ChainConfig, parentTimestamp *uint64, blockContext contract.ConfigurationBlockContext, statedb *state.StateDB) error {
-	return ApplyPrecompileActivations(c, parentTimestamp, blockContext, statedb)
 }

--- a/core/state_processor_ext.go
+++ b/core/state_processor_ext.go
@@ -1,0 +1,75 @@
+// (c) 2025, Ava Labs, Inc.
+package core
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/ava-labs/coreth/core/extstate"
+	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/precompile/contract"
+	"github.com/ava-labs/coreth/precompile/modules"
+	"github.com/ava-labs/libevm/log"
+)
+
+// ApplyPrecompileActivations checks if any of the precompiles specified by the chain config are enabled or disabled by the block
+// transition from [parentTimestamp] to the timestamp set in [blockContext]. If this is the case, it calls [Configure]
+// to apply the necessary state transitions for the upgrade.
+// This function is called within genesis setup to configure the starting state for precompiles enabled at genesis.
+// In block processing and building, ApplyUpgrades is called instead which also applies state upgrades.
+func ApplyPrecompileActivations(c *params.ChainConfig, parentTimestamp *uint64, blockContext contract.ConfigurationBlockContext, statedb *state.StateDB) error {
+	blockTimestamp := blockContext.Timestamp()
+	// Note: RegisteredModules returns precompiles sorted by module addresses.
+	// This ensures that the order we call Configure for each precompile is consistent.
+	// This ensures even if precompiles read/write state other than their own they will observe
+	// an identical global state in a deterministic order when they are configured.
+	extra := params.GetExtra(c)
+	for _, module := range modules.RegisteredModules() {
+		for _, activatingConfig := range extra.GetActivatingPrecompileConfigs(module.Address, parentTimestamp, blockTimestamp, extra.PrecompileUpgrades) {
+			// If this transition activates the upgrade, configure the stateful precompile.
+			// (or deconfigure it if it is being disabled.)
+			if activatingConfig.IsDisabled() {
+				log.Info("Disabling precompile", "name", module.ConfigKey)
+				statedb.SelfDestruct(module.Address)
+				// Calling Finalise here effectively commits Suicide call and wipes the contract state.
+				// This enables re-configuration of the same contract state in the same block.
+				// Without an immediate Finalise call after the Suicide, a reconfigured precompiled state can be wiped out
+				// since Suicide will be committed after the reconfiguration.
+				statedb.Finalise(true)
+			} else {
+				var printIntf interface{}
+				marshalled, err := json.Marshal(activatingConfig)
+				if err == nil {
+					printIntf = string(marshalled)
+				} else {
+					printIntf = activatingConfig
+				}
+
+				log.Info("Activating new precompile", "name", module.ConfigKey, "config", printIntf)
+				// Set the nonce of the precompile's address (as is done when a contract is created) to ensure
+				// that it is marked as non-empty and will not be cleaned up when the statedb is finalized.
+				statedb.SetNonce(module.Address, 1)
+				// Set the code of the precompile's address to a non-zero length byte slice to ensure that the precompile
+				// can be called from within Solidity contracts. Solidity adds a check before invoking a contract to ensure
+				// that it does not attempt to invoke a non-existent contract.
+				statedb.SetCode(module.Address, []byte{0x1})
+				extstatedb := &extstate.StateDB{VmStateDB: statedb}
+				if err := module.Configure(params.GetExtra(c), activatingConfig, extstatedb, blockContext); err != nil {
+					return fmt.Errorf("could not configure precompile, name: %s, reason: %w", module.ConfigKey, err)
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// ApplyUpgrades checks if any of the precompile or state upgrades specified by the chain config are activated by the block
+// transition from [parentTimestamp] to the timestamp set in [header]. If this is the case, it calls [Configure]
+// to apply the necessary state transitions for the upgrade.
+// This function is called:
+// - in block processing to update the state when processing a block.
+// - in the miner to apply the state upgrades when producing a block.
+func ApplyUpgrades(c *params.ChainConfig, parentTimestamp *uint64, blockContext contract.ConfigurationBlockContext, statedb *state.StateDB) error {
+	return ApplyPrecompileActivations(c, parentTimestamp, blockContext, statedb)
+}


### PR DESCRIPTION
Similar to https://github.com/ava-labs/subnet-evm/pull/1442

- Move our code from state_processor.go to state_processor_ext.go
- Slight modifications to state_processor.go to make it more alike geth master