### PR TITLE
add merge groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
     inputs:
       avalanchegoRepo:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -17,6 +17,8 @@ on:
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ master ]
+  merge_group:
+    types: [checks_requested]
   schedule:
     - cron: '44 11 * * 4'
 


### PR DESCRIPTION
## Why this should be merged

Adds merge group actions to ci workflows.

## How this works

This pull request adds a new event type to the GitHub Actions workflows to trigger the workflows when checks are requested for a merge group. This change ensures that the workflows run in response to specific events related to merge groups.

Changes to GitHub Actions workflows:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR7-R8): Added `merge_group` with `types: [checks_requested]` to trigger the workflow when checks are requested for a merge group.
* [`.github/workflows/codeql-analysis.yml`](diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188R20-R21): Added `merge_group` with `types: [checks_requested]` to trigger the workflow when checks are requested for a merge group.

## How this was tested

Need to be tested with merge queue enabled

## Need to be documented?

No

## Need to update RELEASES.md?

No
