### PR TITLE
Improve `plugin/evm/header` tests

### DIFF
--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -522,7 +522,7 @@ func (b *EthAPIBackend) StateAtTransaction(ctx context.Context, block *types.Blo
 }
 
 func (b *EthAPIBackend) MinRequiredTip(ctx context.Context, header *types.Header) (*big.Int, error) {
-	return customheader.MinRequiredTip(b.ChainConfig(), header)
+	return customheader.EstimateRequiredTip(b.ChainConfig(), header)
 }
 
 func (b *EthAPIBackend) isLatestAndAllowed(number rpc.BlockNumber) bool {

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -152,7 +152,7 @@ func newTestBackend(t *testing.T, config *params.ChainConfig, numBlocks int, ext
 }
 
 func (b *testBackend) MinRequiredTip(ctx context.Context, header *types.Header) (*big.Int, error) {
-	return customheader.MinRequiredTip(b.chain.Config(), header)
+	return customheader.EstimateRequiredTip(b.chain.Config(), header)
 }
 
 func (b *testBackend) CurrentHeader() *types.Header {

--- a/params/denomination.go
+++ b/params/denomination.go
@@ -32,6 +32,6 @@ package params
 //	new(big.Int).Mul(value, big.NewInt(params.GWei))
 const (
 	Wei   = 1
-	GWei  = 1e9
-	Ether = 1e18
+	GWei  = 1_000_000_000 * Wei
+	Ether = 1_000_000_000 * GWei
 )

--- a/params/denomination.go
+++ b/params/denomination.go
@@ -32,6 +32,6 @@ package params
 //	new(big.Int).Mul(value, big.NewInt(params.GWei))
 const (
 	Wei   = 1
-	GWei  = 1_000_000_000 * Wei
-	Ether = 1_000_000_000 * GWei
+	GWei  = 1e9
+	Ether = 1e18
 )

--- a/plugin/evm/ap3/window.go
+++ b/plugin/evm/ap3/window.go
@@ -7,7 +7,7 @@ package ap3
 import (
 	"math"
 
-	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/utils"
 	safemath "github.com/ethereum/go-ethereum/common/math"
 )
 
@@ -19,13 +19,13 @@ const (
 	// upgrade.
 	//
 	// This value was modified in Apricot Phase 4.
-	MinBaseFee = 75 * params.GWei
+	MinBaseFee = 75 * utils.GWei
 
 	// MaxBaseFee is the maximum base fee that is allowed after Apricot Phase 3
 	// upgrade.
 	//
 	// This value was modified in Apricot Phase 4.
-	MaxBaseFee = 225 * params.GWei
+	MaxBaseFee = 225 * utils.GWei
 
 	// InitialBaseFee is the base fee that is used for the first Apricot Phase 3
 	// block.

--- a/plugin/evm/ap4/cost.go
+++ b/plugin/evm/ap4/cost.go
@@ -9,7 +9,7 @@ import (
 	"math"
 
 	safemath "github.com/ava-labs/avalanchego/utils/math"
-	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/utils"
 )
 
 const (
@@ -36,13 +36,13 @@ const (
 	// This value modifies the previously used `ap3.MinBaseFee`.
 	//
 	// This value was modified in Etna.
-	MinBaseFee = 25 * params.GWei
+	MinBaseFee = 25 * utils.GWei
 
 	// MaxBaseFee is the maximum base fee that is allowed after Apricot Phase 3
 	// upgrade.
 	//
 	// This value modifies the previously used `ap3.MaxBaseFee`.
-	MaxBaseFee = 1_000 * params.GWei
+	MaxBaseFee = 1_000 * utils.GWei
 )
 
 // BlockGasCost calculates the required block gas cost.

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 )
@@ -1491,7 +1492,7 @@ func TestExportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0]}},
 			ExpectedGasUsed: 1230,
 			ExpectedFee:     30750,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"simple export 225Gwei BaseFee": {
 			UnsignedExportTx: &atomic.UnsignedExportTx{
@@ -1523,7 +1524,7 @@ func TestExportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0]}},
 			ExpectedGasUsed: 1230,
 			ExpectedFee:     276750,
-			BaseFee:         big.NewInt(225 * params.GWei),
+			BaseFee:         big.NewInt(225 * utils.GWei),
 		},
 		"complex export 25Gwei BaseFee": {
 			UnsignedExportTx: &atomic.UnsignedExportTx{
@@ -1567,7 +1568,7 @@ func TestExportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0], testKeys[0], testKeys[0]}},
 			ExpectedGasUsed: 3366,
 			ExpectedFee:     84150,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"complex export 225Gwei BaseFee": {
 			UnsignedExportTx: &atomic.UnsignedExportTx{
@@ -1611,7 +1612,7 @@ func TestExportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0], testKeys[0], testKeys[0]}},
 			ExpectedGasUsed: 3366,
 			ExpectedFee:     757350,
-			BaseFee:         big.NewInt(225 * params.GWei),
+			BaseFee:         big.NewInt(225 * utils.GWei),
 		},
 	}
 

--- a/plugin/evm/gossip_test.go
+++ b/plugin/evm/gossip_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/core/vm"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/prometheus/client_golang/prometheus"
@@ -67,7 +68,7 @@ func TestGossipSubscribe(t *testing.T) {
 	}, 10*time.Second, 500*time.Millisecond, "expected gossipTxPool to be subscribed")
 
 	// create eth txs
-	ethTxs := getValidEthTxs(key, 10, big.NewInt(226*params.GWei))
+	ethTxs := getValidEthTxs(key, 10, big.NewInt(226*utils.GWei))
 
 	// Notify mempool about txs
 	errs := txPool.AddRemotesSync(ethTxs)

