### PR TITLE
Export ACP-176 constants

### DIFF
--- a/plugin/evm/upgrade/acp176/acp176.go
+++ b/plugin/evm/upgrade/acp176/acp176.go
@@ -28,8 +28,11 @@ const (
 	TargetToPriceUpdateConversion = 87   // 87s ~= 60s * ln(2) which makes the price double at most every ~60 seconds
 	MaxTargetChangeRate           = 1024 // Controls the rate that the target can change per block.
 
-	targetToMaxCapacity = TargetToMax * TimeToFillCapacity
-	maxTargetExcess     = 1_024_950_627 // TargetConversion * ln(MaxUint64 / MinTargetPerSecond) + 1
+	TargetToMaxCapacity = TargetToMax * TimeToFillCapacity
+	MinMaxPerSecond     = MinTargetPerSecond * TargetToMax
+	MinMaxCapacity      = MinMaxPerSecond * TimeToFillCapacity
+
+	maxTargetExcess = 1_024_950_627 // TargetConversion * ln(MaxUint64 / MinTargetPerSecond) + 1
 )
 
 // State represents the current state of the gas pricing and constraints.
@@ -52,7 +55,7 @@ func (s *State) Target() gas.Gas {
 // MaxCapacity returns the maximum possible accrued gas capacity, `C`.
 func (s *State) MaxCapacity() gas.Gas {
 	targetPerSecond := s.Target()
-	return mulWithUpperBound(targetPerSecond, targetToMaxCapacity)
+	return mulWithUpperBound(targetPerSecond, TargetToMaxCapacity)
 }
 
 // GasPrice returns the current required fee per gas.
@@ -122,7 +125,7 @@ func (s *State) UpdateTargetExcess(desiredTargetExcess gas.Gas) {
 	)
 
 	// Ensure the gas capacity does not exceed the maximum capacity.
-	newMaxCapacity := mulWithUpperBound(newTargetPerSecond, targetToMaxCapacity) // C
+	newMaxCapacity := mulWithUpperBound(newTargetPerSecond, TargetToMaxCapacity) // C
 	s.Gas.Capacity = min(s.Gas.Capacity, newMaxCapacity)
 }
 

--- a/plugin/evm/upgrade/acp176/acp176_test.go
+++ b/plugin/evm/upgrade/acp176/acp176_test.go
@@ -33,7 +33,7 @@ var (
 				TargetExcess: 0,
 			},
 			target:      MinTargetPerSecond,
