### PR TITLE
Move `header.ExtraPrefix` calculation

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -446,6 +446,14 @@ func (eng *DummyEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, h
 			return nil, err
 		}
 	}
+
+	// finalize the header.Extra
+	extraPrefix, err := customheader.ExtraPrefix(config, parent, header.Time)
+	if err != nil {
+		return nil, fmt.Errorf("failed to calculate new header.Extra: %w", err)
+	}
+	header.Extra = append(extraPrefix, header.Extra...)
+
 	// commit the final state root
 	header.Root = state.IntermediateRoot(config.IsEIP158(header.Number))
 

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -384,10 +384,6 @@ func (cm *chainMaker) makeHeader(parent *types.Block, gap uint64, state *state.S
 		gasLimit = CalcGasLimit(parent.GasUsed(), parent.GasLimit(), parent.GasLimit(), parent.GasLimit())
 	}
 
-	extra, err := header.ExtraPrefix(cm.config, parent.Header(), time)
-	if err != nil {
-		panic(err)
-	}
 	baseFee, err := header.BaseFee(cm.config, parent.Header(), time)
 	if err != nil {
 		panic(err)
@@ -401,7 +397,6 @@ func (cm *chainMaker) makeHeader(parent *types.Block, gap uint64, state *state.S
 		GasLimit:   gasLimit,
 		Number:     new(big.Int).Add(parent.Number(), common.Big1),
 		Time:       time,
-		Extra:      extra,
 		BaseFee:    baseFee,
 	}
 

--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -39,7 +39,7 @@ import (
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/core/vm"
 	"github.com/ava-labs/coreth/params"
-	"github.com/ava-labs/coreth/plugin/evm/header"
+	customheader "github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap1"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/cortina"
@@ -358,8 +358,7 @@ func TestStateProcessorErrors(t *testing.T) {
 func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Transactions, config *params.ChainConfig) *types.Block {
 	fakeChainReader := newChainMaker(nil, config, engine)
 	time := parent.Time() + 10
-	extra, _ := header.ExtraPrefix(config, parent.Header(), time)
-	baseFee, _ := header.BaseFee(config, parent.Header(), time)
+	baseFee, _ := customheader.BaseFee(config, parent.Header(), time)
 	header := &types.Header{
 		ParentHash: parent.Hash(),
 		Coinbase:   parent.Coinbase(),
@@ -372,7 +371,6 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		GasLimit:  parent.GasLimit(),
 		Number:    new(big.Int).Add(parent.Number(), common.Big1),
 		Time:      time,
-		Extra:     extra,
 		UncleHash: types.EmptyUncleHash,
 		BaseFee:   baseFee,
 	}
@@ -397,6 +395,7 @@ func GenerateBadBlock(parent *types.Block, engine consensus.Engine, txs types.Tr
 		cumulativeGas += tx.Gas()
 		nBlobs += len(tx.BlobHashes())
 	}
+	header.Extra, _ = customheader.ExtraPrefix(config, parent.Header(), time)
 	header.Root = common.BytesToHash(hasher.Sum(nil))
 	if config.IsCancun(header.Number, header.Time) {
 		var pExcess, pUsed = uint64(0), uint64(0)

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -161,10 +161,6 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 		gasLimit = core.CalcGasLimit(parent.GasUsed, parent.GasLimit, ap1.GasLimit, ap1.GasLimit)
 	}
 
-	extra, err := header.ExtraPrefix(w.chainConfig, parent, timestamp)
-	if err != nil {
-		return nil, fmt.Errorf("failed to calculate new extra prefix: %w", err)
-	}
 	baseFee, err := header.BaseFee(w.chainConfig, parent, timestamp)
 	if err != nil {
 		return nil, fmt.Errorf("failed to calculate new base fee: %w", err)
@@ -175,7 +171,6 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 		Number:     new(big.Int).Add(parent.Number, common.Big1),
 		GasLimit:   gasLimit,
 		Time:       timestamp,
-		Extra:      extra,
 		BaseFee:    baseFee,
 	}
 


### PR DESCRIPTION
## Why this should be merged

ACP-176 changes the `ExtraPrefix` to be dependent on the `GasUsed` and `ExtDataGasUsed`, in the block. Which is only available after building it. This PR moves the generation of the `ExtraPrefix` to live inside of `FinalizeAndAssemble` rather than at the initial header creation.

## How this works

Moves code around.

## How this was tested

Existing CI.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.