--- a/plugin/evm/header/base_fee.go
+++ b/plugin/evm/header/base_fee.go
@@ -17,7 +17,11 @@ var errEstimateBaseFeeWithoutActivation = errors.New("cannot estimate base fee f
 // calculates the expected base fee for the child block.
 //
 // Prior to AP3, the returned base fee will be nil.
-func BaseFee(config *params.ChainConfig, parent *types.Header, timestamp uint64) (*big.Int, error) {
+func BaseFee(
+	config *params.ChainConfig,
+	parent *types.Header,
+	timestamp uint64,
+) (*big.Int, error) {
 	switch {
 	case config.IsApricotPhase3(timestamp):
 		return baseFeeFromWindow(config, parent, timestamp)
@@ -35,7 +39,11 @@ func BaseFee(config *params.ChainConfig, parent *types.Header, timestamp uint64)
 //
 // Warning: This function should only be used in estimation and should not be
 // used when calculating the canonical base fee for a block.
-func EstimateNextBaseFee(config *params.ChainConfig, parent *types.Header, timestamp uint64) (*big.Int, error) {
+func EstimateNextBaseFee(
+	config *params.ChainConfig,
+	parent *types.Header,
+	timestamp uint64,
+) (*big.Int, error) {
 	if config.ApricotPhase3BlockTimestamp == nil {
 		return nil, errEstimateBaseFeeWithoutActivation
 	}

--- a/plugin/evm/header/base_fee_test.go
+++ b/plugin/evm/header/base_fee_test.go
@@ -142,14 +142,14 @@ func TestBaseFee(t *testing.T) {
 			timestamp: 1,
 			want: func() *big.Int {
 				const (
-					gasTarget                  = ap3.TargetGas
-					gasUsed                    = 2*ap3.TargetGas + ap3.IntrinsicBlockGas
-					amountOverTarget           = gasUsed - gasTarget
-					parentBaseFee              = ap3.MinBaseFee
-					smoothingFactor            = ap3.BaseFeeChangeDenominator
-					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
-					delta                      = baseFeeFractionUnderTarget / smoothingFactor
-					baseFee                    = parentBaseFee + delta
+					gasTarget                 = ap3.TargetGas
+					gasUsed                   = 2*ap3.TargetGas + ap3.IntrinsicBlockGas
+					amountOverTarget          = gasUsed - gasTarget
+					parentBaseFee             = ap3.MinBaseFee
+					smoothingFactor           = ap3.BaseFeeChangeDenominator
+					baseFeeFractionOverTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                     = baseFeeFractionOverTarget / smoothingFactor
+					baseFee                   = parentBaseFee + delta
 				)
 				return big.NewInt(baseFee)
 			}(),
@@ -212,14 +212,14 @@ func TestBaseFee(t *testing.T) {
 			timestamp: 1,
 			want: func() *big.Int {
 				const (
-					gasTarget                  = ap3.TargetGas
-					gasUsed                    = 2*ap3.TargetGas + (ap4.TargetBlockRate-1)*ap4.BlockGasCostStep
-					amountOverTarget           = gasUsed - gasTarget
-					parentBaseFee              = ap4.MinBaseFee
-					smoothingFactor            = ap3.BaseFeeChangeDenominator
-					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
-					delta                      = baseFeeFractionUnderTarget / smoothingFactor
-					baseFee                    = parentBaseFee + delta
+					gasTarget                 = ap3.TargetGas
+					gasUsed                   = 2*ap3.TargetGas + (ap4.TargetBlockRate-1)*ap4.BlockGasCostStep
+					amountOverTarget          = gasUsed - gasTarget
+					parentBaseFee             = ap4.MinBaseFee
+					smoothingFactor           = ap3.BaseFeeChangeDenominator
+					baseFeeFractionOverTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                     = baseFeeFractionOverTarget / smoothingFactor
+					baseFee                   = parentBaseFee + delta
 				)
 				return big.NewInt(baseFee)
 			}(),
@@ -268,14 +268,14 @@ func TestBaseFee(t *testing.T) {
 			timestamp: 1,
 			want: func() *big.Int {
 				const (
-					gasTarget                  = ap5.TargetGas
-					gasUsed                    = 2 * ap5.TargetGas
-					amountOverTarget           = gasUsed - gasTarget
-					parentBaseFee              = ap4.MinBaseFee
-					smoothingFactor            = ap5.BaseFeeChangeDenominator
-					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
-					delta                      = baseFeeFractionUnderTarget / smoothingFactor
-					baseFee                    = parentBaseFee + delta
+					gasTarget                 = ap5.TargetGas
+					gasUsed                   = 2 * ap5.TargetGas
+					amountOverTarget          = gasUsed - gasTarget
+					parentBaseFee             = ap4.MinBaseFee
+					smoothingFactor           = ap5.BaseFeeChangeDenominator
+					baseFeeFractionOverTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                     = baseFeeFractionOverTarget / smoothingFactor
+					baseFee                   = parentBaseFee + delta
 				)
 				return big.NewInt(baseFee)
 			}(),
@@ -301,14 +301,14 @@ func TestBaseFee(t *testing.T) {
 			timestamp: 1,
 			want: func() *big.Int {
 				const (
-					gasTarget                  = ap5.TargetGas
-					gasUsed                    = 2 * ap5.TargetGas
-					amountOverTarget           = gasUsed - gasTarget
-					parentBaseFee              = params.EtnaMinBaseFee
-					smoothingFactor            = ap5.BaseFeeChangeDenominator
-					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
-					delta                      = baseFeeFractionUnderTarget / smoothingFactor
-					baseFee                    = parentBaseFee + delta
+					gasTarget                 = ap5.TargetGas
+					gasUsed                   = 2 * ap5.TargetGas
+					amountOverTarget          = gasUsed - gasTarget
+					parentBaseFee             = params.EtnaMinBaseFee
+					smoothingFactor           = ap5.BaseFeeChangeDenominator
+					baseFeeFractionOverTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                     = baseFeeFractionOverTarget / smoothingFactor
+					baseFee                   = parentBaseFee + delta
 				)
 				return big.NewInt(baseFee)
 			}(),

--- a/plugin/evm/header/base_fee_test.go
+++ b/plugin/evm/header/base_fee_test.go
@@ -11,328 +11,344 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/ap3"
 	"github.com/ava-labs/coreth/plugin/evm/ap4"
+	"github.com/ava-labs/coreth/plugin/evm/ap5"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/math"
-	"github.com/ethereum/go-ethereum/log"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
-type blockDefinition struct {
-	timestamp      uint64
-	gasUsed        uint64
-	extDataGasUsed *big.Int
-}
-
-type test struct {
-	blocks         []blockDefinition
-	minFee, maxFee *big.Int
-}
-
-func TestDynamicFees(t *testing.T) {
-	spacedTimestamps := []uint64{1, 1, 2, 5, 15, 120}
-
-	tests := []test{
-		// Test minimal gas usage
-		{
-			minFee: big.NewInt(ap3.MinBaseFee),
-			maxFee: big.NewInt(ap3.MaxBaseFee),
-			blocks: func() []blockDefinition {
-				blocks := make([]blockDefinition, 0, len(spacedTimestamps))
-				for _, timestamp := range spacedTimestamps {
-					blocks = append(blocks, blockDefinition{
-						timestamp: timestamp,
-						gasUsed:   21000,
-					})
-				}
-				return blocks
-			}(),
-		},
-		// Test overflow handling
-		{
-			minFee: big.NewInt(ap3.MinBaseFee),
-			maxFee: big.NewInt(ap3.MaxBaseFee),
-			blocks: func() []blockDefinition {
-				blocks := make([]blockDefinition, 0, len(spacedTimestamps))
-				for _, timestamp := range spacedTimestamps {
-					blocks = append(blocks, blockDefinition{
-						timestamp: timestamp,
-						gasUsed:   math.MaxUint64,
-					})
-				}
-				return blocks
-			}(),
-		},
-		{
-			minFee: big.NewInt(ap3.MinBaseFee),
-			maxFee: big.NewInt(ap3.MaxBaseFee),
-			blocks: []blockDefinition{
-				{
-					timestamp: 1,
-					gasUsed:   1_000_000,
-				},
-				{
-					timestamp: 3,
-					gasUsed:   1_000_000,
-				},
-				{
-					timestamp: 5,
-					gasUsed:   2_000_000,
-				},
-				{
-					timestamp: 5,
-					gasUsed:   6_000_000,
-				},
-				{
-					timestamp: 7,
-					gasUsed:   6_000_000,
-				},
-				{
-					timestamp: 1000,
-					gasUsed:   6_000_000,
-				},
-				{
-					timestamp: 1001,
-					gasUsed:   6_000_000,
-				},
-				{
-					timestamp: 1002,
-					gasUsed:   6_000_000,
-				},
-			},
-		},
-	}
-
-	for _, test := range tests {
-		testDynamicFeesStaysWithinRange(t, test)
-	}
-}
-
-func testDynamicFeesStaysWithinRange(t *testing.T, test test) {
-	blocks := test.blocks
-	initialBlock := blocks[0]
-	header := &types.Header{
-		Time:    initialBlock.timestamp,
-		GasUsed: initialBlock.gasUsed,
-		Number:  big.NewInt(0),
-	}
-
-	for index, block := range blocks[1:] {
-		nextExtraData, err := ExtraPrefix(params.TestApricotPhase3Config, header, block.timestamp)
-		if err != nil {
-			t.Fatalf("Failed to calculate extra prefix at index %d: %s", index, err)
-		}
-		nextBaseFee, err := BaseFee(params.TestApricotPhase3Config, header, block.timestamp)
-		if err != nil {
-			t.Fatalf("Failed to calculate base fee at index %d: %s", index, err)
-		}
-		if nextBaseFee.Cmp(test.maxFee) > 0 {
-			t.Fatalf("Expected fee to stay less than %d, but found %d", test.maxFee, nextBaseFee)
-		}
-		if nextBaseFee.Cmp(test.minFee) < 0 {
-			t.Fatalf("Expected fee to stay greater than %d, but found %d", test.minFee, nextBaseFee)
-		}
-		log.Info("Update", "baseFee", nextBaseFee)
-		header = &types.Header{
-			Time:    block.timestamp,
-			GasUsed: block.gasUsed,
-			Number:  big.NewInt(int64(index) + 1),
-			BaseFee: nextBaseFee,
-			Extra:   nextExtraData,
-		}
-	}
-}
-
-// TestCalcBaseFeeAP4 confirms that the inclusion of ExtDataGasUsage increases
-// the base fee.
-func TestCalcBaseFeeAP4(t *testing.T) {
-	events := []struct {
-		block             blockDefinition
-		extDataFeeGreater bool
+func TestBaseFee(t *testing.T) {
+	tests := []struct {
+		name      string
+		upgrades  params.NetworkUpgrades
+		parent    *types.Header
+		timestamp uint64
+		want      *big.Int
+		wantErr   error
 	}{
 		{
-			block: blockDefinition{
-				timestamp:      1,
-				gasUsed:        1_000_000,
-				extDataGasUsed: big.NewInt(100_000),
-			},
+			name:     "ap2",
+			upgrades: params.TestApricotPhase2Config.NetworkUpgrades,
+			want:     nil,
+			wantErr:  nil,
 		},
 		{
-			block: blockDefinition{
-				timestamp:      3,
-				gasUsed:        1_000_000,
-				extDataGasUsed: big.NewInt(10_000),
+			name: "ap3_first_block",
+			upgrades: params.NetworkUpgrades{
+				ApricotPhase3BlockTimestamp: utils.NewUint64(1),
 			},
-			extDataFeeGreater: true,
+			parent: &types.Header{
+				Number: big.NewInt(1),
+			},
+			timestamp: 1,
+			want:      big.NewInt(ap3.InitialBaseFee),
 		},
 		{
-			block: blockDefinition{
-				timestamp:      5,
-				gasUsed:        2_000_000,
-				extDataGasUsed: big.NewInt(50_000),
+			name:     "ap3_genesis_block",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
 			},
-			extDataFeeGreater: true,
+			want: big.NewInt(ap3.InitialBaseFee),
 		},
 		{
-			block: blockDefinition{
-				timestamp:      5,
-				gasUsed:        6_000_000,
-				extDataGasUsed: big.NewInt(50_000),
+			name:     "ap3_invalid_fee_window",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(1),
 			},
-			extDataFeeGreater: true,
+			wantErr: errDynamicFeeWindowInsufficientLength,
 		},
 		{
-			block: blockDefinition{
-				timestamp:      7,
-				gasUsed:        6_000_000,
-				extDataGasUsed: big.NewInt(0),
+			name:     "ap3_invalid_timestamp",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(1),
+				Time:   1,
+				Extra:  feeWindowBytes(ap3.Window{}),
 			},
-			extDataFeeGreater: true,
+			timestamp: 0,
+			wantErr:   errInvalidTimestamp,
 		},
 		{
-			block: blockDefinition{
-				timestamp:      1000,
-				gasUsed:        6_000_000,
-				extDataGasUsed: big.NewInt(0),
+			name:     "ap3_no_change",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: ap3.TargetGas - ap3.IntrinsicBlockGas,
+				Time:    1,
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap3.MinBaseFee + 1),
 			},
+			timestamp: 1,
+			want:      big.NewInt(ap3.MinBaseFee + 1),
 		},
 		{
-			block: blockDefinition{
-				timestamp:      1001,
-				gasUsed:        6_000_000,
-				extDataGasUsed: big.NewInt(10_000),
+			name:     "ap3_small_decrease",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap3.MaxBaseFee),
 			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap3.TargetGas
+					gasUsed                    = ap3.IntrinsicBlockGas
+					amountUnderTarget          = gasTarget - gasUsed
+					parentBaseFee              = ap3.MaxBaseFee
+					smoothingFactor            = ap3.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountUnderTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee - delta
+				)
+				return big.NewInt(baseFee)
+			}(),
 		},
 		{
-			block: blockDefinition{
-				timestamp:      1002,
-				gasUsed:        6_000_000,
-				extDataGasUsed: big.NewInt(0),
+			name:     "ap3_large_decrease",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap3.MaxBaseFee),
 			},
-			extDataFeeGreater: true,
+			timestamp: 2 * ap3.WindowLen,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap3.TargetGas
+					gasUsed                    = 0
+					amountUnderTarget          = gasTarget - gasUsed
+					parentBaseFee              = ap3.MaxBaseFee
+					smoothingFactor            = ap3.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountUnderTarget * parentBaseFee / gasTarget
+					windowsElapsed             = 2
+					delta                      = windowsElapsed * baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee - delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "ap3_increase",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: 2 * ap3.TargetGas,
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap3.MinBaseFee),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap3.TargetGas
+					gasUsed                    = 2*ap3.TargetGas + ap3.IntrinsicBlockGas
+					amountOverTarget           = gasUsed - gasTarget
+					parentBaseFee              = ap3.MinBaseFee
+					smoothingFactor            = ap3.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee + delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "ap3_big_1_not_modified",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: 1,
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(1),
+			},
+			timestamp: 2 * ap3.WindowLen,
+			want:      big.NewInt(ap3.MinBaseFee),
+		},
+		{
+			name:     "ap4_genesis_block",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
+			},
+			want: big.NewInt(ap3.InitialBaseFee),
+		},
+		{
+			name:     "ap4_decrease",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:       big.NewInt(1),
+				Extra:        feeWindowBytes(ap3.Window{}),
+				BaseFee:      big.NewInt(ap4.MaxBaseFee),
+				BlockGasCost: big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap3.TargetGas
+					gasUsed                    = (ap4.TargetBlockRate - 1) * ap4.BlockGasCostStep
+					amountUnderTarget          = gasTarget - gasUsed
+					parentBaseFee              = ap4.MaxBaseFee
+					smoothingFactor            = ap3.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountUnderTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee - delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "ap4_increase",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:         big.NewInt(1),
+				GasUsed:        ap3.TargetGas,
+				Extra:          feeWindowBytes(ap3.Window{}),
+				BaseFee:        big.NewInt(ap4.MinBaseFee),
+				ExtDataGasUsed: big.NewInt(ap3.TargetGas),
+				BlockGasCost:   big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap3.TargetGas
+					gasUsed                    = 2*ap3.TargetGas + (ap4.TargetBlockRate-1)*ap4.BlockGasCostStep
+					amountOverTarget           = gasUsed - gasTarget
+					parentBaseFee              = ap4.MinBaseFee
+					smoothingFactor            = ap3.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee + delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "ap5_genesis_block",
+			upgrades: params.TestApricotPhase5Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
+			},
+			want: big.NewInt(ap3.InitialBaseFee),
+		},
+		{
+			name:     "ap5_decrease",
+			upgrades: params.TestApricotPhase5Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap4.MaxBaseFee),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap5.TargetGas
+					gasUsed                    = 0
+					amountUnderTarget          = gasTarget - gasUsed
+					parentBaseFee              = ap4.MaxBaseFee
+					smoothingFactor            = ap5.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountUnderTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee - delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "ap5_increase",
+			upgrades: params.TestApricotPhase5Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:         big.NewInt(1),
+				GasUsed:        ap5.TargetGas,
+				Extra:          feeWindowBytes(ap3.Window{}),
+				BaseFee:        big.NewInt(ap4.MinBaseFee),
+				ExtDataGasUsed: big.NewInt(ap5.TargetGas),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap5.TargetGas
+					gasUsed                    = 2 * ap5.TargetGas
+					amountOverTarget           = gasUsed - gasTarget
+					parentBaseFee              = ap4.MinBaseFee
+					smoothingFactor            = ap5.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee + delta
+				)
+				return big.NewInt(baseFee)
+			}(),
+		},
+		{
+			name:     "etna_genesis_block",
+			upgrades: params.TestEtnaChainConfig.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
+			},
+			want: big.NewInt(ap3.InitialBaseFee),
+		},
+		{
+			name:     "etna_increase",
+			upgrades: params.TestEtnaChainConfig.NetworkUpgrades,
+			parent: &types.Header{
+				Number:         big.NewInt(1),
+				GasUsed:        ap5.TargetGas,
+				Extra:          feeWindowBytes(ap3.Window{}),
+				BaseFee:        big.NewInt(params.EtnaMinBaseFee),
+				ExtDataGasUsed: big.NewInt(ap5.TargetGas),
+			},
+			timestamp: 1,
+			want: func() *big.Int {
+				const (
+					gasTarget                  = ap5.TargetGas
+					gasUsed                    = 2 * ap5.TargetGas
+					amountOverTarget           = gasUsed - gasTarget
+					parentBaseFee              = params.EtnaMinBaseFee
+					smoothingFactor            = ap5.BaseFeeChangeDenominator
+					baseFeeFractionUnderTarget = amountOverTarget * parentBaseFee / gasTarget
+					delta                      = baseFeeFractionUnderTarget / smoothingFactor
+					baseFee                    = parentBaseFee + delta
+				)
+				return big.NewInt(baseFee)
+			}(),
 		},
 	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
 
-	header := &types.Header{
-		Time:    0,
-		GasUsed: 1_000_000,
-		Number:  big.NewInt(0),
-		BaseFee: big.NewInt(225 * params.GWei),
-		Extra:   nil,
+			config := &params.ChainConfig{
+				NetworkUpgrades: test.upgrades,
+			}
+			got, err := BaseFee(config, test.parent, test.timestamp)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.want, got)
+
+			// Verify that [common.Big1] is not modified by [BaseFee].
+			require.Equal(big.NewInt(1), common.Big1)
+		})
 	}
