### PR TITLE
Filter by total gas rather than GasUsed

### DIFF
--- a/eth/gasprice/fee_info_provider.go
+++ b/eth/gasprice/fee_info_provider.go
@@ -92,10 +92,17 @@ func (f *feeInfoProvider) addHeader(ctx context.Context, header *types.Header) (
 		timestamp: header.Time,
 		baseFee:   header.BaseFee,
 	}
+
+	totalGasUsed := new(big.Int).SetUint64(header.GasUsed)
+	if header.ExtDataGasUsed != nil {
+		totalGasUsed.Add(totalGasUsed, header.ExtDataGasUsed)
+	}
+	minGasUsed := new(big.Int).SetUint64(f.minGasUsed)
+
 	// Don't bias the estimate with blocks containing a limited number of transactions paying to
 	// expedite block production.
 	var err error
-	if f.minGasUsed <= header.GasUsed {
+	if minGasUsed.Cmp(totalGasUsed) <= 0 {
 		// Compute minimum required tip to be included in previous block
 		//
 		// NOTE: Using this approach, we will never recommend that the caller

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -395,3 +395,13 @@ func TestSuggestTipCapMaxBlocksSecondsLookback(t *testing.T) {
 		expectedTip:     big.NewInt(92_212_529_424),
 	}, timeCrunchOracleConfig())
 }
+
+func TestSuggestTipCapIncludesExtraDataGas(t *testing.T) {
+	applyGasPriceTest(t, suggestTipCapTest{
+		chainConfig:     params.TestChainConfig,
+		numBlocks:       20,
+		extDataGasUsage: DefaultMinGasUsed,
+		genBlock:        testGenBlock(t, 100_000, 1),
+		expectedTip:     big.NewInt(83_603_561_239),
+	}, timeCrunchOracleConfig())
+}

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -401,7 +401,10 @@ func TestSuggestTipCapIncludesExtraDataGas(t *testing.T) {
 		chainConfig:     params.TestChainConfig,
 		numBlocks:       20,
 		extDataGasUsage: DefaultMinGasUsed,
-		genBlock:        testGenBlock(t, 100_000, 1),
-		expectedTip:     big.NewInt(83_603_561_239),
+		// The tip on the transaction is very large to pay the block gas cost.
+		genBlock: testGenBlock(t, 100_000, 1),
+		// The actual tip doesn't matter, we just want to ensure that the tip is
+		// non-zero when almost all the gas is coming from the extDataGasUsage.
+		expectedTip: big.NewInt(83_603_561_239),
 	}, timeCrunchOracleConfig())
 }


### PR DESCRIPTION
## Why this should be merged

Currently the gas price oracle doesn't account for extraDataGasUsed. This PR includes that gas and adds a unit test for it.

## How this works

Sums the gas.

## How this was tested

unit test

## Need to be documented?

no.

## Need to update RELEASES.md?

no.