### PR TITLE
chore(core/types): code restructure to accomodate future libevm changes

### DIFF
--- a/core/types/imports.go
+++ b/core/types/imports.go
@@ -23,6 +23,8 @@ type (
 	ReceiptForStorage = ethtypes.ReceiptForStorage
 	Receipts          = ethtypes.Receipts
 	Signer            = ethtypes.Signer
+	SlimAccount       = ethtypes.SlimAccount
+	StateAccount      = ethtypes.StateAccount
 	Transaction       = ethtypes.Transaction
 	Transactions      = ethtypes.Transactions
 	TxByNonce         = ethtypes.TxByNonce
@@ -45,12 +47,16 @@ const (
 
 // The following functions are used directly as their upstream definitions.
 var (
-	BloomLookup         = ethtypes.BloomLookup
-	BytesToBloom        = ethtypes.BytesToBloom
-	CreateBloom         = ethtypes.CreateBloom
-	NewContractCreation = ethtypes.NewContractCreation
-	NewReceipt          = ethtypes.NewReceipt
-	NewTransaction      = ethtypes.NewTransaction
+	BloomLookup          = ethtypes.BloomLookup
+	BytesToBloom         = ethtypes.BytesToBloom
+	CreateBloom          = ethtypes.CreateBloom
+	FullAccount          = ethtypes.FullAccount
+	FullAccountRLP       = ethtypes.FullAccountRLP
+	NewContractCreation  = ethtypes.NewContractCreation
+	NewEmptyStateAccount = ethtypes.NewEmptyStateAccount
+	NewReceipt           = ethtypes.NewReceipt
+	NewTransaction       = ethtypes.NewTransaction
+	SlimAccountRLP       = ethtypes.SlimAccountRLP
 
 	// Signers
 	LatestSigner           = ethtypes.LatestSigner

--- a/core/types/imports.go
+++ b/core/types/imports.go
@@ -11,23 +11,22 @@ import (
 // So we list them all here to avoid having many individual files.
 type (
 	AccessList        = ethtypes.AccessList
-	AccessTuple       = ethtypes.AccessTuple
 	AccessListTx      = ethtypes.AccessListTx
-	Bloom             = ethtypes.Bloom
-	Receipt           = ethtypes.Receipt
-	Receipts          = ethtypes.Receipts
-	ReceiptForStorage = ethtypes.ReceiptForStorage
-	LegacyTx          = ethtypes.LegacyTx
-	DynamicFeeTx      = ethtypes.DynamicFeeTx
+	AccessTuple       = ethtypes.AccessTuple
 	BlobTx            = ethtypes.BlobTx
 	BlobTxSidecar     = ethtypes.BlobTxSidecar
-	Signer            = ethtypes.Signer
+	Bloom             = ethtypes.Bloom
+	DynamicFeeTx      = ethtypes.DynamicFeeTx
 	HomesteadSigner   = ethtypes.HomesteadSigner
-
-	Transaction  = ethtypes.Transaction
-	Transactions = ethtypes.Transactions
-	TxByNonce    = ethtypes.TxByNonce
-	TxData       = ethtypes.TxData
+	LegacyTx          = ethtypes.LegacyTx
+	Receipt           = ethtypes.Receipt
+	ReceiptForStorage = ethtypes.ReceiptForStorage
+	Receipts          = ethtypes.Receipts
+	Signer            = ethtypes.Signer
+	Transaction       = ethtypes.Transaction
+	Transactions      = ethtypes.Transactions
+	TxByNonce         = ethtypes.TxByNonce
+	TxData            = ethtypes.TxData
 )
 
 // The following constants are used directly as their upstream definitions.
@@ -38,10 +37,10 @@ const (
 	ReceiptStatusSuccessful = ethtypes.ReceiptStatusSuccessful
 
 	// Transaction types.
-	LegacyTxType     = ethtypes.LegacyTxType
 	AccessListTxType = ethtypes.AccessListTxType
-	DynamicFeeTxType = ethtypes.DynamicFeeTxType
 	BlobTxType       = ethtypes.BlobTxType
+	DynamicFeeTxType = ethtypes.DynamicFeeTxType
+	LegacyTxType     = ethtypes.LegacyTxType
 )
 
 // The following functions are used directly as their upstream definitions.
@@ -49,28 +48,28 @@ var (
 	BloomLookup         = ethtypes.BloomLookup
 	BytesToBloom        = ethtypes.BytesToBloom
 	CreateBloom         = ethtypes.CreateBloom
-	NewReceipt          = ethtypes.NewReceipt
 	NewContractCreation = ethtypes.NewContractCreation
+	NewReceipt          = ethtypes.NewReceipt
 	NewTransaction      = ethtypes.NewTransaction
 
 	// Signers
+	LatestSigner           = ethtypes.LatestSigner
+	LatestSignerForChainID = ethtypes.LatestSignerForChainID
+	MakeSigner             = ethtypes.MakeSigner
+	MustSignNewTx          = ethtypes.MustSignNewTx
+	NewCancunSigner        = ethtypes.NewCancunSigner
 	NewEIP155Signer        = ethtypes.NewEIP155Signer
 	NewEIP2930Signer       = ethtypes.NewEIP2930Signer
 	NewLondonSigner        = ethtypes.NewLondonSigner
-	NewCancunSigner        = ethtypes.NewCancunSigner
-	MakeSigner             = ethtypes.MakeSigner
-	LatestSigner           = ethtypes.LatestSigner
-	LatestSignerForChainID = ethtypes.LatestSignerForChainID
-	SignTx                 = ethtypes.SignTx
-	SignNewTx              = ethtypes.SignNewTx
-	MustSignNewTx          = ethtypes.MustSignNewTx
 	Sender                 = ethtypes.Sender
+	SignNewTx              = ethtypes.SignNewTx
+	SignTx                 = ethtypes.SignTx
 
 	// Transactions
 	NewTx        = ethtypes.NewTx
 	TxDifference = ethtypes.TxDifference
 
 	// Errors
-	ErrTxTypeNotSupported = ethtypes.ErrTxTypeNotSupported
 	ErrGasFeeCapTooLow    = ethtypes.ErrGasFeeCapTooLow
+	ErrTxTypeNotSupported = ethtypes.ErrTxTypeNotSupported
 )

--- a/core/types/libevm.go
+++ b/core/types/libevm.go
@@ -1,0 +1,14 @@
+// (c) 2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package types
+
+import (
+	ethtypes "github.com/ava-labs/libevm/core/types"
+)
+
+var extras = ethtypes.RegisterExtras[
+	ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks,
+	ethtypes.NOOPBlockBodyHooks, *ethtypes.NOOPBlockBodyHooks,
+	isMultiCoin,
+]()

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -1,4 +1,4 @@
-// (c) 2019-2021, Ava Labs, Inc.
+// (c) 2019-2025, Ava Labs, Inc.
 //
 // This file is a derived work, based on the go-ethereum library whose original
 // notices appear below.
@@ -28,20 +28,6 @@ package types
 
 import (
 	ethtypes "github.com/ava-labs/libevm/core/types"
-)
-
-type (
-	// Import these types from the go-ethereum package
-	StateAccount = ethtypes.StateAccount
-	SlimAccount  = ethtypes.SlimAccount
-)
-
-var (
-	// Import these functions from the go-ethereum package
-	NewEmptyStateAccount = ethtypes.NewEmptyStateAccount
-	SlimAccountRLP       = ethtypes.SlimAccountRLP
-	FullAccount          = ethtypes.FullAccount
-	FullAccountRLP       = ethtypes.FullAccountRLP
 )
 
 type isMultiCoin bool

--- a/core/types/state_account.go
+++ b/core/types/state_account.go
@@ -32,14 +32,7 @@ import (
 
 type isMultiCoin bool
 
-var (
-	extras = ethtypes.RegisterExtras[
-		ethtypes.NOOPHeaderHooks, *ethtypes.NOOPHeaderHooks,
-		ethtypes.NOOPBlockBodyHooks, *ethtypes.NOOPBlockBodyHooks,
-		isMultiCoin,
-	]()
-	IsMultiCoinPayloads = extras.StateAccount
-)
+var IsMultiCoinPayloads = extras.StateAccount
 
 func IsMultiCoin(s ethtypes.StateOrSlimAccount) bool {
 	return bool(IsMultiCoinPayloads.Get(s))


### PR DESCRIPTION
- Sort alphabetically libevm imports in `imports.go`
- Move `state_account.go`'s libevm imports to `imports.go`
- Move extras registration from `state_account.go` to new file `libevm.go`