### PR TITLE
chore(all): minimal changes for libevm v1.13.14-0.2.0.rc.3 (1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.56
+          version: v1.63
           working-directory: .
           args: --timeout 3m
           skip-pkg-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,6 @@
 run:
   timeout: 10m
   tests: true
-  # default is true. Enables skipping of directories:
-  #   vendor$, third_party$, testdata$, examples$, Godeps$, builtin$
-  skip-dirs-use-default: true
-  # Include non-test files tagged as test-only.
-  # Context: https://github.com/ava-labs/avalanchego/pull/3173
 
 linters:
   disable-all: true
@@ -18,8 +13,19 @@ linters:
     - ineffassign
     - misspell
     - unconvert
+    - typecheck
     - unused
+    # - staticcheck
+    - bidichk
+    - durationcheck
+    - copyloopvar
     - whitespace
+    # - revive # only certain checks enabled
+    - durationcheck
+    - gocheckcompilerdirectives
+    - reassign
+    - mirror
+    - tenv
 
 linters-settings:
   gofmt:

--- a/accounts/abi/abi_test.go
+++ b/accounts/abi/abi_test.go
@@ -1210,7 +1210,6 @@ func TestUnpackRevert(t *testing.T) {
 		{"4e487b7100000000000000000000000000000000000000000000000000000000000000ff", "unknown panic code: 0xff", nil},
 	}
 	for index, c := range cases {
-		index, c := index, c
 		t.Run(fmt.Sprintf("case %d", index), func(t *testing.T) {
 			t.Parallel()
 			got, err := UnpackRevert(common.Hex2Bytes(c.input))

--- a/accounts/abi/bind/bind.go
+++ b/accounts/abi/bind/bind.go
@@ -262,7 +262,7 @@ func Bind(types []string, abis []string, bytecodes []string, fsigs []map[string]
 		}
 		// Parse library references.
 		for pattern, name := range libs {
-			matched, err := regexp.Match("__\\$"+pattern+"\\$__", []byte(contracts[types[i]].InputBin))
+			matched, err := regexp.MatchString("__\\$"+pattern+"\\$__", contracts[types[i]].InputBin)
 			if err != nil {
 				log.Error("Could not search for pattern", "pattern", pattern, "contract", contracts[types[i]], "err", err)
 			}

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2179,7 +2179,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250212124953-9c7285a21b71")
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250213164614-19ec675e01c4")
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2179,7 +2179,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250213164614-19ec675e01c4")
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250214081829-bd9b506d6610")
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2179,11 +2179,6 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250214081829-bd9b506d6610")
-	replacer.Dir = pkg
-	if out, err := replacer.CombinedOutput(); err != nil {
-		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
-	}
 	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.22")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2179,6 +2179,11 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250210135835-d3f6a5e75e05")
+	replacer.Dir = pkg
+	if out, err := replacer.CombinedOutput(); err != nil {
+		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
+	}
 	tidier := exec.Command(gocmd, "mod", "tidy", "-compat=1.22")
 	tidier.Dir = pkg
 	if out, err := tidier.CombinedOutput(); err != nil {

--- a/accounts/abi/bind/bind_test.go
+++ b/accounts/abi/bind/bind_test.go
@@ -2179,7 +2179,7 @@ func golangBindings(t *testing.T, overload bool) {
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)
 	}
-	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250210135835-d3f6a5e75e05")
+	replacer = exec.Command(gocmd, "mod", "edit", "-x", "-require", "github.com/ava-labs/libevm@v0.0.0", "-replace", "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250212124953-9c7285a21b71")
 	replacer.Dir = pkg
 	if out, err := replacer.CombinedOutput(); err != nil {
 		t.Fatalf("failed to replace binding test dependency to current source tree: %v\n%s", err, out)

--- a/accounts/abi/event_test.go
+++ b/accounts/abi/event_test.go
@@ -341,7 +341,6 @@ func TestEventTupleUnpack(t *testing.T) {
 
 	for _, tc := range testCases {
 		assert := assert.New(t)
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			err := unpackTestEventData(tc.dest, tc.data, tc.jsonLog, assert)
 			if tc.error == "" {

--- a/accounts/abi/pack_test.go
+++ b/accounts/abi/pack_test.go
@@ -44,7 +44,6 @@ import (
 func TestPack(t *testing.T) {
 	t.Parallel()
 	for i, test := range packUnpackTests {
-		i, test := i, test
 		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			t.Parallel()
 			encb, err := hex.DecodeString(test.packed)

--- a/accounts/abi/reflect_test.go
+++ b/accounts/abi/reflect_test.go
@@ -182,7 +182,6 @@ var reflectTests = []reflectTest{
 func TestReflectNameToStruct(t *testing.T) {
 	t.Parallel()
 	for _, test := range reflectTests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			m, err := mapArgNamesToStructFields(test.args, reflect.ValueOf(test.struc))

--- a/accounts/abi/topics_test.go
+++ b/accounts/abi/topics_test.go
@@ -147,7 +147,6 @@ func TestMakeTopics(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := MakeTopics(tt.args.query...)
@@ -383,7 +382,6 @@ func TestParseTopics(t *testing.T) {
 	tests := setupTopicsTests()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			createObj := tt.args.createObj()
@@ -403,7 +401,6 @@ func TestParseTopicsIntoMap(t *testing.T) {
 	tests := setupTopicsTests()
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			outMap := make(map[string]interface{})

--- a/accounts/abi/unpack_test.go
+++ b/accounts/abi/unpack_test.go
@@ -399,7 +399,6 @@ func TestMethodMultiReturn(t *testing.T) {
 		"Can not unpack into a slice with wrong types",
 	}}
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			require := require.New(t)
 			err := abi.UnpackIntoInterface(tc.dest, "multi", data)
@@ -957,7 +956,7 @@ func TestOOMMaliciousInput(t *testing.T) {
 		}
 		encb, err := hex.DecodeString(test.enc)
 		if err != nil {
-			t.Fatalf("invalid hex: %s" + test.enc)
+			t.Fatalf("invalid hex: %s", test.enc)
 		}
 		_, err = abi.Methods["method"].Outputs.UnpackValues(encb)
 		if err == nil {

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -291,7 +291,6 @@ func TestBlockChainOfflinePruningUngracefulShutdown(t *testing.T) {
 		return createBlockChain(db, pruningConfig, gspec, lastAcceptedHash)
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 			tt.testFunc(t, create)

--- a/core/predicate_check_test.go
+++ b/core/predicate_check_test.go
@@ -293,7 +293,6 @@ func TestCheckPredicate(t *testing.T) {
 			expectedErr: ErrIntrinsicGas,
 		},
 	} {
-		test := test
 		t.Run(name, func(t *testing.T) {
 			require := require.New(t)
 			// Create the rules from TestChainConfig and update the predicates based on the test params

--- a/core/rawdb/accessors_chain_test.go
+++ b/core/rawdb/accessors_chain_test.go
@@ -291,10 +291,10 @@ func TestBlockReceiptStorage(t *testing.T) {
 	// Insert the receipt slice into the database and check presence
 	WriteReceipts(db, hash, 0, receipts)
 	if rs := ReadReceipts(db, hash, 0, 0, params.TestChainConfig); len(rs) == 0 {
-		t.Fatalf("no receipts returned")
+		t.Fatal("no receipts returned")
 	} else {
 		if err := checkReceiptsRLP(rs, receipts); err != nil {
-			t.Fatalf(err.Error())
+			t.Fatal(err)
 		}
 	}
 	// Delete the body and ensure that the receipts are no longer returned (metadata can't be recomputed)
@@ -308,7 +308,7 @@ func TestBlockReceiptStorage(t *testing.T) {
 	}
 	// Ensure that receipts without metadata can be returned without the block body too
 	if err := checkReceiptsRLP(ReadRawReceipts(db, hash, 0), receipts); err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err)
 	}
 	// Sanity check that body and header alone without the receipt is a full purge
 	WriteHeader(db, header)

--- a/core/types/header_ext.go
+++ b/core/types/header_ext.go
@@ -23,11 +23,11 @@ func (h *HeaderExtra) DecodeRLP(eth *ethtypes.Header, stream *rlp.Stream) error 
 	panic("not implemented")
 }
 
-func (h *HeaderExtra) MarshalJSON(eth *ethtypes.Header) ([]byte, error) {
+func (h *HeaderExtra) EncodeJSON(eth *ethtypes.Header) ([]byte, error) {
 	panic("not implemented")
 }
 
-func (h *HeaderExtra) UnmarshalJSON(eth *ethtypes.Header, input []byte) error {
+func (h *HeaderExtra) DecodeJSON(eth *ethtypes.Header, input []byte) error {
 	panic("not implemented")
 }
 

--- a/core/types/header_ext.go
+++ b/core/types/header_ext.go
@@ -1,0 +1,36 @@
+// (c) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package types
+
+import (
+	"io"
+
+	ethtypes "github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/rlp"
+)
+
+// HeaderExtra is a struct that contains extra fields used by Avalanche
+// in the block header.
+type HeaderExtra struct {
+}
+
+func (h *HeaderExtra) EncodeRLP(eth *ethtypes.Header, writer io.Writer) error {
+	panic("not implemented")
+}
+
+func (h *HeaderExtra) DecodeRLP(eth *ethtypes.Header, stream *rlp.Stream) error {
+	panic("not implemented")
+}
+
+func (h *HeaderExtra) MarshalJSON(eth *ethtypes.Header) ([]byte, error) {
+	panic("not implemented")
+}
+
+func (h *HeaderExtra) UnmarshalJSON(eth *ethtypes.Header, input []byte) error {
+	panic("not implemented")
+}
+
+func (h *HeaderExtra) PostCopy(dst *ethtypes.Header) {
+	panic("not implemented")
+}

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -46,8 +46,11 @@ var (
 
 type isMultiCoin bool
 
-var IsMultiCoinPayloads = ethtypes.RegisterExtras[isMultiCoin]()
+var (
+	extras              = ethtypes.RegisterExtras[ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks, isMultiCoin]()
+	IsMultiCoinPayloads = extras.StateAccount
+)
 
-func IsMultiCoin(a ethtypes.ExtraPayloadCarrier) bool {
-	return bool(IsMultiCoinPayloads.FromPayloadCarrier(a))
+func IsMultiCoin(s ethtypes.StateOrSlimAccount) bool {
+	return bool(extras.StateAccount.Get(s))
 }

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -47,7 +47,11 @@ var (
 type isMultiCoin bool
 
 var (
-	extras              = ethtypes.RegisterExtras[ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks, isMultiCoin]()
+	extras = ethtypes.RegisterExtras[
+		ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks,
+		ethtypes.NOOPBodyHooks, *ethtypes.NOOPBodyHooks,
+		isMultiCoin,
+	]()
 	IsMultiCoinPayloads = extras.StateAccount
 )
 

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -49,7 +49,7 @@ type isMultiCoin bool
 var (
 	extras = ethtypes.RegisterExtras[
 		ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks,
-		ethtypes.NOOPBodyHooks, *ethtypes.NOOPBodyHooks,
+		ethtypes.NOOPBlockBodyHooks, *ethtypes.NOOPBlockBodyHooks,
 		isMultiCoin,
 	]()
 	IsMultiCoinPayloads = extras.StateAccount

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -56,5 +56,5 @@ var (
 )
 
 func IsMultiCoin(s ethtypes.StateOrSlimAccount) bool {
-	return bool(extras.StateAccount.Get(s))
+	return bool(IsMultiCoinPayloads.Get(s))
 }

--- a/eth/filters/api.go
+++ b/eth/filters/api.go
@@ -350,7 +350,6 @@ func (api *FilterAPI) Logs(ctx context.Context, crit FilterCriteria) (*rpc.Subsc
 			select {
 			case logs := <-matchedLogs:
 				for _, log := range logs {
-					log := log
 					notifier.Notify(rpcSub.ID, &log)
 				}
 			case <-rpcSub.Err(): // client send an unsubscribe request

--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05
+replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71

--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71
+replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4

--- a/go.mod
+++ b/go.mod
@@ -136,4 +136,4 @@ require (
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
 
-replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4
+replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610

--- a/go.mod
+++ b/go.mod
@@ -1,11 +1,13 @@
 module github.com/ava-labs/coreth
 
-go 1.22.8
+go 1.23
+
+toolchain go1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8
-	github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2
+	github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
@@ -135,5 +137,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
-
-replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610

--- a/go.mod
+++ b/go.mod
@@ -135,3 +135,5 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	rsc.io/tmplfunc v0.0.3 // indirect
 )
+
+replace github.com/ava-labs/libevm => github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8 h1:qN3MOBHB//Ynhgt5Vys3iVe42Sr0EWSeN18VL3ecXzE=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8/go.mod h1:2B7+E5neLvkOr2zursGhebjU26d4AfB7RazPxBs8hHg=
-github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2 h1:CVbn0hSsPCl6gCkTCnqwuN4vtJgdVbkCqLXzYAE7qF8=
-github.com/ava-labs/libevm v1.13.14-0.1.0.rc-2/go.mod h1:yBctIV/wnxXTF38h95943jvpuk4aj07TrjbpoGor6LQ=
+github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05 h1:LzpeCE04Opu8tepYoA1xxdWCYZI7J0etGcBAzABt6j0=
+github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05/go.mod h1:M8TCw2g1D5GBB7hu7g1F4aot5bRHGSxnBawNVmHE9Z0=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8 h1:qN3MOBHB//Ynhgt5Vys3iVe42Sr0EWSeN18VL3ecXzE=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8/go.mod h1:2B7+E5neLvkOr2zursGhebjU26d4AfB7RazPxBs8hHg=
-github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71 h1:C8qlqwg/QPnfJCh7ACTFkfXrMh5Q98revSv0R+PRG88=
-github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
+github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4 h1:nk6q9a1XoLp8Gnce8kEl3PpE6Xmpgc3QJKFnyt11M1g=
+github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8 h1:qN3MOBHB//Ynhgt5Vys3iVe42Sr0EWSeN18VL3ecXzE=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8/go.mod h1:2B7+E5neLvkOr2zursGhebjU26d4AfB7RazPxBs8hHg=
-github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4 h1:nk6q9a1XoLp8Gnce8kEl3PpE6Xmpgc3QJKFnyt11M1g=
-github.com/ava-labs/libevm v0.0.0-20250213164614-19ec675e01c4/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
+github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610 h1:88qJrHnjK2rmGroP1DoIoqSkga0/2yJmL/LnnIaujrw=
+github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8 h1:qN3MOBHB//Ynhgt5Vys3iVe42Sr0EWSeN18VL3ecXzE=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8/go.mod h1:2B7+E5neLvkOr2zursGhebjU26d4AfB7RazPxBs8hHg=
-github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610 h1:88qJrHnjK2rmGroP1DoIoqSkga0/2yJmL/LnnIaujrw=
-github.com/ava-labs/libevm v0.0.0-20250214081829-bd9b506d6610/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
+github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3 h1:1CWGo2icnX9dRqGQl7CFywYGIZWxe+ucy0w8NAsVTWE=
+github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8 h1:qN3MOBHB//Ynhgt5Vys3iVe42Sr0EWSeN18VL3ecXzE=
 github.com/ava-labs/avalanchego v1.12.1-0.20250107220127-32f58b4fa9c8/go.mod h1:2B7+E5neLvkOr2zursGhebjU26d4AfB7RazPxBs8hHg=
-github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05 h1:LzpeCE04Opu8tepYoA1xxdWCYZI7J0etGcBAzABt6j0=
-github.com/ava-labs/libevm v0.0.0-20250210135835-d3f6a5e75e05/go.mod h1:M8TCw2g1D5GBB7hu7g1F4aot5bRHGSxnBawNVmHE9Z0=
+github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71 h1:C8qlqwg/QPnfJCh7ACTFkfXrMh5Q98revSv0R+PRG88=
+github.com/ava-labs/libevm v0.0.0-20250212124953-9c7285a21b71/go.mod h1:xi9AcwLOv3gUYYSuRYxXKVmLMFTSM4g0m4cpvC5X8DU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/metrics/json_test.go
+++ b/metrics/json_test.go
@@ -13,7 +13,7 @@ func TestRegistryMarshallJSON(t *testing.T) {
 	r.Register("counter", NewCounter())
 	enc.Encode(r)
 	if s := b.String(); s != "{\"counter\":{\"count\":0}}\n" {
-		t.Fatalf(s)
+		t.Fatal(s)
 	}
 }
 

--- a/nativeasset/contract.go
+++ b/nativeasset/contract.go
@@ -141,7 +141,7 @@ func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller c
 	stateDB.SubBalanceMultiCoin(caller, assetID, assetAmount)
 	stateDB.AddBalanceMultiCoin(to, assetID, assetAmount)
 
-	ret, remainingGas, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
+	ret, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally

--- a/nativeasset/contract.go
+++ b/nativeasset/contract.go
@@ -141,7 +141,8 @@ func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller c
 	stateDB.SubBalanceMultiCoin(caller, assetID, assetAmount)
 	stateDB.AddBalanceMultiCoin(to, assetID, assetAmount)
 
-	ret, remainingGas, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
+	// Drop the returned gas, resulting in a free outgoing call to mirror historical behaviour.
+	ret, _, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally

--- a/nativeasset/contract.go
+++ b/nativeasset/contract.go
@@ -141,7 +141,7 @@ func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller c
 	stateDB.SubBalanceMultiCoin(caller, assetID, assetAmount)
 	stateDB.AddBalanceMultiCoin(to, assetID, assetAmount)
 
-	ret, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
+	ret, remainingGas, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally

--- a/nativeasset/contract.go
+++ b/nativeasset/contract.go
@@ -105,35 +105,45 @@ func UnpackNativeAssetCallInput(input []byte) (common.Address, common.Hash, *big
 
 // Run implements StatefulPrecompiledContract
 func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller common.Address, addr common.Address, input []byte, suppliedGas uint64, readOnly bool) (ret []byte, remainingGas uint64, err error) {
-	if suppliedGas < c.GasCost {
+	env := accessibleState.GetPrecompileEnv()
+	if !env.UseGas(c.GasCost) {
 		return nil, 0, vmerrs.ErrOutOfGas
 	}
-	remainingGas = suppliedGas - c.GasCost
+	ret, err = c.run(env, accessibleState.GetStateDB(), caller, addr, input, readOnly)
+	// This precompile will be wrapped in a libevm `legacy` wrapper, which
+	// allows for the deprecated pattern of returning remaining gas by calling
+	// env.UseGas() on the difference between gas in and gas out. Since we call
+	// UseGas() ourselves, we therefore return `suppliedGas` unchanged to stop
+	// the legacy wrapper from double-counting spends.
+	return ret, suppliedGas, err
+}
 
+// run implements the contract logic, using `env.Gas()` and `env.UseGas()` in
+// place of `suppliedGas` and returning `remainingGas`, respectively. This
+// avoids mixing gas-accounting patterns when using env.Call().
+func (c *NativeAssetCall) run(env vm.PrecompileEnvironment, stateDB contract.StateDB, caller common.Address, addr common.Address, input []byte, readOnly bool) (ret []byte, err error) {
 	if readOnly {
-		return nil, remainingGas, vmerrs.ErrExecutionReverted
+		return nil, vmerrs.ErrExecutionReverted
 	}
 
 	to, assetID, assetAmount, callData, err := UnpackNativeAssetCallInput(input)
 	if err != nil {
 		log.Debug("unpacking native asset call input failed", "err", err)
-		return nil, remainingGas, vmerrs.ErrExecutionReverted
+		return nil, vmerrs.ErrExecutionReverted
 	}
 
-	stateDB := accessibleState.GetStateDB()
 	// Note: it is not possible for a negative assetAmount to be passed in here due to the fact that decoding a
 	// byte slice into a *big.Int type will always return a positive value, as documented on [big.Int.SetBytes].
 	if assetAmount.Sign() != 0 && stateDB.GetBalanceMultiCoin(caller, assetID).Cmp(assetAmount) < 0 {
-		return nil, remainingGas, vmerrs.ErrInsufficientBalance
+		return nil, vmerrs.ErrInsufficientBalance
 	}
 
 	snapshot := stateDB.Snapshot()
 
 	if !stateDB.Exist(to) {
-		if remainingGas < c.CallNewAccountGas {
-			return nil, 0, vmerrs.ErrOutOfGas
+		if !env.UseGas(c.CallNewAccountGas) {
+			return nil, vmerrs.ErrOutOfGas
 		}
-		remainingGas -= c.CallNewAccountGas
 		stateDB.CreateAccount(to)
 	}
 
@@ -141,8 +151,7 @@ func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller c
 	stateDB.SubBalanceMultiCoin(caller, assetID, assetAmount)
 	stateDB.AddBalanceMultiCoin(to, assetID, assetAmount)
 
-	// Drop the returned gas, resulting in a free outgoing call to mirror historical behaviour.
-	ret, _, err = accessibleState.Call(to, callData, remainingGas, new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
+	ret, err = env.Call(to, callData, env.Gas(), new(uint256.Int), vm.WithUNSAFECallerAddressProxying())
 
 	// When an error was returned by the EVM or when setting the creation code
 	// above we revert to the snapshot and consume any gas remaining. Additionally
@@ -150,13 +159,13 @@ func (c *NativeAssetCall) Run(accessibleState contract.AccessibleState, caller c
 	if err != nil {
 		stateDB.RevertToSnapshot(snapshot)
 		if err != vmerrs.ErrExecutionReverted {
-			remainingGas = 0
+			env.UseGas(env.Gas())
 		}
 		// TODO: consider clearing up unused snapshots:
 		//} else {
 		//	evm.StateDB.DiscardSnapshot(snapshot)
 	}
-	return ret, remainingGas, err
+	return ret, err
 }
 
 type DeprecatedContract struct{}

--- a/nativeasset/contract_test.go
+++ b/nativeasset/contract_test.go
@@ -239,8 +239,8 @@ func TestStatefulPrecompile(t *testing.T) {
 			precompileAddr:       NativeAssetCallAddr,
 			input:                PackNativeAssetCallInput(userAddr2, assetID, big.NewInt(50), nil),
 			value:                big0,
-			gasInput:             params.AssetCallApricot + params.CallNewAccountGas,
-			expectedGasRemaining: 0,
+			gasInput:             params.AssetCallApricot + params.CallNewAccountGas + 123,
+			expectedGasRemaining: 123,
 			expectedErr:          nil,
 			expectedResult:       nil,
 			name:                 "native asset call: multicoin transfer",
@@ -459,7 +459,7 @@ func TestStatefulPrecompile(t *testing.T) {
 			evm := vm.NewEVM(vmCtx, vm.TxContext{}, stateDB, params.TestApricotPhase5Config, vm.Config{}) // Use ApricotPhase5Config because these precompiles are deprecated in ApricotPhase6.
 			ret, gasRemaining, err := evm.Call(vm.AccountRef(test.from), test.precompileAddr, test.input, test.gasInput, test.value)
 			// Place gas remaining check before error check, so that it is not skipped when there is an error
-			assert.Equal(t, test.expectedGasRemaining, gasRemaining, "unexpected gas remaining")
+			assert.Equalf(t, test.expectedGasRemaining, gasRemaining, "unexpected gas remaining (%d of %d)", gasRemaining, test.gasInput)
 
 			if test.expectedErr != nil {
 				assert.Equal(t, test.expectedErr, err, "expected error to match")

--- a/params/config_extra.go
+++ b/params/config_extra.go
@@ -59,10 +59,10 @@ func SetEthUpgrades(c *ChainConfig) {
 }
 
 func GetExtra(c *ChainConfig) *extras.ChainConfig {
-	ex := payloads.FromChainConfig(c)
+	ex := payloads.ChainConfig.Get(c)
 	if ex == nil {
 		ex = &extras.ChainConfig{}
-		payloads.SetOnChainConfig(c, ex)
+		payloads.ChainConfig.Set(c, ex)
 	}
 	return ex
 }
@@ -75,7 +75,7 @@ func Copy(c *ChainConfig) ChainConfig {
 
 // WithExtra sets the extra payload on `c` and returns the modified argument.
 func WithExtra(c *ChainConfig, extra *extras.ChainConfig) *ChainConfig {
-	payloads.SetOnChainConfig(c, extra)
+	payloads.ChainConfig.Set(c, extra)
 	return c
 }
 

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -176,13 +176,7 @@ func (a accessableState) Call(addr common.Address, input []byte, gas uint64, val
 	start := a.env.Gas()
 	ret, err = a.env.Call(addr, input, gas, value, opts...)
 	used := start - a.env.Gas()
-	if used > gas {
-		return ret, 0, vm.ErrOutOfGas
-	}
-	// `gasRemaining` is `gas` because [vm.PrecompileEnvironment]'s `Call` method
-	// should consume the gas from the environment directly
-	gasRemaining = gas
-	return ret, gasRemaining, err
+	return ret, gas - used, err
 }
 
 type precompileBlockContext struct {

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/legacy"
-	"github.com/holiman/uint256"
 	"golang.org/x/exp/maps"
 )
 
@@ -172,11 +171,8 @@ func (a accessableState) GetSnowContext() *snow.Context {
 	return GetExtra(a.env.ChainConfig()).SnowCtx
 }
 
-func (a accessableState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, err error) {
-	start := a.env.Gas()
-	ret, err = a.env.Call(addr, input, gas, value, opts...)
-	used := start - a.env.Gas()
-	return ret, gas - used, err
+func (a accessableState) GetPrecompileEnv() vm.PrecompileEnvironment {
+	return a.env
 }
 
 type precompileBlockContext struct {

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -172,8 +172,9 @@ func (a accessableState) GetSnowContext() *snow.Context {
 	return GetExtra(a.env.ChainConfig()).SnowCtx
 }
 
-func (a accessableState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, err error) {
-	return a.env.Call(addr, input, gas, value, opts...)
+func (a accessableState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, err error) {
+	ret, err = a.env.Call(addr, input, gas, value, opts...)
+	return ret, a.env.Gas(), err
 }
 
 type precompileBlockContext struct {

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
+	"github.com/ava-labs/libevm/libevm/legacy"
 	"github.com/holiman/uint256"
 	"golang.org/x/exp/maps"
 )
@@ -23,7 +24,7 @@ import (
 type RulesExtra extras.Rules
 
 func GetRulesExtra(r Rules) *extras.Rules {
-	rules := payloads.PointerFromRules(&r)
+	rules := payloads.Rules.GetPointer(&r)
 	return (*extras.Rules)(rules)
 }
 
@@ -125,7 +126,7 @@ func makePrecompile(contract contract.StatefulPrecompiledContract) libevm.Precom
 		}
 		return contract.Run(accessableState, env.Addresses().Caller, env.Addresses().Self, input, suppliedGas, env.ReadOnly())
 	}
-	return vm.NewStatefulPrecompile(run)
+	return vm.NewStatefulPrecompile(legacy.PrecompiledStatefulContract(run).Upgrade())
 }
 
 func (r RulesExtra) PrecompileOverride(addr common.Address) (libevm.PrecompiledContract, bool) {
@@ -171,7 +172,7 @@ func (a accessableState) GetSnowContext() *snow.Context {
 	return GetExtra(a.env.ChainConfig()).SnowCtx
 }
 
-func (a accessableState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, _ error) {
+func (a accessableState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, err error) {
 	return a.env.Call(addr, input, gas, value, opts...)
 }
 

--- a/plugin/evm/prestate_tracer_test.go
+++ b/plugin/evm/prestate_tracer_test.go
@@ -38,7 +38,6 @@ func testPrestateDiffTracer(tracerName string, dirPath string, t *testing.T) {
 		if !strings.HasSuffix(file.Name(), ".json") {
 			continue
 		}
-		file := file // capture range variable
 		t.Run(camel(strings.TrimSuffix(file.Name(), ".json")), func(t *testing.T) {
 			t.Parallel()
 

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1137,7 +1137,6 @@ func TestConflictingImportTxsAcrossBlocks(t *testing.T) {
 		"apricotPhase4": genesisJSONApricotPhase4,
 		"apricotPhase5": genesisJSONApricotPhase5,
 	} {
-		genesis := genesis
 		t.Run(name, func(t *testing.T) {
 			testConflictingImportTxs(t, genesis)
 		})

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -61,7 +61,7 @@ type AccessibleState interface {
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
 	GetChainConfig() precompileconfig.ChainConfig
-	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, _ error)
+	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, _ error)
 }
 
 // ConfigurationBlockContext defines the interface required to configure a precompile.

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -61,7 +61,7 @@ type AccessibleState interface {
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
 	GetChainConfig() precompileconfig.ChainConfig
-	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, _ error)
+	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, _ error)
 }
 
 // ConfigurationBlockContext defines the interface required to configure a precompile.

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -61,7 +61,7 @@ type AccessibleState interface {
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
 	GetChainConfig() precompileconfig.ChainConfig
-	Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) (ret []byte, gasRemaining uint64, _ error)
+	GetPrecompileEnv() vm.PrecompileEnvironment
 }
 
 // ConfigurationBlockContext defines the interface required to configure a precompile.

--- a/precompile/contract/mocks.go
+++ b/precompile/contract/mocks.go
@@ -305,27 +305,6 @@ func (m *MockAccessibleState) EXPECT() *MockAccessibleStateMockRecorder {
 	return m.recorder
 }
 
-// Call mocks base method.
-func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) ([]byte, uint64, error) {
-	m.ctrl.T.Helper()
-	varargs := []any{addr, input, gas, value}
-	for _, a := range opts {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "Call", varargs...)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(uint64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// Call indicates an expected call of Call.
-func (mr *MockAccessibleStateMockRecorder) Call(addr, input, gas, value any, opts ...any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]any{addr, input, gas, value}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Call", reflect.TypeOf((*MockAccessibleState)(nil).Call), varargs...)
-}
-
 // GetBlockContext mocks base method.
 func (m *MockAccessibleState) GetBlockContext() BlockContext {
 	m.ctrl.T.Helper()
@@ -352,6 +331,20 @@ func (m *MockAccessibleState) GetChainConfig() precompileconfig.ChainConfig {
 func (mr *MockAccessibleStateMockRecorder) GetChainConfig() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChainConfig", reflect.TypeOf((*MockAccessibleState)(nil).GetChainConfig))
+}
+
+// GetPrecompileEnv mocks base method.
+func (m *MockAccessibleState) GetPrecompileEnv() vm.PrecompileEnvironment {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPrecompileEnv")
+	ret0, _ := ret[0].(vm.PrecompileEnvironment)
+	return ret0
+}
+
+// GetPrecompileEnv indicates an expected call of GetPrecompileEnv.
+func (mr *MockAccessibleStateMockRecorder) GetPrecompileEnv() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPrecompileEnv", reflect.TypeOf((*MockAccessibleState)(nil).GetPrecompileEnv))
 }
 
 // GetSnowContext mocks base method.

--- a/precompile/contract/mocks.go
+++ b/precompile/contract/mocks.go
@@ -306,7 +306,7 @@ func (m *MockAccessibleState) EXPECT() *MockAccessibleStateMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) ([]byte, uint64, error) {
+func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) ([]byte, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{addr, input, gas, value}
 	for _, a := range opts {
@@ -314,9 +314,8 @@ func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64
 	}
 	ret := m.ctrl.Call(m, "Call", varargs...)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(uint64)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
 }
 
 // Call indicates an expected call of Call.

--- a/precompile/contract/mocks.go
+++ b/precompile/contract/mocks.go
@@ -306,7 +306,7 @@ func (m *MockAccessibleState) EXPECT() *MockAccessibleStateMockRecorder {
 }
 
 // Call mocks base method.
-func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) ([]byte, error) {
+func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64, value *uint256.Int, opts ...vm.CallOption) ([]byte, uint64, error) {
 	m.ctrl.T.Helper()
 	varargs := []any{addr, input, gas, value}
 	for _, a := range opts {
@@ -314,8 +314,9 @@ func (m *MockAccessibleState) Call(addr common.Address, input []byte, gas uint64
 	}
 	ret := m.ctrl.Call(m, "Call", varargs...)
 	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(uint64)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // Call indicates an expected call of Call.

--- a/rpc/client_test.go
+++ b/rpc/client_test.go
@@ -723,7 +723,6 @@ func TestClientHTTP(t *testing.T) {
 	)
 	defer client.Close()
 	for i := range results {
-		i := i
 		go func() {
 			errc <- client.Call(&results[i], "test_echo", wantResult.String, wantResult.Int, wantResult.Args)
 		}()

--- a/rpc/types_test.go
+++ b/rpc/types_test.go
@@ -145,7 +145,6 @@ func TestBlockNumberOrHash_WithNumber_MarshalAndUnmarshal(t *testing.T) {
 		{"earliest", int64(EarliestBlockNumber)},
 	}
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			bnh := BlockNumberOrHashWithNumber(BlockNumber(test.number))
 			marshalled, err := json.Marshal(bnh)

--- a/scripts/eth-allowed-packages.txt
+++ b/scripts/eth-allowed-packages.txt
@@ -25,6 +25,7 @@
 "github.com/ava-labs/libevm/ethdb/pebble"
 "github.com/ava-labs/libevm/event"
 "github.com/ava-labs/libevm/libevm"
+"github.com/ava-labs/libevm/libevm/legacy"
 "github.com/ava-labs/libevm/libevm/stateconf"
 "github.com/ava-labs/libevm/log"
 "github.com/ava-labs/libevm/params"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -45,7 +45,7 @@ git checkout -B "test-${AVALANCHE_VERSION}" "${AVALANCHE_VERSION}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
-go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250210135835-d3f6a5e75e05"
+go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250212124953-9c7285a21b71"
 go mod tidy
 
 echo "building avalanchego"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -45,6 +45,7 @@ git checkout -B "test-${AVALANCHE_VERSION}" "${AVALANCHE_VERSION}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
+go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250210135835-d3f6a5e75e05"
 go mod tidy
 
 echo "building avalanchego"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -45,7 +45,7 @@ git checkout -B "test-${AVALANCHE_VERSION}" "${AVALANCHE_VERSION}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
-go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250212124953-9c7285a21b71"
+go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250213164614-19ec675e01c4"
 go mod tidy
 
 echo "building avalanchego"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -45,7 +45,6 @@ git checkout -B "test-${AVALANCHE_VERSION}" "${AVALANCHE_VERSION}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
-go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250214081829-bd9b506d6610"
 go mod tidy
 
 echo "building avalanchego"

--- a/scripts/tests.e2e.sh
+++ b/scripts/tests.e2e.sh
@@ -45,7 +45,7 @@ git checkout -B "test-${AVALANCHE_VERSION}" "${AVALANCHE_VERSION}"
 
 echo "updating coreth dependency to point to ${CORETH_PATH}"
 go mod edit -replace "github.com/ava-labs/coreth=${CORETH_PATH}"
-go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250213164614-19ec675e01c4"
+go mod edit -replace "github.com/ava-labs/libevm=github.com/ava-labs/libevm@v0.0.0-20250214081829-bd9b506d6610"
 go mod tidy
 
 echo "building avalanchego"


### PR DESCRIPTION
- Bump libevm dependency to [v1.13.14-0.2.0.rc.3](https://github.com/ava-labs/libevm/releases/tag/v1.13.14-0.2.0.rc.3)
- Add `HeaderExtra` not-implemented implementation
- Minimal changes copied over from #746
- Cherry picked #805 to support libevm release using Go 1.23
- "Gas remaining" slight code changes

This should be the first pull request to get merged into libevm in the series of libevm-phase-2.5 PRs.

## PRs plan

(each of these branches are based off the previous one)

1. This PR: minimal changes for libevm v1.13.14-0.2.0.rc.3
1. Merge master into libevm #812 
1. Re-structure code a bit (no PR yet) using branch [`qdm12/libevm/structure`](https://github.com/ava-labs/coreth/tree/qdm12/libevm/structure)
1. Header extra RLP+JSON implementation PR: #746 
1. Header extra PostCopy hook PR: #759 
1. Body + Block hooks PR: #760
1. core/rawdb InspectDatabase test #790 
1. core/rawdb InspectDatabase uses libevm #791 
1. core/rawdb full replacement #772