### PR TITLE
chore: disallow direct `libevm/params` import

### DIFF
--- a/core/types/block_test.go
+++ b/core/types/block_test.go
@@ -24,7 +24,7 @@
 // You should have received a copy of the GNU Lesser General Public License
 // along with the go-ethereum library. If not, see <http://www.gnu.org/licenses/>.
 
-package types
+package types_test
 
 import (
 	"bytes"
@@ -33,11 +33,13 @@ import (
 	"testing"
 
 	"github.com/ava-labs/coreth/internal/blocktest"
+	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/math"
 	"github.com/ava-labs/libevm/crypto"
-	"github.com/ava-labs/libevm/params"
 	"github.com/ava-labs/libevm/rlp"
+
+	. "github.com/ava-labs/coreth/core/types"
 )
 
 // This test has been modified from https://github.com/ethereum/go-ethereum/blob/v1.9.21/core/types/block_test.go#L35 to fit

--- a/scripts/eth-allowed-packages.txt
+++ b/scripts/eth-allowed-packages.txt
@@ -30,7 +30,6 @@
 "github.com/ava-labs/libevm/libevm/stateconf"
 "github.com/ava-labs/libevm/log"
 "github.com/ava-labs/libevm/metrics"
-"github.com/ava-labs/libevm/params"
 "github.com/ava-labs/libevm/rlp"
 "github.com/ava-labs/libevm/trie"
 "github.com/ava-labs/libevm/trie/testutil"


### PR DESCRIPTION
## Why this should be merged

Until a complete transition to a `libevm` package, it shouldn't be allowed to be imported directly.

## How this works

Remove the package from the allowed list and move a `types` test into `package types_test` to avoid a circular dependency.

## How this was tested

NA

## Need to be documented?

No

## Need to update RELEASES.md?

No
