### PR TITLE
fix(params): add missing `CheckPrecompilesCompatible` call to `ChainConfig.checkCompatible`

### DIFF
--- a/params/config.go
+++ b/params/config.go
@@ -728,6 +728,7 @@ func (c *ChainConfig) CheckCompatible(newcfg *ChainConfig, height uint64, time u
 			bhead.SetUint64(err.RewindToBlock)
 		}
 	}
+
 	return lasterr
 }
 
@@ -885,6 +886,12 @@ func (c *ChainConfig) checkCompatible(newcfg *ChainConfig, headNumber *big.Int, 
 	if err := c.CheckNetworkUpgradesCompatible(&newcfg.NetworkUpgrades, headTimestamp); err != nil {
 		return err
 	}
+
+	// Check that the precompiles on the new config are compatible with the existing precompile config.
+	if err := c.CheckPrecompilesCompatible(newcfg.PrecompileUpgrades, headTimestamp); err != nil {
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Spotted by @darioush working on the libevm branch, in https://github.com/ava-labs/coreth/pull/820#discussion_r2010135791

The ChainConfig method  `CheckPrecompilesCompatible` was unused prior to this pull request.

## How this works

Call `CheckPrecompilesCompatible` method within `checkCompatible` function

## How this was tested

- [ ] existing CI passing
- [ ] Add test cases to TestCheckCompatible

## Need to be documented?

No

## Need to update RELEASES.md?

Maybe?
