### PR TITLE
chore(deps): align avalanchego version with master branch one

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.12.3-0.20250314173032-a3d150e0aad0
+	github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886
 	github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
@@ -42,7 +42,6 @@ require (
 require (
 	github.com/DataDog/zstd v1.5.2 // indirect
 	github.com/Microsoft/go-winio v0.6.1 // indirect
-	github.com/StephenButtolph/canoto v0.10.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bits-and-blooms/bitset v1.10.0 // indirect
 	github.com/btcsuite/btcd/btcec/v2 v2.3.2 // indirect
@@ -110,6 +109,7 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/supranational/blst v0.3.13 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
+	github.com/thepudds/fzgen v0.4.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,6 @@ github.com/Joker/hpp v1.0.0/go.mod h1:8x5n+M1Hp5hC0g8okX3sR3vFQwynaX/UgSOM9MeBKz
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
 github.com/Shopify/goreferrer v0.0.0-20181106222321-ec9c9a553398/go.mod h1:a1uqRtAwp2Xwc6WNPJEufxJ7fx3npB4UV/JOLmbu5I0=
-github.com/StephenButtolph/canoto v0.10.0 h1:KdW85TYQXH+gwR8vOxfOUf28TRpkLU+X06Kycg1IR7s=
-github.com/StephenButtolph/canoto v0.10.0/go.mod h1:MxppdgKRApRBvIg4ZgO2e14m/NSBjFMuydy97OB/gYY=
 github.com/VictoriaMetrics/fastcache v1.12.1 h1:i0mICQuojGDL3KblA7wUNlY5lOK6a4bwt3uRKnkZU40=
 github.com/VictoriaMetrics/fastcache v1.12.1/go.mod h1:tX04vaqcNoQeGLD+ra5pU5sWkuxnzWhEzLwhP9w653o=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
@@ -58,8 +56,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.12.3-0.20250314173032-a3d150e0aad0 h1:hpj9PYsuZ6EmCIrzDntfi8NJG6yd2UGH8QQS+4A2ZDE=
-github.com/ava-labs/avalanchego v1.12.3-0.20250314173032-a3d150e0aad0/go.mod h1:SScmofd4T6zDl6YeerdWa83q0+2Cf/V6eVmPITxf1Tc=
+github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886 h1:Xsu3iyvRAQsK9SozqPy4hWDo0k37Xrk9wjNYig0SJCQ=
+github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886/go.mod h1:pTFY9shpYMDDM5DDIMnQXNoYXiRSG9/gS0wcnE/2RLI=
 github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3 h1:1CWGo2icnX9dRqGQl7CFywYGIZWxe+ucy0w8NAsVTWE=
 github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/scripts/versions.sh
+++ b/scripts/versions.sh
@@ -18,9 +18,10 @@ if [[ -z ${AVALANCHE_VERSION:-} ]]; then
   # If not, the value is assumed to represent a tag
   if [[ "${AVALANCHE_VERSION}" =~ ^v.*[0-9]{14}-[0-9a-f]{12}$ ]]; then
     # Extract module hash from version
-    MODULE_HASH="$(echo "${AVALANCHE_VERSION}" | cut -d'-' -f3)"
+    MODULE_HASH="$(echo "${AVALANCHE_VERSION}" | grep -Eo '[0-9a-f]{12}$')"
 
     # The first 8 chars of the hash is used as the tag of avalanchego images
     AVALANCHE_VERSION="${MODULE_HASH::8}"
   fi
 fi
+echo $AVALANCHE_VERSION


### PR DESCRIPTION
## Why this should be merged

Previous avalanchego was based on top of v1.12.3, although master branch is based off v1.12.3-name-fortuna.0. This changes the avalanchego libevm to be based off v1.12.3-name-fortuna.0 as well.

## How this works

- Current avalanchego is now based on top of v1.12.3-name-fortuna.0
- Fix versions.sh to detect avalanchego commit hashes for names with more dashes

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
