### PR TITLE
simplify: remove blockManager type

### DIFF
--- a/plugin/evm/atomic/vm/block_extension.go
+++ b/plugin/evm/atomic/vm/block_extension.go
@@ -20,7 +20,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/extension"
 )
 
-var _ extension.BlockManagerExtension = (*blockExtension)(nil)
+var _ extension.BlockExtension = (*blockExtension)(nil)
 
 var (
 	errNilExtDataGasUsedApricotPhase4 = errors.New("nil extDataGasUsed is invalid after apricotPhase4")

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -35,7 +35,7 @@ var (
 type Block struct {
 	id        ids.ID
 	ethBlock  *types.Block
-	extension extension.BlockManagerExtension
+	extension extension.BlockExtension
 	vm        *VM
 }
 

--- a/plugin/evm/extension/config.go
+++ b/plugin/evm/extension/config.go
@@ -86,9 +86,9 @@ type VMBlock interface {
 	GetEthBlock() *types.Block
 }
 
-// BlockManagerExtension is an extension for the block manager
+// BlockExtension is an extension for the block manager
 // to handle BlockManager events
-type BlockManagerExtension interface {
+type BlockExtension interface {
 	// SyntacticVerify verifies the block syntactically
 	// it can be implemented to extend inner block verification
 	SyntacticVerify(b VMBlock, rules params.Rules) error
@@ -146,10 +146,9 @@ type Config struct {
 	// SyncableParser is to parse summary messages from the network.
 	// It's required and should be non-nil
 	SyncableParser message.SyncableParser
-	// BlockManagerExtension is the extension for the block manager
-	// to handle block manager events.
+	// BlockExtension allows the VM extension to handle block processing events.
 	// It's optional and can be nil
-	BlockExtension BlockManagerExtension
+	BlockExtension BlockExtension
 	// ExtraSyncLeafHandlerConfig is the extra configuration to handle leaf requests
 	// in the network and syncer. It's optional and can be nil
 	ExtraSyncLeafHandlerConfig *LeafRequestConfig

--- a/plugin/evm/extension/config.go
+++ b/plugin/evm/extension/config.go
@@ -86,8 +86,7 @@ type VMBlock interface {
 	GetEthBlock() *types.Block
 }
 
-// BlockExtension is an extension for the block manager
-// to handle BlockManager events
+// BlockExtension allows the VM extension to handle block processing events.
 type BlockExtension interface {
 	// SyntacticVerify verifies the block syntactically
 	// it can be implemented to extend inner block verification

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -193,7 +193,6 @@ type VM struct {
 
 	// Extension Points
 	extensionConfig *extension.Config
-	blockManager    *blockManager
 
 	// pointers to eth constructs
 	eth        *eth.Ethereum
@@ -650,8 +649,7 @@ func (vm *VM) initializeStateSync(lastAcceptedHeight uint64) error {
 }
 
 func (vm *VM) initChainState(lastAcceptedBlock *types.Block) error {
-	vm.blockManager = newBlockManager(vm, vm.extensionConfig.BlockExtension)
-	block, err := vm.blockManager.newBlock(lastAcceptedBlock)
+	block, err := vm.newBlock(lastAcceptedBlock)
 	if err != nil {
 		return fmt.Errorf("failed to create block wrapper for the last accepted block: %w", err)
 	}
@@ -890,7 +888,7 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	}
 
 	// Note: the status of block is set by ChainState
-	blk, err := vm.blockManager.newBlock(block)
+	blk, err := vm.newBlock(block)
 	if err != nil {
 		log.Debug("discarding txs due to error making new block", "err", err)
 		return nil, fmt.Errorf("%w: %w", vmerrors.ErrMakeNewBlockFailed, err)
@@ -924,7 +922,7 @@ func (vm *VM) parseBlock(_ context.Context, b []byte) (snowman.Block, error) {
 	}
 
 	// Note: the status of block is set by ChainState
-	block, err := vm.blockManager.newBlock(ethBlock)
+	block, err := vm.newBlock(ethBlock)
 	if err != nil {
 		return nil, err
 	}
@@ -955,7 +953,7 @@ func (vm *VM) getBlock(_ context.Context, id ids.ID) (snowman.Block, error) {
 		return nil, avalanchedatabase.ErrNotFound
 	}
 	// Note: the status of block is set by ChainState
-	return vm.blockManager.newBlock(ethBlock)
+	return vm.newBlock(ethBlock)
 }
 
 // GetAcceptedBlock attempts to retrieve block [blkID] from the VM. This method

--- a/plugin/evm/vm_extensible.go
+++ b/plugin/evm/vm_extensible.go
@@ -50,7 +50,7 @@ func (vm *VM) LastAcceptedVMBlock() extension.VMBlock {
 }
 
 func (vm *VM) NewVMBlock(ethBlock *types.Block) (extension.VMBlock, error) {
-	blk, err := vm.blockManager.newBlock(ethBlock)
+	blk, err := vm.newBlock(ethBlock)
 	if err != nil {
 		return nil, err
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1413,7 +1413,7 @@ func TestUncleBlock(t *testing.T) {
 		blkDEthBlock.ExtData(),
 		false,
 	)
-	uncleBlock, err := vm2.blockManager.newBlock(uncleEthBlock)
+	uncleBlock, err := vm2.newBlock(uncleEthBlock)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1678,7 +1678,7 @@ func TestFutureBlock(t *testing.T) {
 		false,
 	)
 
-	futureBlock, err := vm.blockManager.newBlock(modifiedBlock)
+	futureBlock, err := vm.newBlock(modifiedBlock)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2077,7 +2077,7 @@ func TestParentBeaconRootBlock(t *testing.T) {
 			header.ParentBeaconRoot = test.beaconRoot
 			parentBeaconEthBlock := ethBlock.WithSeal(header)
 
-			parentBeaconBlock, err := vm.blockManager.newBlock(parentBeaconEthBlock)
+			parentBeaconBlock, err := vm.newBlock(parentBeaconEthBlock)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -2138,7 +2138,7 @@ func TestNoBlobsAllowed(t *testing.T) {
 	defer func() { require.NoError(vm.Shutdown(ctx)) }()
 
 	// Verification should fail
-	vmBlock, err := vm.blockManager.newBlock(blocks[0])
+	vmBlock, err := vm.newBlock(blocks[0])
 	require.NoError(err)
 	_, err = vm.ParseBlock(ctx, vmBlock.Bytes())
 	require.ErrorContains(err, "blobs not enabled on avalanche networks")


### PR DESCRIPTION
Seems we can inline the 2 fields of the blockManager to the block itself.

This is 1 less "manager" abstraction to maintain and understand. I didn't like this abstraction as I'm not sure what it represents. This link has a good writeup which I agree with https://softwareengineering.stackexchange.com/a/112444/144520

Previously the block already had access to the vm pointer, so it seems fine to add another pointer. It may be possible to simplify this a bit more (perhaps putting the responsibility of processing block hooks back on the VM or entirely wrapping the block type, which I can explore next), but I think this is a good start.

We can subsequently rename block_manager.go or re-distribute the methods of that file.