### PR TITLE
Cleanup `SyntacticVerify`

### DIFF
--- a/plugin/evm/block_verification.go
+++ b/plugin/evm/block_verification.go
@@ -180,16 +180,8 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 
 	// If we are in ApricotPhase4, ensure that ExtDataGasUsed is populated correctly.
 	if rules.IsApricotPhase4 {
-		// Make sure ExtDataGasUsed is not nil and correct
-		if ethHeader.ExtDataGasUsed == nil {
-			return errNilExtDataGasUsedApricotPhase4
-		}
 		if rules.IsApricotPhase5 {
 			if !utils.BigLessOrEqualUint64(ethHeader.ExtDataGasUsed, ap5.AtomicGasLimit) {
-				return fmt.Errorf("too large extDataGasUsed: %d", ethHeader.ExtDataGasUsed)
-			}
-		} else {
-			if !ethHeader.ExtDataGasUsed.IsUint64() {
 				return fmt.Errorf("too large extDataGasUsed: %d", ethHeader.ExtDataGasUsed)
 			}
 		}
@@ -202,14 +194,14 @@ func (v blockValidator) SyntacticVerify(b *Block, rules params.Rules) error {
 			if err != nil {
 				return err
 			}
-			totalGasUsed, err = safemath.Add64(totalGasUsed, gasUsed)
+			totalGasUsed, err = safemath.Add(totalGasUsed, gasUsed)
 			if err != nil {
 				return err
 			}
 		}
 
 		switch {
-		case ethHeader.ExtDataGasUsed.Cmp(new(big.Int).SetUint64(totalGasUsed)) != 0:
+		case !utils.BigEqualUint64(ethHeader.ExtDataGasUsed, totalGasUsed):
 			return fmt.Errorf("invalid extDataGasUsed: have %d, want %d", ethHeader.ExtDataGasUsed, totalGasUsed)
 
 		// Make sure BlockGasCost is not nil

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -164,16 +164,15 @@ var (
 )
 
 var (
-	errEmptyBlock                     = errors.New("empty block")
-	errUnsupportedFXs                 = errors.New("unsupported feature extensions")
-	errInvalidBlock                   = errors.New("invalid block")
-	errInvalidNonce                   = errors.New("invalid nonce")
-	errUnclesUnsupported              = errors.New("uncles unsupported")
-	errRejectedParent                 = errors.New("rejected parent")
-	errNilBaseFeeApricotPhase3        = errors.New("nil base fee is invalid after apricotPhase3")
-	errNilExtDataGasUsedApricotPhase4 = errors.New("nil extDataGasUsed is invalid after apricotPhase4")
-	errNilBlockGasCostApricotPhase4   = errors.New("nil blockGasCost is invalid after apricotPhase4")
-	errInvalidHeaderPredicateResults  = errors.New("invalid header predicate results")
+	errEmptyBlock                    = errors.New("empty block")
+	errUnsupportedFXs                = errors.New("unsupported feature extensions")
+	errInvalidBlock                  = errors.New("invalid block")
+	errInvalidNonce                  = errors.New("invalid nonce")
+	errUnclesUnsupported             = errors.New("uncles unsupported")
+	errRejectedParent                = errors.New("rejected parent")
+	errNilBaseFeeApricotPhase3       = errors.New("nil base fee is invalid after apricotPhase3")
+	errNilBlockGasCostApricotPhase4  = errors.New("nil blockGasCost is invalid after apricotPhase4")
+	errInvalidHeaderPredicateResults = errors.New("invalid header predicate results")
 )
 
 var originalStderr *os.File


### PR DESCRIPTION
## Why this should be merged

This removes code that is not needed (and would complicate the introduction of ACP-176 if it were kept.

## How this works

Replaces equality checks with existing helpers and removes unnecessary checks.

## How this was tested

existing CI.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.