### PR TITLE
fix(eth/gasprice): EstimateBaseFee using Next Fee

### DIFF
--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -37,11 +37,9 @@ import (
 	"github.com/ava-labs/coreth/params"
 	customheader "github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
-	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 	"github.com/ava-labs/coreth/rpc"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
-	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/event"
 	"github.com/ethereum/go-ethereum/log"
 	"golang.org/x/exp/slices"
@@ -66,7 +64,6 @@ const (
 var (
 	DefaultMaxPrice           = big.NewInt(150 * params.GWei)
 	DefaultMinPrice           = big.NewInt(acp176.MinGasPrice)
-	DefaultMinBaseFee         = big.NewInt(ap3.InitialBaseFee)
 	DefaultMinGasUsed         = big.NewInt(acp176.MinTargetPerSecond)
 	DefaultMaxLookbackSeconds = uint64(80)
 )
@@ -106,10 +103,9 @@ type OracleBackend interface {
 // Oracle recommends gas prices based on the content of recent
 // blocks. Suitable for both light and full clients.
 type Oracle struct {
-	backend     OracleBackend
-	lastHead    common.Hash
-	lastPrice   *big.Int
-	lastBaseFee *big.Int
+	backend   OracleBackend
+	lastHead  common.Hash
+	lastPrice *big.Int
 	// [minPrice] ensures we don't get into a positive feedback loop where tips
 	// sink to 0 during a period of slow block production, such that nobody's
 	// transactions will be included until the full block fee duration has
@@ -196,7 +192,6 @@ func NewOracle(backend OracleBackend, config Config) (*Oracle, error) {
 	return &Oracle{
 		backend:             backend,
 		lastPrice:           minPrice,
-		lastBaseFee:         DefaultMinBaseFee,
 		minPrice:            minPrice,
 		maxPrice:            maxPrice,
 		checkBlocks:         blocks,
@@ -213,26 +208,7 @@ func NewOracle(backend OracleBackend, config Config) (*Oracle, error) {
 // produced at the current time. If ApricotPhase3 has not been activated, it may
 // return a nil value and a nil error.
 func (oracle *Oracle) EstimateBaseFee(ctx context.Context) (*big.Int, error) {
-	_, baseFee, err := oracle.suggestDynamicFees(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	// We calculate the [nextBaseFee] if a block were to be produced immediately.
-	// If [nextBaseFee] is lower than the estimate from sampling, then we return it
-	// to prevent returning an incorrectly high fee when the network is quiescent.
-	nextBaseFee, err := oracle.estimateNextBaseFee(ctx)
-	if err != nil {
-		log.Warn("failed to estimate next base fee", "err", err)
-		return baseFee, nil
-	}
-	// If base fees have not been enabled, return a nil value.
-	if nextBaseFee == nil {
-		return nil, nil
-	}
-
-	baseFee = math.BigMin(baseFee, nextBaseFee)
-	return baseFee, nil
+	return oracle.estimateNextBaseFee(ctx)
 }
 
 // estimateNextBaseFee calculates what the base fee should be on the next block if it
@@ -260,25 +236,23 @@ func (oracle *Oracle) estimateNextBaseFee(ctx context.Context) (*big.Int, error)
 // SuggestPrice returns an estimated price for legacy transactions.
 func (oracle *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 	// Estimate the effective tip based on recent blocks.
-	tip, baseFee, err := oracle.suggestDynamicFees(ctx)
+	tip, err := oracle.suggestTip(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	// We calculate the [nextBaseFee] if a block were to be produced immediately.
-	// If [nextBaseFee] is lower than the estimate from sampling, then we return it
-	// to prevent returning an incorrectly high fee when the network is quiescent.
+	// We calculate the `nextBaseFee` if a block were to be produced immediately.
 	nextBaseFee, err := oracle.estimateNextBaseFee(ctx)
 	if err != nil {
 		log.Warn("failed to estimate next base fee", "err", err)
+		return nil, err
 	}
-	// Separately from checking the error value, check that [nextBaseFee] is non-nil
-	// before attempting to take the minimum.
-	if nextBaseFee != nil {
-		baseFee = math.BigMin(baseFee, nextBaseFee)
+	if nextBaseFee == nil {
+		// This occurs if AP3 has not been scheduled yet
+		return tip, nil
 	}
 
-	return new(big.Int).Add(tip, baseFee), nil
+	return new(big.Int).Add(tip, nextBaseFee), nil
 }
 
 // SuggestTipCap returns a tip cap so that newly created transaction can have a
@@ -288,42 +262,40 @@ func (oracle *Oracle) SuggestPrice(ctx context.Context) (*big.Int, error) {
 // necessary to add the basefee to the returned number to fall back to the legacy
 // behavior.
 func (oracle *Oracle) SuggestTipCap(ctx context.Context) (*big.Int, error) {
-	tip, _, err := oracle.suggestDynamicFees(ctx)
-	return tip, err
+	return oracle.suggestTip(ctx)
 }
 
-// suggestDynamicFees estimates the gas tip and base fee based on a simple sampling method
-func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.Int, error) {
+// suggestTip estimates the gas tip based on a simple sampling method
+func (oracle *Oracle) suggestTip(ctx context.Context) (*big.Int, error) {
 	head, err := oracle.backend.HeaderByNumber(ctx, rpc.LatestBlockNumber)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	headHash := head.Hash()
 
 	// If the latest gasprice is still available, return it.
 	oracle.cacheLock.RLock()
-	lastHead, lastPrice, lastBaseFee := oracle.lastHead, oracle.lastPrice, oracle.lastBaseFee
+	lastHead, lastPrice := oracle.lastHead, oracle.lastPrice
 	oracle.cacheLock.RUnlock()
 	if headHash == lastHead {
-		return new(big.Int).Set(lastPrice), new(big.Int).Set(lastBaseFee), nil
+		return new(big.Int).Set(lastPrice), nil
 	}
 	oracle.fetchLock.Lock()
 	defer oracle.fetchLock.Unlock()
 
 	// Try checking the cache again, maybe the last fetch fetched what we need
 	oracle.cacheLock.RLock()
-	lastHead, lastPrice, lastBaseFee = oracle.lastHead, oracle.lastPrice, oracle.lastBaseFee
+	lastHead, lastPrice = oracle.lastHead, oracle.lastPrice
 	oracle.cacheLock.RUnlock()
 	if headHash == lastHead {
-		return new(big.Int).Set(lastPrice), new(big.Int).Set(lastBaseFee), nil
+		return new(big.Int).Set(lastPrice), nil
 	}
 	var (
 		latestBlockNumber     = head.Number.Uint64()
 		lowerBlockNumberLimit = uint64(0)
 		currentTime           = oracle.clock.Unix()
 		tipResults            []*big.Int
-		baseFeeResults        []*big.Int
 	)
 
 	if uint64(oracle.checkBlocks) <= latestBlockNumber {
@@ -334,7 +306,7 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 	for i := latestBlockNumber; i > lowerBlockNumberLimit; i-- {
 		feeInfo, err := oracle.getFeeInfo(ctx, i)
 		if err != nil {
-			return new(big.Int).Set(lastPrice), new(big.Int).Set(lastBaseFee), err
+			return new(big.Int).Set(lastPrice), err
 		}
 
 		if feeInfo.timestamp+oracle.maxLookbackSeconds < currentTime {
@@ -346,25 +318,14 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 		} else {
 			tipResults = append(tipResults, new(big.Int).Set(common.Big0))
 		}
-
-		if feeInfo.baseFee != nil {
-			baseFeeResults = append(baseFeeResults, feeInfo.baseFee)
-		} else {
-			baseFeeResults = append(baseFeeResults, new(big.Int).Set(common.Big0))
-		}
 	}
 
 	price := lastPrice
-	baseFee := lastBaseFee
 	if len(tipResults) > 0 {
 		slices.SortFunc(tipResults, func(a, b *big.Int) int { return a.Cmp(b) })
 		price = tipResults[(len(tipResults)-1)*oracle.percentile/100]
 	}
 
-	if len(baseFeeResults) > 0 {
-		slices.SortFunc(baseFeeResults, func(a, b *big.Int) int { return a.Cmp(b) })
-		baseFee = baseFeeResults[(len(baseFeeResults)-1)*oracle.percentile/100]
-	}
 	if price.Cmp(oracle.maxPrice) > 0 {
 		price = new(big.Int).Set(oracle.maxPrice)
 	}
@@ -374,10 +335,9 @@ func (oracle *Oracle) suggestDynamicFees(ctx context.Context) (*big.Int, *big.In
 	oracle.cacheLock.Lock()
 	oracle.lastHead = headHash
 	oracle.lastPrice = price
-	oracle.lastBaseFee = baseFee
 	oracle.cacheLock.Unlock()
 
-	return new(big.Int).Set(price), new(big.Int).Set(baseFee), nil
+	return new(big.Int).Set(price), nil
 }
 
 // getFeeInfo calculates the minimum required tip to be included in a given


### PR DESCRIPTION
## Why this should be merged
See issue #858 

## How this works
Rather than sampling base fees as well as tips, simply returns the next base fee in `SuggestPrice` and `EstimateBaseFee`. Additionally, removes sampling and tracking of gas fees from sampling method.

## How this was tested
Existing unit tests

## Need to be documented?
Yes, but unsure where

## Need to update RELEASES.md?
No