### PR TITLE
Refactor header extra verification

### DIFF
--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ava-labs/coreth/constants"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/trie"
 )
 
@@ -120,37 +121,9 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 		}
 	}
 
-	// Check that the size of the header's Extra data field is correct for [rules].
-	headerExtraDataSize := len(ethHeader.Extra)
-	switch {
-	case rules.IsDurango:
-		if headerExtraDataSize < params.DynamicFeeExtraDataSize {
-			return fmt.Errorf(
-				"expected header ExtraData to be len >= %d but got %d",
-				params.DynamicFeeExtraDataSize, len(ethHeader.Extra),
-			)
-		}
-	case rules.IsApricotPhase3:
-		if headerExtraDataSize != params.DynamicFeeExtraDataSize {
-			return fmt.Errorf(
-				"expected header ExtraData to be len %d but got %d",
-				params.DynamicFeeExtraDataSize, headerExtraDataSize,
-			)
-		}
-	case rules.IsApricotPhase1:
-		if headerExtraDataSize != 0 {
-			return fmt.Errorf(
-				"expected header ExtraData to be 0 but got %d",
-				headerExtraDataSize,
-			)
-		}
-	default:
-		if uint64(headerExtraDataSize) > params.MaximumExtraDataSize {
-			return fmt.Errorf(
-				"expected header ExtraData to be <= %d but got %d",
-				params.MaximumExtraDataSize, headerExtraDataSize,
-			)
-		}
+	// Verify the extra data is well-formed.
+	if err := header.VerifyExtra(rules.AvalancheRules, ethHeader.Extra); err != nil {
+		return err
 	}
 
 	if b.ethBlock.Version() != 0 {

--- a/plugin/evm/header/extra.go
+++ b/plugin/evm/header/extra.go
@@ -1,0 +1,57 @@
+// (c) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package header
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ava-labs/coreth/params"
+)
+
+var ErrInvalidExtraLength = errors.New("invalid header.Extra length")
+
+// VerifyExtra verifies that the header's Extra field is correctly formatted for
+// [rules].
+func VerifyExtra(rules params.AvalancheRules, extra []byte) error {
+	extraLen := len(extra)
+	switch {
+	case rules.IsDurango:
+		if extraLen < params.DynamicFeeExtraDataSize {
+			return fmt.Errorf(
+				"%w: expected >= %d but got %d",
+				ErrInvalidExtraLength,
+				params.DynamicFeeExtraDataSize,
+				extraLen,
+			)
+		}
+	case rules.IsApricotPhase3:
+		if extraLen != params.DynamicFeeExtraDataSize {
+			return fmt.Errorf(
+				"%w: expected %d but got %d",
+				ErrInvalidExtraLength,
+				params.DynamicFeeExtraDataSize,
+				extraLen,
+			)
+		}
+	case rules.IsApricotPhase1:
+		if extraLen != 0 {
+			return fmt.Errorf(
+				"%w: expected 0 but got %d",
+				ErrInvalidExtraLength,
+				extraLen,
+			)
+		}
+	default:
+		if uint64(extraLen) > params.MaximumExtraDataSize {
+			return fmt.Errorf(
+				"%w: expected <= %d but got %d",
+				ErrInvalidExtraLength,
+				params.MaximumExtraDataSize,
+				extraLen,
+			)
+		}
+	}
+	return nil
+}

--- a/plugin/evm/header/extra_test.go
+++ b/plugin/evm/header/extra_test.go
@@ -1,0 +1,103 @@
+// (c) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package header
+
+import (
+	"testing"
+
+	"github.com/ava-labs/coreth/params"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyExtra(t *testing.T) {
+	tests := []struct {
+		name     string
+		rules    params.AvalancheRules
+		extra    []byte
+		expected error
+	}{
+		{
+			name:     "initial_valid",
+			rules:    params.AvalancheRules{},
+			extra:    make([]byte, params.MaximumExtraDataSize),
+			expected: nil,
+		},
+		{
+			name:     "initial_invalid",
+			rules:    params.AvalancheRules{},
+			extra:    make([]byte, params.MaximumExtraDataSize+1),
+			expected: ErrInvalidExtraLength,
+		},
+		{
+			name: "ap1_valid",
+			rules: params.AvalancheRules{
+				IsApricotPhase1: true,
+			},
+			extra:    nil,
+			expected: nil,
+		},
+		{
+			name: "ap1_invalid",
+			rules: params.AvalancheRules{
+				IsApricotPhase1: true,
+			},
+			extra:    make([]byte, 1),
+			expected: ErrInvalidExtraLength,
+		},
+		{
+			name: "ap3_valid",
+			rules: params.AvalancheRules{
+				IsApricotPhase3: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize),
+			expected: nil,
+		},
+		{
+			name: "ap3_invalid_less",
+			rules: params.AvalancheRules{
+				IsApricotPhase3: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize-1),
+			expected: ErrInvalidExtraLength,
+		},
+		{
+			name: "ap3_invalid_more",
+			rules: params.AvalancheRules{
+				IsApricotPhase3: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize+1),
+			expected: ErrInvalidExtraLength,
+		},
+		{
+			name: "durango_valid_min",
+			rules: params.AvalancheRules{
+				IsDurango: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize),
+			expected: nil,
+		},
+		{
+			name: "durango_valid_extra",
+			rules: params.AvalancheRules{
+				IsDurango: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize+1),
+			expected: nil,
+		},
+		{
+			name: "durango_invalid",
+			rules: params.AvalancheRules{
+				IsDurango: true,
+			},
+			extra:    make([]byte, params.DynamicFeeExtraDataSize-1),
+			expected: ErrInvalidExtraLength,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := VerifyExtra(test.rules, test.extra)
+			require.ErrorIs(t, err, test.expected)
+		})
+	}
+}


### PR DESCRIPTION
## Why this should be merged

Removes duplicate code and uniformly enforces the extra data header lengths.

## How this works

Adds a helper and tests it.

## How this was tested

Unit test.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.