### PR TITLE
Add Rules to PredicateBytesFromExtra

### DIFF
--- a/core/vm/evm.go
+++ b/core/vm/evm.go
@@ -235,7 +235,7 @@ func NewEVM(blockCtx BlockContext, txCtx TxContext, statedb StateDB, chainConfig
 
 	// Parse the predicate results from the extra field and store them in the
 	// block context.
-	predicateBytes := header.PredicateBytesFromExtra(blockCtx.Extra)
+	predicateBytes := header.PredicateBytesFromExtra(evm.chainRules.AvalancheRules, blockCtx.Extra)
 	if len(predicateBytes) == 0 {
 		return evm
 	}

--- a/plugin/evm/block.go
+++ b/plugin/evm/block.go
@@ -382,7 +382,7 @@ func (b *Block) verifyPredicates(predicateContext *precompileconfig.PredicateCon
 		return fmt.Errorf("failed to marshal predicate results: %w", err)
 	}
 	extraData := b.ethBlock.Extra()
-	headerPredicateResultsBytes := header.PredicateBytesFromExtra(extraData)
+	headerPredicateResultsBytes := header.PredicateBytesFromExtra(rules.AvalancheRules, extraData)
 	if !bytes.Equal(headerPredicateResultsBytes, predicateResultsBytes) {
 		return fmt.Errorf("%w (remote: %x local: %x)", errInvalidHeaderPredicateResults, headerPredicateResultsBytes, predicateResultsBytes)
 	}

--- a/plugin/evm/header/extra.go
+++ b/plugin/evm/header/extra.go
@@ -79,11 +79,10 @@ func VerifyExtra(rules params.AvalancheRules, extra []byte) error {
 
 // PredicateBytesFromExtra returns the predicate result bytes from the header's
 // extra data. If the extra data is not long enough, an empty slice is returned.
-func PredicateBytesFromExtra(extra []byte) []byte {
+func PredicateBytesFromExtra(_ params.AvalancheRules, extra []byte) []byte {
 	// Prior to Durango, the VM enforces the extra data is smaller than or equal
-	// to this size.
-	// After Durango, the VM pre-verifies the extra data past the dynamic fee
-	// rollup window is valid.
+	// to `offset`.
+	// After Durango, the VM pre-verifies the extra data past `offset` is valid.
 	if len(extra) <= FeeWindowSize {
 		return nil
 	}

--- a/plugin/evm/header/extra.go
+++ b/plugin/evm/header/extra.go
@@ -81,8 +81,9 @@ func VerifyExtra(rules params.AvalancheRules, extra []byte) error {
 // extra data. If the extra data is not long enough, an empty slice is returned.
 func PredicateBytesFromExtra(_ params.AvalancheRules, extra []byte) []byte {
 	// Prior to Durango, the VM enforces the extra data is smaller than or equal
-	// to `offset`.
-	// After Durango, the VM pre-verifies the extra data past `offset` is valid.
+	// to this size.
+	// After Durango, the VM pre-verifies the extra data past the dynamic fee
+	// rollup window is valid.
 	if len(extra) <= FeeWindowSize {
 		return nil
 	}

--- a/plugin/evm/header/extra_test.go
+++ b/plugin/evm/header/extra_test.go
@@ -331,6 +331,7 @@ func TestVerifyExtra(t *testing.T) {
 func TestPredicateBytesFromExtra(t *testing.T) {
 	tests := []struct {
 		name     string
+		rules    params.AvalancheRules
 		extra    []byte
 		expected []byte
 	}{
@@ -359,7 +360,7 @@ func TestPredicateBytesFromExtra(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := PredicateBytesFromExtra(test.extra)
+			got := PredicateBytesFromExtra(test.rules, test.extra)
 			require.Equal(t, test.expected, got)
 		})
 	}

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -653,7 +653,8 @@ func testReceiveWarpMessage(
 
 	// Require the block was built with a successful predicate result
 	ethBlock := block2.(*chain.BlockWrapper).Block.(*Block).ethBlock
-	headerPredicateResultsBytes := customheader.PredicateBytesFromExtra(ethBlock.Extra())
+	rules := vm.chainConfig.GetAvalancheRules(ethBlock.Time())
+	headerPredicateResultsBytes := customheader.PredicateBytesFromExtra(rules, ethBlock.Extra())
 	results, err := predicate.ParseResults(headerPredicateResultsBytes)
 	require.NoError(err)
 


### PR DESCRIPTION
## Why this should be merged

Factored out of #815 to make the libevm migration easier.

## How this works

Passes rules (and doesn't use them yet) during predicate bytes parsing.

## How this was tested

CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.