### PR TITLE
chore(accounts/keystore): return nil when error has already been checked

### DIFF
--- a/accounts/keystore/presale.go
+++ b/accounts/keystore/presale.go
@@ -120,7 +120,7 @@ func aesCTRXOR(key, inText, iv []byte) ([]byte, error) {
 	stream := cipher.NewCTR(aesBlock, iv)
 	outText := make([]byte, len(inText))
 	stream.XORKeyStream(outText, inText)
-	return outText, err
+	return outText, nil
 }
 
 func aesCBCDecrypt(key, cipherText, iv []byte) ([]byte, error) {
@@ -135,7 +135,7 @@ func aesCBCDecrypt(key, cipherText, iv []byte) ([]byte, error) {
 	if plaintext == nil {
 		return nil, ErrDecrypt
 	}
-	return plaintext, err
+	return plaintext, nil
 }
 
 // From https://leanpub.com/gocrypto/read#leanpub-auto-block-cipher-modes


### PR DESCRIPTION
## Why this should be merged


The logic of err not being nil has been processed and returned before, so err must be nil here.

## How this works

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