-			maxCapacity: MinMaxPerSecond,
+			maxCapacity: MinMaxCapacity,
 			gasPrice:    MinGasPrice,
 		},
 		{
@@ -46,7 +46,7 @@ var (
 			},
 			skipTestDesiredTargetExcess: true,
 			target:                      MinTargetPerSecond,
-			maxCapacity:                 MinMaxPerSecond,
+			maxCapacity:                 MinMaxCapacity,
 			gasPrice:                    2 * MinGasPrice,
 		},
 		{

--- a/plugin/evm/upgrade/acp176/acp176_test.go
+++ b/plugin/evm/upgrade/acp176/acp176_test.go
@@ -33,7 +33,7 @@ var (
 				TargetExcess: 0,
 			},
 			target:      MinTargetPerSecond,
-			maxCapacity: targetToMaxCapacity * MinTargetPerSecond,
+			maxCapacity: MinMaxPerSecond,
 			gasPrice:    MinGasPrice,
 		},
 		{
@@ -46,7 +46,7 @@ var (
 			},
 			skipTestDesiredTargetExcess: true,
 			target:                      MinTargetPerSecond,
-			maxCapacity:                 targetToMaxCapacity * MinTargetPerSecond,
+			maxCapacity:                 MinMaxPerSecond,
 			gasPrice:                    2 * MinGasPrice,
 		},
 		{
@@ -58,7 +58,7 @@ var (
 				TargetExcess: 34, // Smallest excess that increases the target
 			},
 			target:      MinTargetPerSecond + 1,
-			maxCapacity: targetToMaxCapacity * (MinTargetPerSecond + 1),
+			maxCapacity: TargetToMaxCapacity * (MinTargetPerSecond + 1),
 			gasPrice:    2 * MinGasPrice,
 		},
 		{
@@ -71,7 +71,7 @@ var (
 			},
 			skipTestDesiredTargetExcess: true,
 			target:                      MinTargetPerSecond + 977,
-			maxCapacity:                 targetToMaxCapacity * (MinTargetPerSecond + 977),
+			maxCapacity:                 TargetToMaxCapacity * (MinTargetPerSecond + 977),
 			gasPrice:                    3 * MinGasPrice,
 		},
 		{
@@ -83,7 +83,7 @@ var (
 				TargetExcess: 13_605_152, // 2^25 * ln(1.5)
 			},
 			target:      1_500_000,
-			maxCapacity: targetToMaxCapacity * 1_500_000,
+			maxCapacity: TargetToMaxCapacity * 1_500_000,
 			gasPrice:    nAVAX*MinGasPrice + 2, // +2 due to approximation
 		},
 		{
@@ -95,7 +95,7 @@ var (
 				TargetExcess: 36_863_312, // 2^25 * ln(3)
 			},
 			target:      3_000_000,
-			maxCapacity: targetToMaxCapacity * 3_000_000,
+			maxCapacity: TargetToMaxCapacity * 3_000_000,
 			gasPrice:    100*nAVAX*MinGasPrice + 4, // +4 due to approximation
 		},
 		{
@@ -107,7 +107,7 @@ var (
 				TargetExcess: 60_121_472, // 2^25 * ln(6)
 			},
 			target:      6_000_000,
-			maxCapacity: targetToMaxCapacity * 6_000_000,
+			maxCapacity: TargetToMaxCapacity * 6_000_000,
 			gasPrice:    100*nAVAX*MinGasPrice + 4, // +4 due to approximation
 		},
 		{
@@ -119,7 +119,7 @@ var (
 				TargetExcess: 77_261_935, // 2^25 * ln(10)
 			},
 			target:      10_000_000,
-			maxCapacity: targetToMaxCapacity * 10_000_000,
+			maxCapacity: TargetToMaxCapacity * 10_000_000,
 			gasPrice:    100*nAVAX*MinGasPrice + 5, // +5 due to approximation
 		},
 		{
@@ -131,7 +131,7 @@ var (
 				TargetExcess: 154_523_870, // 2^25 * ln(100)
 			},
 			target:      100_000_000,
-			maxCapacity: targetToMaxCapacity * 100_000_000,
+			maxCapacity: TargetToMaxCapacity * 100_000_000,
 			gasPrice:    100*nAVAX*MinGasPrice + 5, // +5 due to approximation
 		},
 		{
@@ -143,7 +143,7 @@ var (
 				TargetExcess: 231_785_804, // 2^25 * ln(1000)
 			},
 			target:      1_000_000_000 - 24,
-			maxCapacity: targetToMaxCapacity * (1_000_000_000 - 24),
+			maxCapacity: TargetToMaxCapacity * (1_000_000_000 - 24),
 			gasPrice:    100 * nAVAX * MinGasPrice,
 		},
 		{
@@ -155,7 +155,7 @@ var (
 				TargetExcess: 231_785_805, // 2^25 * ln(1000) + 1
 			},
 			target:      1_000_000_000 + 6,
-			maxCapacity: targetToMaxCapacity * (1_000_000_000 + 6),
+			maxCapacity: TargetToMaxCapacity * (1_000_000_000 + 6),
 			gasPrice:    100 * nAVAX * MinGasPrice,
 		},
 		{
@@ -200,7 +200,7 @@ var (
 				Gas: gas.State{
 					Excess: math.MaxUint64,
 				},
-				TargetExcess: 1_024_950_627, // 2^25 * ln(MaxUint64 / MinTargetPerSecond) + 1
+				TargetExcess: maxTargetExcess,
 			},
 			target:      math.MaxUint64,
 			maxCapacity: math.MaxUint64,


### PR DESCRIPTION
## Why this should be merged

1. Uses an existing constant
2. Exposes constants from the ACP-176 library to reduce the larger PR diff.

## How this works

N/A

## How this was tested

N/A

## Need to be documented?

No.

## Need to update RELEASES.md?

No.