### PR TITLE
Round up in `header.EstimateRequiredTip`

### DIFF
--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -250,7 +250,7 @@ func TestSuggestTipCapEmptyExtDataGasUsage(t *testing.T) {
 		numBlocks:       3,
 		extDataGasUsage: nil,
 		genBlock:        testGenBlock(t, 55, 370),
-		expectedTip:     big.NewInt(5_713_963_963),
+		expectedTip:     big.NewInt(5_713_963_964),
 	}, defaultOracleConfig())
 }
 
@@ -260,7 +260,7 @@ func TestSuggestTipCapSimple(t *testing.T) {
 		numBlocks:       3,
 		extDataGasUsage: common.Big0,
 		genBlock:        testGenBlock(t, 55, 370),
-		expectedTip:     big.NewInt(5_713_963_963),
+		expectedTip:     big.NewInt(5_713_963_964),
 	}, defaultOracleConfig())
 }
 
@@ -316,7 +316,7 @@ func TestSuggestTipCapSmallTips(t *testing.T) {
 			}
 		},
 		// NOTE: small tips do not bias estimate
-		expectedTip: big.NewInt(5_713_963_963),
+		expectedTip: big.NewInt(5_713_963_964),
 	}, defaultOracleConfig())
 }
 
@@ -326,7 +326,7 @@ func TestSuggestTipCapExtDataUsage(t *testing.T) {
 		numBlocks:       3,
 		extDataGasUsage: big.NewInt(10_000),
 		genBlock:        testGenBlock(t, 55, 370),
-		expectedTip:     big.NewInt(5_706_726_649),
+		expectedTip:     big.NewInt(5_706_726_650),
 	}, defaultOracleConfig())
 }
 
@@ -382,7 +382,7 @@ func TestSuggestTipCapMaxBlocksLookback(t *testing.T) {
 		numBlocks:       20,
 		extDataGasUsage: common.Big0,
 		genBlock:        testGenBlock(t, 550, 370),
-		expectedTip:     big.NewInt(51_565_264_256),
+		expectedTip:     big.NewInt(51_565_264_257),
 	}, defaultOracleConfig())
 }
 
@@ -392,6 +392,6 @@ func TestSuggestTipCapMaxBlocksSecondsLookback(t *testing.T) {
 		numBlocks:       20,
 		extDataGasUsage: big.NewInt(1),
 		genBlock:        testGenBlock(t, 550, 370),
-		expectedTip:     big.NewInt(92_212_529_423),
+		expectedTip:     big.NewInt(92_212_529_424),
 	}, timeCrunchOracleConfig())
 }

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -11,12 +11,14 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap4"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap5"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 var (
 	errBaseFeeNil        = errors.New("base fee is nil")
 	errBlockGasCostNil   = errors.New("block gas cost is nil")
 	errExtDataGasUsedNil = errors.New("extDataGasUsed is nil")
+	errNoGasUsed         = errors.New("no gas used")
 )
 
 // BlockGasCost calculates the required block gas cost based on the parent
@@ -96,10 +98,18 @@ func EstimateRequiredTip(
 	// totalGasUsed = GasUsed + ExtDataGasUsed
 	totalGasUsed := new(big.Int).SetUint64(header.GasUsed)
 	totalGasUsed.Add(totalGasUsed, header.ExtDataGasUsed)
+	if totalGasUsed.Sign() == 0 {
+		return nil, errNoGasUsed
+	}
 
-	// totalRequiredTips = blockGasCost * baseFee
+	// totalRequiredTips = blockGasCost * baseFee + totalGasUsed - 1
+	//
+	// We add totalGasUsed - 1 to ensure that the total required tips
+	// calculation rounds up.
 	totalRequiredTips := new(big.Int)
 	totalRequiredTips.Mul(header.BlockGasCost, header.BaseFee)
+	totalRequiredTips.Add(totalRequiredTips, totalGasUsed)
+	totalRequiredTips.Sub(totalRequiredTips, common.Big1)
 
 	// estimatedTip = totalRequiredTips / totalGasUsed
 	estimatedTip := totalRequiredTips.Div(totalRequiredTips, totalGasUsed)

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -203,6 +203,17 @@ func TestEstimateRequiredTip(t *testing.T) {
 			wantErr: errExtDataGasUsedNil,
 		},
 		{
+			name:         "no_gas_used",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				GasUsed:        0,
+				ExtDataGasUsed: big.NewInt(0),
+				BaseFee:        big.NewInt(1),
+				BlockGasCost:   big.NewInt(1),
+			},
+			wantErr: errNoGasUsed,
+		},
+		{
 			name:         "success",
 			ap4Timestamp: utils.NewUint64(0),
 			header: &types.Header{
@@ -215,6 +226,20 @@ func TestEstimateRequiredTip(t *testing.T) {
 			// totalRequiredTips = BlockGasCost * BaseFee
 			// estimatedTip = totalRequiredTips / totalGasUsed
 			want: big.NewInt((101112 * 456) / (123 + 789)),
+		},
+		{
+			name:         "success_rounds_up",
+			ap4Timestamp: utils.NewUint64(0),
+			header: &types.Header{
+				GasUsed:        124,
+				ExtDataGasUsed: big.NewInt(789),
+				BaseFee:        big.NewInt(456),
+				BlockGasCost:   big.NewInt(101112),
+			},
+			// totalGasUsed = GasUsed + ExtDataGasUsed
+			// totalRequiredTips = BlockGasCost * BaseFee
+			// estimatedTip = totalRequiredTips / totalGasUsed
+			want: big.NewInt((101112*456)/(124+789) + 1), // +1 to round up
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
## Why this should be merged

1. `header.EstimateRequiredTip` currently assumes that the sum of the GasUsed and ExtraDataGasUsed is > 0. This adds a check so that the code can't panic if this invariant were to be broken.
2. `header.EstimateRequiredTip` currently rounds down, but we should actually round up.

## How this works

Updates `header.EstimateRequiredTip`.

## How this was tested

Added unit tests

## Need to be documented?

No.

## Need to update RELEASES.md?

No.