### PR TITLE
Remove `header.Extra` from `EstimateNextBaseFee`

### DIFF
--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -169,11 +169,12 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 // If [timestamp] is less than the timestamp of [parent], then it uses the same timestamp as parent.
 // Warning: This function should only be used in estimation and should not be used when calculating the canonical
 // base fee for a subsequent block.
-func EstimateNextBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uint64) ([]byte, *big.Int, error) {
+func EstimateNextBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uint64) (*big.Int, error) {
 	if timestamp < parent.Time {
 		timestamp = parent.Time
 	}
-	return CalcBaseFee(config, parent, timestamp)
+	_, baseFee, err := CalcBaseFee(config, parent, timestamp)
+	return baseFee, err
 }
 
 // selectBigWithinBounds returns [value] if it is within the bounds:

--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -410,7 +410,7 @@ func (p *BlobPool) Init(gasTip uint64, head *types.Header, reserve txpool.Addres
 	for addr := range p.index {
 		p.recheck(addr, nil)
 	}
-	_, baseFee, err := dummy.EstimateNextBaseFee(
+	baseFee, err := dummy.EstimateNextBaseFee(
 		p.chain.Config(),
 		p.head,
 		uint64(time.Now().Unix()),
@@ -840,7 +840,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	if p.chain.Config().IsCancun(p.head.Number, p.head.Time) {
 		p.limbo.finalize(p.chain.CurrentFinalBlock())
 	}
-	_, baseFeeBig, err := dummy.EstimateNextBaseFee(
+	baseFeeBig, err := dummy.EstimateNextBaseFee(
 		p.chain.Config(),
 		p.head,
 		uint64(time.Now().Unix()),

--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1816,7 +1816,7 @@ func (pool *LegacyPool) updateBaseFee() {
 
 // assumes lock is already held
 func (pool *LegacyPool) updateBaseFeeAt(head *types.Header) error {
-	_, baseFeeEstimate, err := dummy.EstimateNextBaseFee(pool.chainconfig, head, uint64(time.Now().Unix()))
+	baseFeeEstimate, err := dummy.EstimateNextBaseFee(pool.chainconfig, head, uint64(time.Now().Unix()))
 	if err != nil {
 		return err
 	}

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -252,8 +252,7 @@ func (oracle *Oracle) estimateNextBaseFee(ctx context.Context) (*big.Int, error)
 	// If the block does have a baseFee, calculate the next base fee
 	// based on the current time and add it to the tip to estimate the
 	// total gas price estimate.
-	_, nextBaseFee, err := dummy.EstimateNextBaseFee(oracle.backend.ChainConfig(), header, oracle.clock.Unix())
-	return nextBaseFee, err
+	return dummy.EstimateNextBaseFee(oracle.backend.ChainConfig(), header, oracle.clock.Unix())
 }
 
 // SuggestPrice returns an estimated price for legacy transactions.

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1587,7 +1587,7 @@ func (vm *VM) verifyTxAtTip(tx *atomic.Tx) error {
 	var nextBaseFee *big.Int
 	timestamp := uint64(vm.clock.Time().Unix())
 	if vm.chainConfig.IsApricotPhase3(timestamp) {
-		_, nextBaseFee, err = dummy.EstimateNextBaseFee(vm.chainConfig, parentHeader, timestamp)
+		nextBaseFee, err = dummy.EstimateNextBaseFee(vm.chainConfig, parentHeader, timestamp)
 		if err != nil {
 			// Return extremely detailed error since CalcBaseFee should never encounter an issue here
 			return fmt.Errorf("failed to calculate base fee with parent timestamp (%d), parent ExtraData: (0x%x), and current timestamp (%d): %w", parentHeader.Time, parentHeader.Extra, timestamp, err)


### PR DESCRIPTION
## Why this should be merged

This return value is never used (and with the ACP-176 work, `CalcBaseFee` won't return the extra field).

## How this works

## How this was tested

## Need to be documented?

no.

## Need to update RELEASES.md?

no.