### PR TITLE
Cleanup header gas verification

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -152,7 +152,7 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 			return fmt.Errorf("failed to calculate base fee: %w", err)
 		}
 		if !bytes.HasPrefix(header.Extra, expectedExtraPrefix) {
-			return fmt.Errorf("expected rollup window bytes: %x, found %x", expectedExtraPrefix, header.Extra)
+			return fmt.Errorf("expected header.Extra to have prefix: %x, found %x", expectedExtraPrefix, header.Extra)
 		}
 		if !utils.BigEqual(header.BaseFee, expectedBaseFee) {
 			return fmt.Errorf("expected base fee (%d), found (%d)", expectedBaseFee, header.BaseFee)

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"time"
 
+	"github.com/ava-labs/avalanchego/utils/math"
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/coreth/consensus"
 	"github.com/ava-labs/coreth/consensus/misc/eip4844"
@@ -131,13 +132,9 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 		}
 	} else {
 		// Verify that the gas limit remains within allowed bounds
-		diff := int64(parent.GasLimit) - int64(header.GasLimit)
-		if diff < 0 {
-			diff *= -1
-		}
+		diff := math.AbsDiff(parent.GasLimit, header.GasLimit)
 		limit := parent.GasLimit / params.GasLimitBoundDivisor
-
-		if uint64(diff) >= limit || header.GasLimit < params.MinGasLimit {
+		if diff >= limit || header.GasLimit < params.MinGasLimit {
 			return fmt.Errorf("invalid gas limit: have %d, want %d += %d", header.GasLimit, parent.GasLimit, limit)
 		}
 	}
@@ -150,20 +147,14 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 	} else {
 		// Verify baseFee and rollupWindow encoding as part of header verification
 		// starting in AP3
-		expectedRollupWindowBytes, expectedBaseFee, err := CalcBaseFee(config, parent, header.Time)
+		expectedExtraPrefix, expectedBaseFee, err := CalcBaseFee(config, parent, header.Time)
 		if err != nil {
 			return fmt.Errorf("failed to calculate base fee: %w", err)
 		}
-		if len(header.Extra) < len(expectedRollupWindowBytes) || !bytes.Equal(expectedRollupWindowBytes, header.Extra[:len(expectedRollupWindowBytes)]) {
-			return fmt.Errorf("expected rollup window bytes: %x, found %x", expectedRollupWindowBytes, header.Extra)
+		if !bytes.HasPrefix(header.Extra, expectedExtraPrefix) {
+			return fmt.Errorf("expected rollup window bytes: %x, found %x", expectedExtraPrefix, header.Extra)
 		}
-		if header.BaseFee == nil {
-			return errors.New("expected baseFee to be non-nil")
-		}
-		if bfLen := header.BaseFee.BitLen(); bfLen > 256 {
-			return fmt.Errorf("too large base fee: bitlen %d", bfLen)
-		}
-		if header.BaseFee.Cmp(expectedBaseFee) != 0 {
+		if !utils.BigEqual(header.BaseFee, expectedBaseFee) {
 			return fmt.Errorf("expected base fee (%d), found (%d)", expectedBaseFee, header.BaseFee)
 		}
 	}

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -145,8 +145,7 @@ func (eng *DummyEngine) verifyHeaderGasFields(config *params.ChainConfig, header
 			return fmt.Errorf("invalid baseFee before fork: have %d, want <nil>", header.BaseFee)
 		}
 	} else {
-		// Verify baseFee and rollupWindow encoding as part of header verification
-		// starting in AP3
+		// Verify header.Extra and header.BaseFee match their expected values.
 		expectedExtraPrefix, expectedBaseFee, err := CalcBaseFee(config, parent, header.Time)
 		if err != nil {
 			return fmt.Errorf("failed to calculate base fee: %w", err)

--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -18,6 +18,9 @@ import (
 const ApricotPhase3BlockGasFee = 1_000_000
 
 var (
+	MaxUint256Plus1 = new(big.Int).Lsh(common.Big1, 256)
+	MaxUint256      = new(big.Int).Sub(MaxUint256Plus1, common.Big1)
+
 	ApricotPhase3MinBaseFee     = big.NewInt(params.ApricotPhase3MinBaseFee)
 	ApricotPhase3MaxBaseFee     = big.NewInt(params.ApricotPhase3MaxBaseFee)
 	ApricotPhase4MinBaseFee     = big.NewInt(params.ApricotPhase4MinBaseFee)
@@ -155,9 +158,9 @@ func CalcBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uin
 	// Ensure that the base fee does not increase/decrease outside of the bounds
 	switch {
 	case isEtna:
-		baseFee = selectBigWithinBounds(EtnaMinBaseFee, baseFee, nil)
+		baseFee = selectBigWithinBounds(EtnaMinBaseFee, baseFee, MaxUint256)
 	case isApricotPhase5:
-		baseFee = selectBigWithinBounds(ApricotPhase4MinBaseFee, baseFee, nil)
+		baseFee = selectBigWithinBounds(ApricotPhase4MinBaseFee, baseFee, MaxUint256)
 	case isApricotPhase4:
 		baseFee = selectBigWithinBounds(ApricotPhase4MinBaseFee, baseFee, ApricotPhase4MaxBaseFee)
 	default:

--- a/utils/numbers.go
+++ b/utils/numbers.go
@@ -29,6 +29,15 @@ func Uint64PtrEqual(x, y *uint64) bool {
 	return *x == *y
 }
 
+// BigEqual returns true if a is equal to b. If a and b are nil, it returns
+// true.
+func BigEqual(a, b *big.Int) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	return a.Cmp(b) == 0
+}
+
 // BigEqualUint64 returns true if a is equal to b. If a is nil or not a uint64,
 // it returns false.
 func BigEqualUint64(a *big.Int, b uint64) bool {

--- a/utils/numbers_test.go
+++ b/utils/numbers_test.go
@@ -10,6 +10,48 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestBigEqual(t *testing.T) {
+	tests := []struct {
+		name string
+		a    *big.Int
+		b    *big.Int
+		want bool
+	}{
+		{
+			name: "nil_nil",
+			a:    nil,
+			b:    nil,
+			want: true,
+		},
+		{
+			name: "0_nil",
+			a:    big.NewInt(0),
+			b:    nil,
+			want: false,
+		},
+		{
+			name: "0_1",
+			a:    big.NewInt(0),
+			b:    big.NewInt(1),
+			want: false,
+		},
+		{
+			name: "1_1",
+			a:    big.NewInt(1),
+			b:    big.NewInt(1),
+			want: true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			assert := assert.New(t)
+
+			assert.Equal(test.want, BigEqual(test.a, test.b))
+			assert.Equal(test.want, BigEqual(test.b, test.a))
+		})
+	}
+}
+
 func TestBigEqualUint64(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Why this should be merged

Cleans up `verifyHeaderGasFields` a bit.

## How this works

Ensures that `CalcBaseFee` returns reasonable values (BaseFee < 2^256). This is technically a breaking change... But this can't actually be hit on fuji or mainnet (as the maximum amount of AVAX that can exist wouldn't be sufficient to produce fees so large).

Adds a `BigEqual` helper that supports `nil` values.

## How this was tested

Added unit tests + CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.