### PR TITLE
Move AP4 params

### DIFF
--- a/consensus/dummy/dynamic_fees.go
+++ b/consensus/dummy/dynamic_fees.go
@@ -24,8 +24,8 @@ var (
 
 	ApricotPhase3MinBaseFee     = big.NewInt(params.ApricotPhase3MinBaseFee)
 	ApricotPhase3MaxBaseFee     = big.NewInt(params.ApricotPhase3MaxBaseFee)
-	ApricotPhase4MinBaseFee     = big.NewInt(params.ApricotPhase4MinBaseFee)
-	ApricotPhase4MaxBaseFee     = big.NewInt(params.ApricotPhase4MaxBaseFee)
+	ApricotPhase4MinBaseFee     = big.NewInt(ap4.MinBaseFee)
+	ApricotPhase4MaxBaseFee     = big.NewInt(ap4.MaxBaseFee)
 	ApricotPhase3InitialBaseFee = big.NewInt(params.ApricotPhase3InitialBaseFee)
 	EtnaMinBaseFee              = big.NewInt(params.EtnaMinBaseFee)
 

--- a/consensus/dummy/dynamic_fees_test.go
+++ b/consensus/dummy/dynamic_fees_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/ap4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/log"
@@ -346,7 +347,7 @@ func TestDynamicFeesEtna(t *testing.T) {
 	require.NoError(err)
 	// After some time has passed in the Etna phase, the base fee should drop
 	// lower than the prior base fee minimum.
-	require.Less(nextBaseFee.Int64(), params.ApricotPhase4MinBaseFee)
+	require.Less(nextBaseFee.Int64(), ap4.MinBaseFee)
 }
 
 func TestCalcBaseFeeRegression(t *testing.T) {

--- a/consensus/dummy/dynamic_fees_test.go
+++ b/consensus/dummy/dynamic_fees_test.go
@@ -347,7 +347,7 @@ func TestDynamicFeesEtna(t *testing.T) {
 	require.NoError(err)
 	// After some time has passed in the Etna phase, the base fee should drop
 	// lower than the prior base fee minimum.
-	require.Less(nextBaseFee.Int64(), ap4.MinBaseFee)
+	require.Less(nextBaseFee.Int64(), int64(ap4.MinBaseFee))
 }
 
 func TestCalcBaseFeeRegression(t *testing.T) {

--- a/params/avalanche_params.go
+++ b/params/avalanche_params.go
@@ -26,8 +26,6 @@ const (
 	ApricotPhase3MaxBaseFee                      = 225 * GWei
 	ApricotPhase3InitialBaseFee           int64  = 225 * GWei
 	ApricotPhase3TargetGas                       = 10_000_000
-	ApricotPhase4MinBaseFee               int64  = 25 * GWei
-	ApricotPhase4MaxBaseFee               int64  = 1_000 * GWei
 	ApricotPhase3BaseFeeChangeDenominator        = 12
 	ApricotPhase5TargetGas                       = 15_000_000
 	ApricotPhase5BaseFeeChangeDenominator uint64 = 36

--- a/plugin/evm/ap4/cost.go
+++ b/plugin/evm/ap4/cost.go
@@ -9,25 +9,47 @@ import (
 	"math"
 
 	safemath "github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/coreth/params"
 )
 
 const (
+	// MinBlockGasCost is the minimum block gas cost.
 	MinBlockGasCost = 0
+	// MaxBlockGasCost is the maximum block gas cost. If the maximum block gas
+	// cost would exceed this value, the block gas cost is set to this value.
 	MaxBlockGasCost = 1_000_000
-	TargetBlockRate = 2 // in seconds
+	// TargetBlockRate is the target amount of time in seconds between blocks.
+	// If blocks are produced faster than this rate, the block gas cost is
+	// increased. If blocks are produced slower than this rate, the block gas
+	// cost is decreased.
+	TargetBlockRate = 2
 
 	// BlockGasCostStep is the rate at which the block gas cost changes per
 	// second.
 	//
 	// This value was modified by the Apricot Phase 5 upgrade.
 	BlockGasCostStep = 50_000
+
+	// MinBaseFee is the minimum base fee that is allowed after Apricot Phase 3
+	// upgrade.
+	//
+	// This value modifies the previously used `ap3.MinBaseFee`.
+	//
+	// This value was modified in Etna.
+	MinBaseFee = 25 * params.GWei
+
+	// MaxBaseFee is the maximum base fee that is allowed after Apricot Phase 3
+	// upgrade.
+	//
+	// This value modifies the previously used `ap3.MaxBaseFee`.
+	MaxBaseFee = 1_000 * params.GWei
 )
 
 // BlockGasCost calculates the required block gas cost.
 //
-// cost = parentCost + step * (TargetBlockRate - timeElapsed)
+// cost = parentCost + step * ([TargetBlockRate] - timeElapsed)
 //
-// The returned cost is clamped to [MinBlockGasCost, MaxBlockGasCost].
+// The returned cost is clamped to [[MinBlockGasCost], [MaxBlockGasCost]].
 func BlockGasCost(
 	parentCost uint64,
 	step uint64,

--- a/plugin/evm/ap4/cost.go
+++ b/plugin/evm/ap4/cost.go
@@ -15,8 +15,8 @@ import (
 const (
 	// MinBlockGasCost is the minimum block gas cost.
 	MinBlockGasCost = 0
-	// MaxBlockGasCost is the maximum block gas cost. If the maximum block gas
-	// cost would exceed this value, the block gas cost is set to this value.
+	// MaxBlockGasCost is the maximum block gas cost. If the block gas cost
+	// would exceed this value, the block gas cost is set to this value.
 	MaxBlockGasCost = 1_000_000
 	// TargetBlockRate is the target amount of time in seconds between blocks.
 	// If blocks are produced faster than this rate, the block gas cost is


### PR DESCRIPTION
## Why this should be merged

This is the start of removing the usage of the `params` package to stuff all configurations.

Is PR moves and documents parameters that were defined for the AP4 upgrade in the AP4 package.

## How this works

Move + comment

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No
