### PR TITLE
chore(ci): use go.mod Go version for actions/setup-go

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.23.6"
+          go-version-file: "go.mod"
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -72,7 +72,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.23.6"
+          go-version-file: "go.mod"
       - name: change avalanchego dep
         if: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
@@ -121,7 +121,7 @@ jobs:
           token: ${{ secrets.AVALANCHE_PAT }}
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.23.6"
+          go-version-file: "go.mod"
       - name: Run e2e tests
         run: E2E_SERIAL=1 ./scripts/tests.e2e.sh
         shell: bash

--- a/.github/workflows/sync-subnet-evm-branch.yml
+++ b/.github/workflows/sync-subnet-evm-branch.yml
@@ -13,7 +13,6 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-
       - uses: actions/setup-go@v5
         with:
-          go-version: "~1.23.6"
+          go-version-file: "go.mod"


### PR DESCRIPTION
## Why this should be merged

Removes static versions and uses version from go.mod. 

Thanks @qdm12 for showing that.

## How this works

uses `go-version-file` option for `setup-go` action

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No