-	extDataHeader := &types.Header{
-		Time:    0,
-		GasUsed: 1_000_000,
-		Number:  big.NewInt(0),
-		BaseFee: big.NewInt(225 * params.GWei),
-		Extra:   nil,
-		// ExtDataGasUsage is set to be nil to ensure CalcBaseFee can handle the
-		// AP3/AP4 boundary.
-	}
-
-	for index, event := range events {
-		block := event.block
-		nextExtraData, err := ExtraPrefix(params.TestApricotPhase4Config, header, block.timestamp)
-		assert.NoError(t, err)
-		nextBaseFee, err := BaseFee(params.TestApricotPhase4Config, header, block.timestamp)
-		assert.NoError(t, err)
-		log.Info("Update", "baseFee", nextBaseFee)
-		header = &types.Header{
-			Time:    block.timestamp,
-			GasUsed: block.gasUsed,
-			Number:  big.NewInt(int64(index) + 1),
-			BaseFee: nextBaseFee,
-			Extra:   nextExtraData,
-		}
-
-		nextExtraData, err = ExtraPrefix(params.TestApricotPhase4Config, extDataHeader, block.timestamp)
-		assert.NoError(t, err)
-		nextBaseFee, err = BaseFee(params.TestApricotPhase4Config, extDataHeader, block.timestamp)
-		assert.NoError(t, err)
-		log.Info("Update", "baseFee (w/extData)", nextBaseFee)
-		extDataHeader = &types.Header{
-			Time:           block.timestamp,
-			GasUsed:        block.gasUsed,
-			Number:         big.NewInt(int64(index) + 1),
-			BaseFee:        nextBaseFee,
-			Extra:          nextExtraData,
-			ExtDataGasUsed: block.extDataGasUsed,
-		}
-
-		assert.Equal(t, event.extDataFeeGreater, extDataHeader.BaseFee.Cmp(header.BaseFee) == 1, "unexpected cmp for index %d", index)
-	}
-}
-
-func TestDynamicFeesEtna(t *testing.T) {
-	require := require.New(t)
-	header := &types.Header{
-		Number: big.NewInt(0),
-	}
-
-	timestamp := uint64(1)
-	extra, err := ExtraPrefix(params.TestEtnaChainConfig, header, timestamp)
-	require.NoError(err)
-	nextBaseFee, err := BaseFee(params.TestEtnaChainConfig, header, timestamp)
-	require.NoError(err)
-	// Genesis matches the initial base fee
-	require.Equal(int64(ap3.InitialBaseFee), nextBaseFee.Int64())
-
-	timestamp = uint64(10_000)
-	header = &types.Header{
-		Number:  big.NewInt(1),
-		Time:    header.Time,
-		BaseFee: nextBaseFee,
-		Extra:   extra,
-	}
-	nextBaseFee, err = BaseFee(params.TestEtnaChainConfig, header, timestamp)
-	require.NoError(err)
-	// After some time has passed in the Etna phase, the base fee should drop
-	// lower than the prior base fee minimum.
-	require.Less(nextBaseFee.Int64(), int64(ap4.MinBaseFee))
-}
-
-func TestCalcBaseFeeRegression(t *testing.T) {
-	parentTimestamp := uint64(1)
-	timestamp := parentTimestamp + ap3.WindowLen + 1000
-
-	parentHeader := &types.Header{
-		Time:    parentTimestamp,
-		GasUsed: 14_999_999,
-		Number:  big.NewInt(1),
-		BaseFee: big.NewInt(1),
-		Extra:   make([]byte, FeeWindowSize),
-	}
-
-	_, err := BaseFee(params.TestChainConfig, parentHeader, timestamp)
-	require.NoError(t, err)
-	require.Equalf(t, 0, common.Big1.Cmp(big.NewInt(1)), "big1 should be 1, got %s", common.Big1)
 }
 
 func TestEstimateNextBaseFee(t *testing.T) {
 	tests := []struct {
-		name string
-
-		upgrades params.NetworkUpgrades
-
-		parentTime           uint64
-		parentNumber         int64
-		parentExtra          []byte
-		parentBaseFee        *big.Int
-		parentGasUsed        uint64
-		parentExtDataGasUsed *big.Int
-
+		name      string
+		upgrades  params.NetworkUpgrades
+		parent    *types.Header
 		timestamp uint64
-
-		want    *big.Int
-		wantErr error
+		want      *big.Int
+		wantErr   error
 	}{
 		{
-			name:          "ap3",
-			upgrades:      params.TestApricotPhase3Config.NetworkUpgrades,
-			parentNumber:  1,
-			parentExtra:   feeWindowBytes(ap3.Window{}),
-			parentBaseFee: big.NewInt(ap3.MaxBaseFee),
-			timestamp:     1,
+			name:     "ap3",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				Extra:   feeWindowBytes(ap3.Window{}),
+				BaseFee: big.NewInt(ap3.MaxBaseFee),
+			},
+			timestamp: 1,
 			want: func() *big.Int {
 				const (
 					gasTarget                  = ap3.TargetGas
@@ -360,16 +376,7 @@ func TestEstimateNextBaseFee(t *testing.T) {
 			config := &params.ChainConfig{
 				NetworkUpgrades: test.upgrades,
 			}
-			parentHeader := &types.Header{
-				Time:           test.parentTime,
-				Number:         big.NewInt(test.parentNumber),
-				Extra:          test.parentExtra,
-				BaseFee:        test.parentBaseFee,
-				GasUsed:        test.parentGasUsed,
-				ExtDataGasUsed: test.parentExtDataGasUsed,
-			}
-
-			got, err := EstimateNextBaseFee(config, parentHeader, test.timestamp)
+			got, err := EstimateNextBaseFee(config, test.parent, test.timestamp)
 			require.ErrorIs(err, test.wantErr)
 			require.Equal(test.want, got)
 		})

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -69,37 +69,38 @@ func BlockGasCostWithStep(
 	)
 }
 
-// MinRequiredTip is the estimated minimum tip a transaction would have
-// needed to pay to be included in a given block (assuming it paid a tip
-// proportional to its gas usage). In reality, there is no minimum tip that
-// is enforced by the consensus engine and high tip paying transactions can
-// subsidize the inclusion of low tip paying transactions. The only
-// correctness check performed is that the sum of all tips is >= the
-// required block fee.
+// EstimateRequiredTip is the estimated tip a transaction would have needed to
+// pay to be included in a given block (assuming it paid a tip proportional to
+// its gas usage).
+//
+// In reality, there is no minimum tip that is enforced by the consensus engine
+// and high tip paying transactions can subsidize the inclusion of low tip
+// paying transactions. The only correctness check performed is that the sum of
+// all tips is >= the required block fee.
 //
 // This function will return nil for all return values prior to Apricot Phase 4.
-func MinRequiredTip(config *params.ChainConfig, header *types.Header) (*big.Int, error) {
-	if !config.IsApricotPhase4(header.Time) {
+func EstimateRequiredTip(
+	config *params.ChainConfig,
+	header *types.Header,
+) (*big.Int, error) {
+	switch {
+	case !config.IsApricotPhase4(header.Time):
 		return nil, nil
-	}
-	if header.BaseFee == nil {
+	case header.BaseFee == nil:
 		return nil, errBaseFeeNil
-	}
-	if header.BlockGasCost == nil {
+	case header.ExtDataGasUsed == nil:
+		return nil, errExtDataGasUsedNil
+	case header.BlockGasCost == nil:
 		return nil, errBlockGasCostNil
 	}
-	if header.ExtDataGasUsed == nil {
-		return nil, errExtDataGasUsedNil
-	}
 
-	// minTip = requiredBlockFee/blockGasUsage
-	requiredBlockFee := new(big.Int).Mul(
-		header.BlockGasCost,
-		header.BaseFee,
-	)
-	blockGasUsage := new(big.Int).Add(
-		new(big.Int).SetUint64(header.GasUsed),
-		header.ExtDataGasUsed,
-	)
-	return new(big.Int).Div(requiredBlockFee, blockGasUsage), nil
+	// totalGasUsed = GasUsed + ExtDataGasUsed
+	totalGasUsed := new(big.Int).SetUint64(header.GasUsed)
+	totalGasUsed.Add(totalGasUsed, header.ExtDataGasUsed)
+
+	// requiredTip = (blockGasCost * baseFee) / totalGasUsed
+	requiredTip := new(big.Int)
+	requiredTip.Mul(header.BlockGasCost, header.BaseFee) // Total required fee
+	requiredTip.Div(requiredTip, totalGasUsed)
+	return requiredTip, nil
 }

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -73,10 +73,9 @@ func BlockGasCostWithStep(
 // pay to be included in a given block (assuming it paid a tip proportional to
 // its gas usage).
 //
-// In reality, there is no minimum tip that is enforced by the consensus engine
-// and high tip paying transactions can subsidize the inclusion of low tip
-// paying transactions. The only correctness check performed is that the sum of
-// all tips is >= the required block fee.
+// In reality, the consensus engine does not enforce a minimum tip on individual
+// transactions. The only correctness check performed is that the sum of all
+// tips is >= the required block fee.
 //
 // This function will return nil for all return values prior to Apricot Phase 4.
 func EstimateRequiredTip(
@@ -102,7 +101,7 @@ func EstimateRequiredTip(
 	totalRequiredTips := new(big.Int)
 	totalRequiredTips.Mul(header.BlockGasCost, header.BaseFee)
 
-	// requiredTip = totalRequiredTips / totalGasUsed
-	requiredTip := totalRequiredTips.Div(totalRequiredTips, totalGasUsed)
-	return requiredTip, nil
+	// estimatedTip = totalRequiredTips / totalGasUsed
+	estimatedTip := totalRequiredTips.Div(totalRequiredTips, totalGasUsed)
+	return estimatedTip, nil
 }

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -98,9 +98,11 @@ func EstimateRequiredTip(
 	totalGasUsed := new(big.Int).SetUint64(header.GasUsed)
 	totalGasUsed.Add(totalGasUsed, header.ExtDataGasUsed)
 
-	// requiredTip = (blockGasCost * baseFee) / totalGasUsed
-	requiredTip := new(big.Int)
-	requiredTip.Mul(header.BlockGasCost, header.BaseFee) // Total required fee
-	requiredTip.Div(requiredTip, totalGasUsed)
+	// totalRequiredTips = blockGasCost * baseFee
+	totalRequiredTips := new(big.Int)
+	totalRequiredTips.Mul(header.BlockGasCost, header.BaseFee)
+
+	// requiredTip = totalRequiredTips / totalGasUsed
+	requiredTip := totalRequiredTips.Div(totalRequiredTips, totalGasUsed)
 	return requiredTip, nil
 }

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -88,10 +88,10 @@ func EstimateRequiredTip(
 		return nil, nil
 	case header.BaseFee == nil:
 		return nil, errBaseFeeNil
-	case header.ExtDataGasUsed == nil:
-		return nil, errExtDataGasUsedNil
 	case header.BlockGasCost == nil:
 		return nil, errBlockGasCostNil
+	case header.ExtDataGasUsed == nil:
+		return nil, errExtDataGasUsedNil
 	}
 
 	// totalGasUsed = GasUsed + ExtDataGasUsed

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -185,15 +185,6 @@ func TestEstimateRequiredTip(t *testing.T) {
 			wantErr: errBaseFeeNil,
 		},
 		{
-			name:         "nil_extra_data_gas_used",
-			ap4Timestamp: utils.NewUint64(0),
-			header: &types.Header{
-				BaseFee:      big.NewInt(1),
-				BlockGasCost: big.NewInt(1),
-			},
-			wantErr: errExtDataGasUsedNil,
-		},
-		{
 			name:         "nil_block_gas_cost",
 			ap4Timestamp: utils.NewUint64(0),
 			header: &types.Header{
@@ -201,6 +192,15 @@ func TestEstimateRequiredTip(t *testing.T) {
 				ExtDataGasUsed: big.NewInt(1),
 			},
 			wantErr: errBlockGasCostNil,
+		},
+		{
+			name:         "nil_extra_data_gas_used",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				BaseFee:      big.NewInt(1),
+				BlockGasCost: big.NewInt(1),
+			},
+			wantErr: errExtDataGasUsedNil,
 		},
 		{
 			name:         "success",

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -211,8 +211,8 @@ func TestEstimateRequiredTip(t *testing.T) {
 				ExtDataGasUsed: big.NewInt(789),
 				BlockGasCost:   big.NewInt(101112),
 			},
-			// totalRequiredTips = BlockGasCost * BaseFee
 			// totalGasUsed = GasUsed + ExtDataGasUsed
+			// totalRequiredTips = BlockGasCost * BaseFee
 			// requiredTip = totalRequiredTips / totalGasUsed
 			want: big.NewInt((101112 * 456) / (123 + 789)),
 		},

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -207,13 +207,13 @@ func TestEstimateRequiredTip(t *testing.T) {
 			ap4Timestamp: utils.NewUint64(0),
 			header: &types.Header{
 				GasUsed:        123,
-				BaseFee:        big.NewInt(456),
 				ExtDataGasUsed: big.NewInt(789),
+				BaseFee:        big.NewInt(456),
 				BlockGasCost:   big.NewInt(101112),
 			},
 			// totalGasUsed = GasUsed + ExtDataGasUsed
 			// totalRequiredTips = BlockGasCost * BaseFee
-			// requiredTip = totalRequiredTips / totalGasUsed
+			// estimatedTip = totalRequiredTips / totalGasUsed
 			want: big.NewInt((101112 * 456) / (123 + 789)),
 		},
 	}

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -13,16 +13,17 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/ap5"
 	"github.com/ava-labs/coreth/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestBlockGasCost(t *testing.T) {
 	tests := []struct {
-		name                        string
-		apricotPhase5BlockTimestamp *uint64
-		parentTime                  uint64
-		parentCost                  *big.Int
-		timestamp                   uint64
-		expected                    uint64
+		name         string
+		ap5Timestamp *uint64
+		parentTime   uint64
+		parentCost   *big.Int
+		timestamp    uint64
+		expected     uint64
 	}{
 		{
 			name:       "normal_ap4",
@@ -32,12 +33,12 @@ func TestBlockGasCost(t *testing.T) {
 			expected:   ap4.MaxBlockGasCost - ap4.BlockGasCostStep,
 		},
 		{
-			name:                        "normal_ap5",
-			apricotPhase5BlockTimestamp: utils.NewUint64(0),
-			parentTime:                  10,
-			parentCost:                  big.NewInt(ap4.MaxBlockGasCost),
-			timestamp:                   10 + ap4.TargetBlockRate + 1,
-			expected:                    ap4.MaxBlockGasCost - ap5.BlockGasCostStep,
+			name:         "normal_ap5",
+			ap5Timestamp: utils.NewUint64(0),
+			parentTime:   10,
+			parentCost:   big.NewInt(ap4.MaxBlockGasCost),
+			timestamp:    10 + ap4.TargetBlockRate + 1,
+			expected:     ap4.MaxBlockGasCost - ap5.BlockGasCostStep,
 		},
 		{
 			name:       "negative_time_elapsed",
@@ -52,7 +53,7 @@ func TestBlockGasCost(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			config := &params.ChainConfig{
 				NetworkUpgrades: params.NetworkUpgrades{
-					ApricotPhase5BlockTimestamp: test.apricotPhase5BlockTimestamp,
+					ApricotPhase5BlockTimestamp: test.ap5Timestamp,
 				},
 			}
 			parent := &types.Header{
@@ -157,6 +158,77 @@ func TestBlockGasCostWithStep(t *testing.T) {
 				ap4.BlockGasCostStep,
 				test.timeElapsed,
 			))
+		})
+	}
+}
+
+func TestEstimateRequiredTip(t *testing.T) {
+	tests := []struct {
+		name         string
+		ap4Timestamp *uint64
+		header       *types.Header
+		want         *big.Int
+		wantErr      error
+	}{
+		{
+			name:         "not_ap4",
+			ap4Timestamp: utils.NewUint64(1),
+			header:       &types.Header{},
+		},
+		{
+			name:         "nil_base_fee",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				ExtDataGasUsed: big.NewInt(1),
+				BlockGasCost:   big.NewInt(1),
+			},
+			wantErr: errBaseFeeNil,
+		},
+		{
+			name:         "nil_extra_data_gas_used",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				BaseFee:      big.NewInt(1),
+				BlockGasCost: big.NewInt(1),
+			},
+			wantErr: errExtDataGasUsedNil,
+		},
+		{
+			name:         "nil_block_gas_cost",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				BaseFee:        big.NewInt(1),
+				ExtDataGasUsed: big.NewInt(1),
+			},
+			wantErr: errBlockGasCostNil,
+		},
+		{
+			name:         "success",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				GasUsed:        123,
+				BaseFee:        big.NewInt(456),
+				ExtDataGasUsed: big.NewInt(789),
+				BlockGasCost:   big.NewInt(101112),
+			},
+			// totalRequiredTips = BlockGasCost * BaseFee
+			// totalGasUsed = GasUsed + ExtDataGasUsed
+			// requiredTip = totalRequiredTips / totalGasUsed
+			want: big.NewInt((101112 * 456) / (123 + 789)),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			config := &params.ChainConfig{
+				NetworkUpgrades: params.NetworkUpgrades{
+					ApricotPhase4BlockTimestamp: test.ap4Timestamp,
+				},
+			}
+			requiredTip, err := EstimateRequiredTip(config, test.header)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.want, requiredTip)
 		})
 	}
 }

