### PR TITLE
move ap4 block gas cost check to header

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -178,9 +178,6 @@ func verifyHeaderGasFields(config *params.ChainConfig, header *types.Header, par
 
 	// Verify BlockGasCost, ExtDataGasUsed not present before AP4
 	if !config.IsApricotPhase4(header.Time) {
-		if header.BlockGasCost != nil {
-			return fmt.Errorf("invalid blockGasCost before fork: have %d, want <nil>", header.BlockGasCost)
-		}
 		if header.ExtDataGasUsed != nil {
 			return fmt.Errorf("invalid extDataGasUsed before fork: have %d, want <nil>", header.ExtDataGasUsed)
 		}

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -176,7 +176,7 @@ func verifyHeaderGasFields(config *params.ChainConfig, header *types.Header, par
 		return fmt.Errorf("invalid block gas cost: have %d, want %d", header.BlockGasCost, expectedBlockGasCost)
 	}
 
-	// Verify BlockGasCost, ExtDataGasUsed not present before AP4
+	// Verify ExtDataGasUsed not present before AP4
 	if !config.IsApricotPhase4(header.Time) {
 		if header.ExtDataGasUsed != nil {
 			return fmt.Errorf("invalid extDataGasUsed before fork: have %d, want <nil>", header.ExtDataGasUsed)

--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -431,12 +431,11 @@ func (eng *DummyEngine) FinalizeAndAssemble(chain consensus.ChainHeaderReader, h
 
 	config := chain.Config()
 	// Calculate the required block gas cost for this block.
-	blockGasCost := customheader.BlockGasCost(
+	header.BlockGasCost = customheader.BlockGasCost(
 		config,
 		parent,
 		header.Time,
 	)
-	header.BlockGasCost = blockGasCost
 	if config.IsApricotPhase4(header.Time) {
 		header.ExtDataGasUsed = extDataGasUsed
 		if header.ExtDataGasUsed == nil {

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -27,7 +27,10 @@ func BlockGasCost(
 	config *params.ChainConfig,
 	parent *types.Header,
 	timestamp uint64,
-) uint64 {
+) *big.Int {
+	if !config.IsApricotPhase4(timestamp) {
+		return nil
+	}
 	step := uint64(ap4.BlockGasCostStep)
 	if config.IsApricotPhase5(timestamp) {
 		step = ap5.BlockGasCostStep
@@ -40,11 +43,11 @@ func BlockGasCost(
 	if parent.Time <= timestamp {
 		timeElapsed = timestamp - parent.Time
 	}
-	return BlockGasCostWithStep(
+	return new(big.Int).SetUint64(BlockGasCostWithStep(
 		parent.BlockGasCost,
 		step,
 		timeElapsed,
-	)
+	))
 }
 
 // BlockGasCostWithStep calculates the required block gas cost based on the

--- a/plugin/evm/header/block_gas_cost.go
+++ b/plugin/evm/header/block_gas_cost.go
@@ -23,6 +23,7 @@ var (
 
 // BlockGasCost calculates the required block gas cost based on the parent
 // header and the timestamp of the new block.
+// Prior to AP4, the returned block gas cost will be nil.
 func BlockGasCost(
 	config *params.ChainConfig,
 	parent *types.Header,

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -19,18 +19,27 @@ import (
 func TestBlockGasCost(t *testing.T) {
 	tests := []struct {
 		name         string
+		beforeAP4    bool
 		ap5Timestamp *uint64
 		parentTime   uint64
 		parentCost   *big.Int
 		timestamp    uint64
-		expected     uint64
+		expected     *big.Int
 	}{
+		{
+			name:       "before_ap4",
+			parentTime: 10,
+			beforeAP4:  true,
+			parentCost: big.NewInt(ap4.MaxBlockGasCost),
+			timestamp:  10 + ap4.TargetBlockRate + 1,
+			expected:   nil,
+		},
 		{
 			name:       "normal_ap4",
 			parentTime: 10,
 			parentCost: big.NewInt(ap4.MaxBlockGasCost),
 			timestamp:  10 + ap4.TargetBlockRate + 1,
-			expected:   ap4.MaxBlockGasCost - ap4.BlockGasCostStep,
+			expected:   big.NewInt(ap4.MaxBlockGasCost - ap4.BlockGasCostStep),
 		},
 		{
 			name:         "normal_ap5",
@@ -38,21 +47,26 @@ func TestBlockGasCost(t *testing.T) {
 			parentTime:   10,
 			parentCost:   big.NewInt(ap4.MaxBlockGasCost),
 			timestamp:    10 + ap4.TargetBlockRate + 1,
-			expected:     ap4.MaxBlockGasCost - ap5.BlockGasCostStep,
+			expected:     big.NewInt(ap4.MaxBlockGasCost - ap5.BlockGasCostStep),
 		},
 		{
 			name:       "negative_time_elapsed",
 			parentTime: 10,
 			parentCost: big.NewInt(ap4.MinBlockGasCost),
 			timestamp:  9,
-			expected:   ap4.MinBlockGasCost + ap4.BlockGasCostStep*ap4.TargetBlockRate,
+			expected:   big.NewInt(ap4.MinBlockGasCost + ap4.BlockGasCostStep*ap4.TargetBlockRate),
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			ap4Timestamp := utils.NewUint64(0)
+			if test.beforeAP4 {
+				ap4Timestamp = nil
+			}
 			config := &params.ChainConfig{
 				NetworkUpgrades: params.NetworkUpgrades{
+					ApricotPhase4BlockTimestamp: ap4Timestamp,
 					ApricotPhase5BlockTimestamp: test.ap5Timestamp,
 				},
 			}

--- a/plugin/evm/header/block_gas_cost_test.go
+++ b/plugin/evm/header/block_gas_cost_test.go
@@ -18,18 +18,17 @@ import (
 
 func TestBlockGasCost(t *testing.T) {
 	tests := []struct {
-		name         string
-		beforeAP4    bool
-		ap5Timestamp *uint64
-		parentTime   uint64
-		parentCost   *big.Int
-		timestamp    uint64
-		expected     *big.Int
+		name       string
+		upgrades   params.NetworkUpgrades
+		parentTime uint64
+		parentCost *big.Int
+		timestamp  uint64
+		expected   *big.Int
 	}{
 		{
 			name:       "before_ap4",
 			parentTime: 10,
-			beforeAP4:  true,
+			upgrades:   params.TestApricotPhase3Config.NetworkUpgrades,
 			parentCost: big.NewInt(ap4.MaxBlockGasCost),
 			timestamp:  10 + ap4.TargetBlockRate + 1,
 			expected:   nil,
@@ -37,20 +36,22 @@ func TestBlockGasCost(t *testing.T) {
 		{
 			name:       "normal_ap4",
 			parentTime: 10,
+			upgrades:   params.TestApricotPhase4Config.NetworkUpgrades,
 			parentCost: big.NewInt(ap4.MaxBlockGasCost),
 			timestamp:  10 + ap4.TargetBlockRate + 1,
 			expected:   big.NewInt(ap4.MaxBlockGasCost - ap4.BlockGasCostStep),
 		},
 		{
-			name:         "normal_ap5",
-			ap5Timestamp: utils.NewUint64(0),
-			parentTime:   10,
-			parentCost:   big.NewInt(ap4.MaxBlockGasCost),
-			timestamp:    10 + ap4.TargetBlockRate + 1,
-			expected:     big.NewInt(ap4.MaxBlockGasCost - ap5.BlockGasCostStep),
+			name:       "normal_ap5",
+			upgrades:   params.TestApricotPhase5Config.NetworkUpgrades,
+			parentTime: 10,
+			parentCost: big.NewInt(ap4.MaxBlockGasCost),
+			timestamp:  10 + ap4.TargetBlockRate + 1,
+			expected:   big.NewInt(ap4.MaxBlockGasCost - ap5.BlockGasCostStep),
 		},
 		{
 			name:       "negative_time_elapsed",
+			upgrades:   params.TestApricotPhase4Config.NetworkUpgrades,
 			parentTime: 10,
 			parentCost: big.NewInt(ap4.MinBlockGasCost),
 			timestamp:  9,
@@ -60,15 +61,8 @@ func TestBlockGasCost(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ap4Timestamp := utils.NewUint64(0)
-			if test.beforeAP4 {
-				ap4Timestamp = nil
-			}
 			config := &params.ChainConfig{
-				NetworkUpgrades: params.NetworkUpgrades{
-					ApricotPhase4BlockTimestamp: ap4Timestamp,
-					ApricotPhase5BlockTimestamp: test.ap5Timestamp,
-				},
+				NetworkUpgrades: test.upgrades,
 			}
 			parent := &types.Header{
 				Time:         test.parentTime,


### PR DESCRIPTION
## Why this should be merged

moves AP4 gas limit calc to header (return nil)

## How this works

BlockGasCost return type changed to big.Int (from uint64), and returns nil for !AP4 

## How this was tested

added UT

## Need to be documented?

no

## Need to update RELEASES.md?

no