### PR TITLE
ci: bump avalanchego to master

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.8
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.12.3-0.20250213211448-ecd0efda0c2c
+	github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf
 	github.com/cespare/cp v0.1.0
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.12.3-0.20250213211448-ecd0efda0c2c h1:0m7VsyPVJmKRRyWrR+o5jq88Mzgths4i+g6PCmuVuyU=
-github.com/ava-labs/avalanchego v1.12.3-0.20250213211448-ecd0efda0c2c/go.mod h1:PkpeGfEdsTccz87SDHidto21U5+BSBGZ+BNPW6Zplbc=
+github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf h1:4aq9V24PsH92vDSQTBx+uhm60BTeaNcXg/7FreQ8Q3M=
+github.com/ava-labs/avalanchego v1.12.3-0.20250213221544-df1bf8c8a6cf/go.mod h1:PkpeGfEdsTccz87SDHidto21U5+BSBGZ+BNPW6Zplbc=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -6,4 +6,4 @@
 set -euo pipefail
 
 # Don't export them as they're used in the context of other calls
-AVALANCHE_VERSION=${AVALANCHE_VERSION:-'ecd0efda'}
+AVALANCHE_VERSION=${AVALANCHE_VERSION:-'df1bf8c8'}


### PR DESCRIPTION
Fixes CI since the branch avalanchego was bumped to previously is now merged and we can depend on master instead