--- a/plugin/evm/header/dynamic_fee_windower.go
+++ b/plugin/evm/header/dynamic_fee_windower.go
@@ -40,6 +40,7 @@ var (
 	ap3BaseFeeChangeDenominator = big.NewInt(ap3.BaseFeeChangeDenominator)
 	ap5BaseFeeChangeDenominator = big.NewInt(ap5.BaseFeeChangeDenominator)
 
+	errInvalidTimestamp                   = errors.New("invalid timestamp")
 	errDynamicFeeWindowInsufficientLength = errors.New("insufficient length for dynamic fee window")
 )
 
@@ -169,7 +170,8 @@ func feeWindow(
 	}
 
 	if timestamp < parent.Time {
-		return ap3.Window{}, fmt.Errorf("cannot calculate fee window for timestamp %d prior to parent timestamp %d",
+		return ap3.Window{}, fmt.Errorf("%w: timestamp %d prior to parent timestamp %d",
+			errInvalidTimestamp,
 			timestamp,
 			parent.Time,
 		)

--- a/plugin/evm/header/extra_test.go
+++ b/plugin/evm/header/extra_test.go
@@ -4,11 +4,237 @@
 package header
 
 import (
+	"math/big"
 	"testing"
 
+	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/ap3"
+	"github.com/ava-labs/coreth/plugin/evm/ap4"
+	"github.com/ava-labs/coreth/plugin/evm/ap5"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/stretchr/testify/require"
 )
+
+func TestExtraPrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		upgrades  params.NetworkUpgrades
+		parent    *types.Header
+		timestamp uint64
+		want      []byte
+		wantErr   error
+	}{
+		{
+			name:     "ap2",
+			upgrades: params.TestApricotPhase2Config.NetworkUpgrades,
+			want:     nil,
+			wantErr:  nil,
+		},
+		{
+			name: "ap3_first_block",
+			upgrades: params.NetworkUpgrades{
+				ApricotPhase3BlockTimestamp: utils.NewUint64(1),
+			},
+			parent: &types.Header{
+				Number: big.NewInt(1),
+			},
+			timestamp: 1,
+			want:      feeWindowBytes(ap3.Window{}),
+		},
+		{
+			name:     "ap3_genesis_block",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
+			},
+			want: feeWindowBytes(ap3.Window{}),
+		},
+		{
+			name:     "ap3_invalid_fee_window",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(1),
+			},
+			wantErr: errDynamicFeeWindowInsufficientLength,
+		},
+		{
+			name:     "ap3_invalid_timestamp",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(1),
+				Time:   1,
+				Extra:  feeWindowBytes(ap3.Window{}),
+			},
+			timestamp: 0,
+			wantErr:   errInvalidTimestamp,
+		},
+		{
+			name:     "ap3_normal",
+			upgrades: params.TestApricotPhase3Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: ap3.TargetGas,
+				Extra: feeWindowBytes(ap3.Window{
+					1, 2, 3, 4,
+				}),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				window := ap3.Window{
+					1, 2, 3, 4,
+				}
+				window.Add(ap3.TargetGas, ap3.IntrinsicBlockGas)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap4_genesis_block",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number: big.NewInt(0),
+			},
+			want: feeWindowBytes(ap3.Window{}),
+		},
+		{
+			name:     "ap4_no_block_gas_cost",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: ap3.TargetGas,
+				Extra:   feeWindowBytes(ap3.Window{}),
+			},
+			timestamp: 2,
+			want: func() []byte {
+				var window ap3.Window
+				window.Add(ap3.TargetGas)
+				window.Shift(2)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap4_with_block_gas_cost",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:       big.NewInt(1),
+				GasUsed:      ap3.TargetGas,
+				Extra:        feeWindowBytes(ap3.Window{}),
+				BlockGasCost: big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				var window ap3.Window
+				window.Add(
+					ap3.TargetGas,
+					(ap4.TargetBlockRate-1)*ap4.BlockGasCostStep,
+				)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap4_with_extra_data_gas",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:         big.NewInt(1),
+				GasUsed:        ap3.TargetGas,
+				Extra:          feeWindowBytes(ap3.Window{}),
+				ExtDataGasUsed: big.NewInt(5),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				var window ap3.Window
+				window.Add(
+					ap3.TargetGas,
+					5,
+				)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap4_normal",
+			upgrades: params.TestApricotPhase4Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: ap3.TargetGas,
+				Extra: feeWindowBytes(ap3.Window{
+					1, 2, 3, 4,
+				}),
+				ExtDataGasUsed: big.NewInt(5),
+				BlockGasCost:   big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				window := ap3.Window{
+					1, 2, 3, 4,
+				}
+				window.Add(
+					ap3.TargetGas,
+					5,
+					(ap4.TargetBlockRate-1)*ap4.BlockGasCostStep,
+				)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap5_no_extra_data_gas",
+			upgrades: params.TestApricotPhase5Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:       big.NewInt(1),
+				GasUsed:      ap5.TargetGas,
+				Extra:        feeWindowBytes(ap3.Window{}),
+				BlockGasCost: big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				var window ap3.Window
+				window.Add(ap5.TargetGas)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+		{
+			name:     "ap5_normal",
+			upgrades: params.TestApricotPhase5Config.NetworkUpgrades,
+			parent: &types.Header{
+				Number:  big.NewInt(1),
+				GasUsed: ap5.TargetGas,
+				Extra: feeWindowBytes(ap3.Window{
+					1, 2, 3, 4,
+				}),
+				ExtDataGasUsed: big.NewInt(5),
+				BlockGasCost:   big.NewInt(ap4.MinBlockGasCost),
+			},
+			timestamp: 1,
+			want: func() []byte {
+				window := ap3.Window{
+					1, 2, 3, 4,
+				}
+				window.Add(
+					ap5.TargetGas,
+					5,
+				)
+				window.Shift(1)
+				return feeWindowBytes(window)
+			}(),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			config := &params.ChainConfig{
+				NetworkUpgrades: test.upgrades,
+			}
+			got, err := ExtraPrefix(config, test.parent, test.timestamp)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.want, got)
+		})
+	}
+}
 
 func TestVerifyExtra(t *testing.T) {
 	tests := []struct {

--- a/plugin/evm/import_tx_test.go
+++ b/plugin/evm/import_tx_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/coreth/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/holiman/uint256"
 
@@ -574,7 +575,7 @@ func TestImportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0]}},
 			ExpectedGasUsed: 1230,
 			ExpectedFee:     30750,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"simple import 1wei": {
 			UnsignedImportTx: &atomic.UnsignedImportTx{
@@ -659,7 +660,7 @@ func TestImportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0]}, {testKeys[0]}},
 			ExpectedGasUsed: 2318,
 			ExpectedFee:     57950,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"complex ANT import": {
 			UnsignedImportTx: &atomic.UnsignedImportTx{
@@ -700,7 +701,7 @@ func TestImportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0]}, {testKeys[0]}},
 			ExpectedGasUsed: 2378,
 			ExpectedFee:     59450,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"multisig import": {
 			UnsignedImportTx: &atomic.UnsignedImportTx{
@@ -724,7 +725,7 @@ func TestImportTxGasCost(t *testing.T) {
 			Keys:            [][]*secp256k1.PrivateKey{{testKeys[0], testKeys[1]}},
 			ExpectedGasUsed: 2234,
 			ExpectedFee:     55850,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 		"large import": {
 			UnsignedImportTx: &atomic.UnsignedImportTx{
@@ -835,7 +836,7 @@ func TestImportTxGasCost(t *testing.T) {
 			},
 			ExpectedGasUsed: 11022,
 			ExpectedFee:     275550,
-			BaseFee:         big.NewInt(25 * params.GWei),
+			BaseFee:         big.NewInt(25 * utils.GWei),
 		},
 	}
 

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/coreth/utils"
 
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
 	"github.com/ava-labs/avalanchego/ids"
@@ -36,7 +37,7 @@ func TestCalculateDynamicFee(t *testing.T) {
 		},
 		{
 			gas:           21000,
-			baseFee:       big.NewInt(25 * params.GWei),
+			baseFee:       big.NewInt(25 * utils.GWei),
 			expectedValue: 525000,
 		},
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3276,7 +3276,7 @@ func TestBuildApricotPhase4Block(t *testing.T) {
 	if eExtDataGasUsed := ethBlk.ExtDataGasUsed(); eExtDataGasUsed == nil || eExtDataGasUsed.Cmp(big.NewInt(1230)) != 0 {
 		t.Fatalf("expected extDataGasUsed to be 1000 but got %d", eExtDataGasUsed)
 	}
-	minRequiredTip, err := header.MinRequiredTip(vm.chainConfig, ethBlk.Header())
+	minRequiredTip, err := header.EstimateRequiredTip(vm.chainConfig, ethBlk.Header())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3335,7 +3335,7 @@ func TestBuildApricotPhase4Block(t *testing.T) {
 	if ethBlk.ExtDataGasUsed() == nil || ethBlk.ExtDataGasUsed().Cmp(common.Big0) != 0 {
 		t.Fatalf("expected extDataGasUsed to be 0 but got %d", ethBlk.ExtDataGasUsed())
 	}
-	minRequiredTip, err = header.MinRequiredTip(vm.chainConfig, ethBlk.Header())
+	minRequiredTip, err = header.EstimateRequiredTip(vm.chainConfig, ethBlk.Header())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3446,7 +3446,7 @@ func TestBuildApricotPhase5Block(t *testing.T) {
 	if eExtDataGasUsed := ethBlk.ExtDataGasUsed(); eExtDataGasUsed == nil || eExtDataGasUsed.Cmp(big.NewInt(11230)) != 0 {
 		t.Fatalf("expected extDataGasUsed to be 11230 but got %d", eExtDataGasUsed)
 	}
-	minRequiredTip, err := header.MinRequiredTip(vm.chainConfig, ethBlk.Header())
+	minRequiredTip, err := header.EstimateRequiredTip(vm.chainConfig, ethBlk.Header())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -3497,7 +3497,7 @@ func TestBuildApricotPhase5Block(t *testing.T) {
 	if ethBlk.ExtDataGasUsed() == nil || ethBlk.ExtDataGasUsed().Cmp(common.Big0) != 0 {
 		t.Fatalf("expected extDataGasUsed to be 0 but got %d", ethBlk.ExtDataGasUsed())
 	}
-	minRequiredTip, err = header.MinRequiredTip(vm.chainConfig, ethBlk.Header())
+	minRequiredTip, err = header.EstimateRequiredTip(vm.chainConfig, ethBlk.Header())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3339,7 +3339,7 @@ func TestBuildApricotPhase4Block(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if minRequiredTip == nil || minRequiredTip.Cmp(big.NewInt(0.05*params.GWei)) < 0 {
+	if minRequiredTip == nil || minRequiredTip.Cmp(big.NewInt(0.05*utils.GWei)) < 0 {
 		t.Fatalf("expected minRequiredTip to be at least 0.05 gwei but got %d", minRequiredTip)
 	}
 
@@ -3501,7 +3501,7 @@ func TestBuildApricotPhase5Block(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if minRequiredTip == nil || minRequiredTip.Cmp(big.NewInt(0.05*params.GWei)) < 0 {
+	if minRequiredTip == nil || minRequiredTip.Cmp(big.NewInt(0.05*utils.GWei)) < 0 {
 		t.Fatalf("expected minRequiredTip to be at least 0.05 gwei but got %d", minRequiredTip)
 	}
 

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -327,7 +327,7 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 	require.NoError(err)
 
 	createTx, err := types.SignTx(
-		types.NewContractCreation(0, common.Big0, 7_000_000, big.NewInt(225*params.GWei), common.Hex2Bytes(exampleWarpBin)),
+		types.NewContractCreation(0, common.Big0, 7_000_000, big.NewInt(225*utils.GWei), common.Hex2Bytes(exampleWarpBin)),
 		types.LatestSignerForChainID(vm.chainConfig.ChainID),
 		testKeys[0].ToECDSA(),
 	)
@@ -340,8 +340,8 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 			1,
 			&exampleWarpAddress,
 			1_000_000,
-			big.NewInt(225*params.GWei),
-			big.NewInt(params.GWei),
+			big.NewInt(225*utils.GWei),
+			big.NewInt(utils.GWei),
 			common.Big0,
 			txPayload,
 			types.AccessList{},
@@ -622,8 +622,8 @@ func testReceiveWarpMessage(
 			vm.txPool.Nonce(testEthAddrs[0]),
 			&warpcontract.Module.Address,
 			1_000_000,
-			big.NewInt(225*params.GWei),
-			big.NewInt(params.GWei),
+			big.NewInt(225*utils.GWei),
+			big.NewInt(utils.GWei),
 			common.Big0,
 			getWarpMsgInput,
 			types.AccessList{},

--- a/utils/denomination.go
+++ b/utils/denomination.go
@@ -1,0 +1,10 @@
+// (c) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package utils
+
+const (
+	Wei   = 1
+	GWei  = 1_000_000_000 * Wei
+	Ether = 1_000_000_000 * GWei
+)


### PR DESCRIPTION
## Why this should be merged

This PR primarily cleans up the tests in the `plugin/evm/header` package.

Additionally, it slightly cleans up the `MinRequiredTip` function and renames it to `EstimateRequiredTip` to align with the `EstimateNextBaseFee` function.

## How this works

1. Add tests
2. Rename

## How this was tested

CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.