### PR TITLE
fix(internal/ethapi): fix minBaseFee for fortuna

### DIFF
--- a/internal/ethapi/api.coreth.go
+++ b/internal/ethapi/api.coreth.go
@@ -47,11 +47,6 @@ type PriceOptions struct {
 // SuggestPriceOptions returns suggestions for what to display to a user for
 // current transaction fees.
 func (s *EthereumAPI) SuggestPriceOptions(ctx context.Context) (*PriceOptions, error) {
-	var (
-		minBaseFee    int64
-		bigMinBaseFee *big.Int
-	)
-
 	baseFee, err := s.b.EstimateBaseFee(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to estimate base fee: %w", err)
@@ -66,14 +61,17 @@ func (s *EthereumAPI) SuggestPriceOptions(ctx context.Context) (*PriceOptions, e
 		return nil, nil
 	}
 
+	// Find min base fee based on chain config
+	// TODO: This can be removed after Fortuna is activated
 	time := s.b.CurrentHeader().Time
 	chainConfig := s.b.ChainConfig()
+	var minBaseFee int64
 	if chainConfig.IsFortuna(time) {
 		minBaseFee = acp176.MinGasPrice
 	} else {
 		minBaseFee = etna.MinBaseFee
 	}
-	bigMinBaseFee = big.NewInt(minBaseFee)
+	bigMinBaseFee := big.NewInt(minBaseFee)
 
 	cfg := s.b.PriceOptionsConfig()
 	bigSlowFeePercent := new(big.Int).SetUint64(cfg.SlowFeePercentage)

--- a/internal/ethapi/api.coreth.go
+++ b/internal/ethapi/api.coreth.go
@@ -65,20 +65,19 @@ func (s *EthereumAPI) SuggestPriceOptions(ctx context.Context) (*PriceOptions, e
 	// TODO: This can be removed after Fortuna is activated
 	time := s.b.CurrentHeader().Time
 	chainConfig := s.b.ChainConfig()
-	var minBaseFee int64
+	minBaseFee := new(big.Int)
 	if chainConfig.IsFortuna(time) {
-		minBaseFee = acp176.MinGasPrice
+		minBaseFee.SetUint64(acp176.MinGasPrice)
 	} else {
-		minBaseFee = etna.MinBaseFee
+		minBaseFee.SetUint64(etna.MinBaseFee)
 	}
-	bigMinBaseFee := big.NewInt(minBaseFee)
 
 	cfg := s.b.PriceOptionsConfig()
 	bigSlowFeePercent := new(big.Int).SetUint64(cfg.SlowFeePercentage)
 	bigFastFeePercent := new(big.Int).SetUint64(cfg.FastFeePercentage)
 
 	baseFees := calculateFeeSpeeds(
-		bigMinBaseFee,
+		minBaseFee,
 		baseFee,
 		big.NewInt(int64(cfg.MaxBaseFee)),
 		bigSlowFeePercent,

--- a/internal/ethapi/api.coreth_test.go
+++ b/internal/ethapi/api.coreth_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
+	"github.com/ava-labs/coreth/plugin/evm/upgrade/etna"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/require"
@@ -53,7 +54,7 @@ func TestSuggestPriceOptions(t *testing.T) {
 		MaxBaseFee:        100 * params.GWei,
 		MaxTip:            20 * params.GWei,
 	}
-	minBaseFee := 1 * params.GWei
+	minBaseFee := etna.MinBaseFee
 	bigMinBaseFee := big.NewInt(int64(minBaseFee))
 	fortunaMinBaseFee := acp176.MinGasPrice
 	bigFortunaMinBaseFee := big.NewInt(int64(fortunaMinBaseFee))

--- a/internal/ethapi/api.coreth_test.go
+++ b/internal/ethapi/api.coreth_test.go
@@ -42,6 +42,8 @@ func TestSuggestPriceOptions(t *testing.T) {
 		MaxBaseFee:        100 * params.GWei,
 		MaxTip:            20 * params.GWei,
 	}
+	minBaseFee := 1 * params.GWei
+	bigMinBaseFee := big.NewInt(int64(minBaseFee))
 	slowFeeNumerator := testCfg.SlowFeePercentage
 	fastFeeNumerator := testCfg.FastFeePercentage
 	maxNormalGasTip := testCfg.MaxTip


### PR DESCRIPTION
## Why this should be merged

On Fortuna activation, the `ethapi` uses Etna's min base fee. After ACP-176 is activated, the min base fee is lowered, resulting in an improper min application.

## How this works

If the Fortuna timestamp is reached, will use `acp176.MinGasPrice` instead of `etna.MinBaseFee`.

## How this was tested

Additional unit test checking the `chainCfg` in the eth backend.

## Need to be documented?

No

## Need to update RELEASES.md?

Unsure
