### PR TITLE
chore(deps): bump libevm to v1.13.14-0.2.0.rc.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886
+	github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250326131842-1e9f474dee74
 	github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
@@ -109,7 +109,6 @@ require (
 	github.com/subosito/gotenv v1.3.0 // indirect
 	github.com/supranational/blst v0.3.13 // indirect
 	github.com/syndtr/goleveldb v1.0.1-0.20220614013038-64ee5596c38a // indirect
-	github.com/thepudds/fzgen v0.4.3 // indirect
 	github.com/tklauser/go-sysconf v0.3.12 // indirect
 	github.com/tklauser/numcpus v0.6.1 // indirect
 	github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 // indirect

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.6
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886
-	github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3
+	github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4
 	github.com/crate-crypto/go-ipa v0.0.0-20231025140028-3c0104f4b233
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886 h1:Xsu3iyvRAQsK9SozqPy4hWDo0k37Xrk9wjNYig0SJCQ=
 github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886/go.mod h1:pTFY9shpYMDDM5DDIMnQXNoYXiRSG9/gS0wcnE/2RLI=
-github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3 h1:1CWGo2icnX9dRqGQl7CFywYGIZWxe+ucy0w8NAsVTWE=
-github.com/ava-labs/libevm v1.13.14-0.2.0.rc.3/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
+github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4 h1:wnq3x3OE8DnBTBeKFjiywRO/MfnEXWjoSgnZtTQ1LS8=
+github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -56,8 +56,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886 h1:Xsu3iyvRAQsK9SozqPy4hWDo0k37Xrk9wjNYig0SJCQ=
-github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250325171534-e5413707e886/go.mod h1:pTFY9shpYMDDM5DDIMnQXNoYXiRSG9/gS0wcnE/2RLI=
+github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250326131842-1e9f474dee74 h1:3GYL5JGp8vsC3donZHU/Q/ylOdDjX4IRka87hBEVs6Q=
+github.com/ava-labs/avalanchego v1.12.3-name-fortuna.0.0.20250326131842-1e9f474dee74/go.mod h1:mcl8JQ5kJKmh1s0/+y/5NJirgwA2nR67h6iHfL5Dklk=
 github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4 h1:wnq3x3OE8DnBTBeKFjiywRO/MfnEXWjoSgnZtTQ1LS8=
 github.com/ava-labs/libevm v1.13.14-0.2.0.rc.4/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -114,15 +114,8 @@ type Config struct {
 	ReferenceRootAtomicallyOnUpdate bool   // Whether to reference the root node on update
 }
 
-func (c Config) BackendConstructor(diskdb ethdb.Database, config *triedb.Config) triedb.DBOverride {
-	var resolver ChildResolver
-	if config.IsVerkle {
-		// TODO define verkle resolver
-		log.Crit("Verkle node resolver is not defined")
-	} else {
-		resolver = trie.MerkleResolver{}
-	}
-	return New(diskdb, &c, resolver)
+func (c Config) BackendConstructor(diskdb ethdb.Database) triedb.DBOverride {
+	return New(diskdb, &c, trie.MerkleResolver{})
 }
 
 // Defaults is the default setting for database if it's not specified.

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -103,7 +103,7 @@ type Config struct {
 	ReadOnly       bool   // Flag whether the database is opened in read only mode.
 }
 
-func (c Config) BackendConstructor(diskdb ethdb.Database, _ *triedb.Config) triedb.DBOverride {
+func (c Config) BackendConstructor(diskdb ethdb.Database) triedb.DBOverride {
 	return New(diskdb, &c)
 }
 


### PR DESCRIPTION
## Why this should be merged

- [Metrics were not enabled correctly](https://github.com/ava-labs/coreth/pull/880)
- Address comments on the libevm branch review
  - [BackendConstructor does not need to support a future Verkle tree option](https://github.com/ava-labs/coreth/pull/820#discussion_r2010194724)
  - We want to [use upstream newTimestampCompatError which needs to be exported](https://github.com/ava-labs/coreth/pull/820#discussion_r2010136784)
- We want to use upstream rlpHash which needs to be exported
- We want to have a working rlpgen for type aliases

## How this works

- [Metrics enabled corrrectly](https://github.com/ava-labs/libevm/commit/7be6bee7ab32ebb89cafa134d5f9c30b8c5df733)
- [Remove `config` argument from `BackendConstructor`](https://github.com/ava-labs/libevm/commit/87a2d57b9686fc406276d0c65ed046bc3149ff27) since it's no longer needed
- [Export `newTimestampCompatError` with wrapping function `NewTimestampCompatErr`](https://github.com/ava-labs/libevm/commit/319a92458d062b021d375a431ed1c395f6714852)  (to be applied in #862)
- [Export `rlpHash` with wrapping function `RLPHash`](https://github.com/ava-labs/libevm/commit/433c6069e29f1bb2ee07b642592421685743ee2c) (to be applied in #862)
- [rlpgen supports type aliases](https://github.com/ava-labs/libevm/commit/739ba847f6f407f63fd6a24175b24e56fea583a1)
- [Better logging](https://github.com/ava-labs/libevm/commit/02110d3f3406745e1dee0ef7d46f767b07a694c3)

See https://github.com/ava-labs/libevm/compare/v1.13.14-0.2.0.rc.3...v1.13.14-0.2.0.rc.4 for a full list of changes

## How this was tested

CI passing

## Need to be documented?

No

## Need to update RELEASES.md?

No