### PR TITLE
Fix `params.ApricotPhase4BaseFeeChangeDenominator` name

### DIFF
--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -29,7 +29,7 @@ var (
 	ApricotPhase3InitialBaseFee = big.NewInt(params.ApricotPhase3InitialBaseFee)
 	EtnaMinBaseFee              = big.NewInt(params.EtnaMinBaseFee)
 
-	ApricotPhase4BaseFeeChangeDenominator = new(big.Int).SetUint64(params.ApricotPhase4BaseFeeChangeDenominator)
+	ApricotPhase3BaseFeeChangeDenominator = new(big.Int).SetUint64(params.ApricotPhase3BaseFeeChangeDenominator)
 	ApricotPhase5BaseFeeChangeDenominator = new(big.Int).SetUint64(params.ApricotPhase5BaseFeeChangeDenominator)
 
 	errEstimateBaseFeeWithoutActivation = errors.New("cannot estimate base fee for chain without apricot phase 3 scheduled")
@@ -86,7 +86,7 @@ func calcBaseFeeWithWindow(config *params.ChainConfig, parent *types.Header, tim
 	// block limit
 	var (
 		isApricotPhase5                 = config.IsApricotPhase5(parent.Time)
-		baseFeeChangeDenominator        = ApricotPhase4BaseFeeChangeDenominator
+		baseFeeChangeDenominator        = ApricotPhase3BaseFeeChangeDenominator
 		parentGasTarget          uint64 = params.ApricotPhase3TargetGas
 	)
 	if isApricotPhase5 {

--- a/consensus/dummy/dynamic_fees_test.go
+++ b/consensus/dummy/dynamic_fees_test.go
@@ -397,7 +397,7 @@ func TestEstimateNextBaseFee(t *testing.T) {
 					gasUsed                    = ApricotPhase3BlockGasFee
 					amountUnderTarget          = gasTarget - gasUsed
 					parentBaseFee              = params.ApricotPhase3MaxBaseFee
-					smoothingFactor            = params.ApricotPhase4BaseFeeChangeDenominator
+					smoothingFactor            = params.ApricotPhase3BaseFeeChangeDenominator
 					baseFeeFractionUnderTarget = amountUnderTarget * parentBaseFee / gasTarget
 					delta                      = baseFeeFractionUnderTarget / smoothingFactor
 					baseFee                    = parentBaseFee - delta

--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -28,7 +28,7 @@ const (
 	ApricotPhase3TargetGas                       = 10_000_000
 	ApricotPhase4MinBaseFee               int64  = 25 * GWei
 	ApricotPhase4MaxBaseFee               int64  = 1_000 * GWei
-	ApricotPhase4BaseFeeChangeDenominator        = 12
+	ApricotPhase3BaseFeeChangeDenominator        = 12
 	ApricotPhase5TargetGas                       = 15_000_000
 	ApricotPhase5BaseFeeChangeDenominator uint64 = 36
 	EtnaMinBaseFee                        int64  = GWei


### PR DESCRIPTION
## Why this should be merged

In 7ab07dc0f59b6f3826f5021bd0548c9716b049f2 `params.BaseFeeChangeDenominator` was incorrectly renamed to `params.ApricotPhase4BaseFeeChangeDenominator`.

in c2fde6191604c3d6bea0035012ffb0287c6e4f3b `params.BaseFeeChangeDenominator` was finalized for AP3, not AP4.

## How this works

Rename

## How this was tested

N/A

## Need to be documented?

No

## Need to update RELEASES.md?

No