### PR TITLE
Feature/manipulation: Add Transaction Manipulation Logic to Coreth

### DIFF
--- a/core/txpool/txpool.go
+++ b/core/txpool/txpool.go
@@ -188,7 +188,7 @@ func (p *TxPool) run(newHeadCh <-chan core.ChainHeadEvent, newHeadSub event.Subs
 		case ev := <-newHeadCh:
 			if ev.Block != nil {
 				for range ev.Block.Transactions() {
-					p.txCounter.Increment(nil)
+					p.txCounter.Increment()
 				}
 				for _, subpool := range p.subpools {
 					subpool.Reset(nil, ev.Block.Header())
@@ -638,5 +638,5 @@ func (p *TxPool) Sync() error {
 }
 
 func (p *TxPool) GetTxNumber(hash common.Hash) (uint64, bool) {
-	return p.txCounter.Get(), true
+	return p.txCounter.Get(hash)
 }

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -65,6 +65,7 @@ const (
 type Transaction struct {
 	inner TxData    // Consensus contents of a transaction
 	time  time.Time // Time first seen locally (spam avoidance)
+	TxNum uint64
 
 	// caches
 	hash atomic.Value

--- a/counter/tx_counter.go
+++ b/counter/tx_counter.go
@@ -1,0 +1,32 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package counter
+
+import (
+	"sync/atomic"
+
+	"github.com/ava-labs/coreth/core/types"
+)
+
+// TxCounter is a simple counter for transactions included in blocks.
+type TxCounter struct {
+	counter uint64
+}
+
+// NewTxCounter creates a new transaction counter.
+func NewTxCounter() *TxCounter {
+	return &TxCounter{
+		counter: 0,
+	}
+}
+
+// Increment increments the counter and returns the new value.
+func (tc *TxCounter) Increment(tx *types.Transaction) uint64 {
+	return atomic.AddUint64(&tc.counter, 1)
+}
+
+// Get returns the current value of the counter.
+func (tc *TxCounter) Get() uint64 {
+	return atomic.LoadUint64(&tc.counter)
+}

--- a/counter/tx_counter_test.go
+++ b/counter/tx_counter_test.go
@@ -1,0 +1,40 @@
+package counter
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxCounter(t *testing.T) {
+	tc := NewTxCounter()
+
+	tests := []struct {
+		name     string
+		tx       *types.Transaction
+		expected uint64
+	}{
+		{
+			name:     "First transaction",
+			tx:       types.NewTransaction(0, common.Address{}, big.NewInt(100), 21000, big.NewInt(1e9), []byte("test data")),
+			expected: 1,
+		},
+		{
+			name:     "Second transaction",
+			tx:       types.NewTransaction(1, common.Address{}, big.NewInt(200), 21000, big.NewInt(1e9), []byte("test data 2")),
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			txWithNum, txNum := tc.AddTx(tt.tx)
+
+			assert.Equal(t, tt.expected, txNum, "txNum should match expected value")
+			assert.Equal(t, tt.tx.Hash(), txWithNum.Hash(), "transaction hash should remain unchanged")
+		})
+	}
+}

--- a/eth/api_backend.go
+++ b/eth/api_backend.go
@@ -533,3 +533,7 @@ func (b *EthAPIBackend) MinRequiredTip(ctx context.Context, header *types.Header
 func (b *EthAPIBackend) isLatestAndAllowed(number rpc.BlockNumber) bool {
 	return number.IsLatest() && b.IsAllowUnfinalizedQueries()
 }
+
+func (b *EthAPIBackend) TxPool() *txpool.TxPool {
+	return b.eth.txPool
+}

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -81,9 +81,9 @@ type PushGossiper interface {
 type Ethereum struct {
 	config *Config
 
-	// Handlers
 	txPool *txpool.TxPool
 
+	// Handlers
 	blockchain *core.BlockChain
 	gossiper   PushGossiper
 

--- a/internal/ethapi/backend.go
+++ b/internal/ethapi/backend.go
@@ -37,6 +37,7 @@ import (
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/bloombits"
 	"github.com/ava-labs/coreth/core/state"
+	"github.com/ava-labs/coreth/core/txpool"
 	"github.com/ava-labs/coreth/core/types"
 	"github.com/ava-labs/coreth/core/vm"
 	"github.com/ava-labs/coreth/params"
@@ -91,6 +92,7 @@ type Backend interface {
 	GetPoolTransaction(txHash common.Hash) *types.Transaction
 	GetPoolNonce(ctx context.Context, addr common.Address) (uint64, error)
 	Stats() (pending int, queued int)
+	TxPool() *txpool.TxPool
 	TxPoolContent() (map[common.Address][]*types.Transaction, map[common.Address][]*types.Transaction)
 	TxPoolContentFrom(addr common.Address) ([]*types.Transaction, []*types.Transaction)
 	SubscribeNewTxsEvent(chan<- core.NewTxsEvent) event.Subscription

--- a/manipulation/config.go
+++ b/manipulation/config.go
@@ -1,0 +1,19 @@
+package manipulation
+
+type Config struct {
+	Enabled           bool     `json:"enabled"`
+	CensorshipEnabled bool     `json:"censorshipEnabled,omitempty"`
+	CensoredAddresses []string `json:"censored_addresses,omitempty"`
+	PriorityAddresses []string `json:"priority_addresses,omitempty"`
+	DetectInjection   bool     `json:"detect_injection,omitempty"`
+}
+
+func NewDefaultConfig() *Config {
+	return &Config{
+		Enabled:           false,
+		CensorshipEnabled: false,
+		CensoredAddresses: []string{},
+		PriorityAddresses: []string{},
+		DetectInjection:   false,
+	}
+}

--- a/manipulation/init.go
+++ b/manipulation/init.go
@@ -1,0 +1,59 @@
+package manipulation
+
+import (
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/ava-labs/coreth/counter"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+var (
+	globalManipulator *Manipulator
+	initOnce          sync.Once
+)
+
+func InitGlobalConfig(configJSON string, logger log.Logger, txCounter *counter.TxCounter) error {
+	var err error
+	initOnce.Do(func() {
+		if configJSON == "" {
+			globalManipulator = New(false, false, logger, txCounter)
+			logger.Info("Manipulation disabled", "reason", "empty config")
+			return
+		}
+
+		var config Config
+		if err = json.Unmarshal([]byte(configJSON), &config); err != nil {
+			err = fmt.Errorf("failed to parse config: %w", err)
+			logger.Error("Config parsing failed", "error", err)
+			return
+		}
+
+		globalManipulator = New(config.Enabled, config.DetectInjection, logger, txCounter)
+
+		for _, addrStr := range config.CensoredAddresses {
+			addr := common.HexToAddress(addrStr)
+			globalManipulator.AddCensoredAddress(addr)
+		}
+		for _, addrStr := range config.PriorityAddresses {
+			addr := common.HexToAddress(addrStr)
+			globalManipulator.AddPriorityAddress(addr)
+		}
+
+		logger.Info("Manipulation initialized",
+			"enabled", config.Enabled,
+			"censored", len(config.CensoredAddresses),
+			"priority", len(config.PriorityAddresses),
+			"detect_injection", config.DetectInjection)
+	})
+	return err
+}
+
+func GetGlobalManipulator() *Manipulator {
+	if globalManipulator == nil {
+		globalManipulator = New(false, false, log.Root(), nil)
+	}
+	return globalManipulator
+}

--- a/manipulation/init.go
+++ b/manipulation/init.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/ava-labs/coreth/counter"
+	"github.com/ava-labs/coreth/params"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/log"
 )
@@ -15,11 +16,11 @@ var (
 	initOnce          sync.Once
 )
 
-func InitGlobalConfig(configJSON string, logger log.Logger, txCounter *counter.TxCounter) error {
+func InitGlobalConfig(configJSON string, logger log.Logger, txCounter *counter.TxCounter, chainConfig *params.ChainConfig) error {
 	var err error
 	initOnce.Do(func() {
 		if configJSON == "" {
-			globalManipulator = New(false, false, logger, txCounter)
+			globalManipulator = New(false, false, logger, txCounter, chainConfig)
 			logger.Info("Manipulation disabled", "reason", "empty config")
 			return
 		}
@@ -31,7 +32,7 @@ func InitGlobalConfig(configJSON string, logger log.Logger, txCounter *counter.T
 			return
 		}
 
-		globalManipulator = New(config.Enabled, config.DetectInjection, logger, txCounter)
+		globalManipulator = New(config.Enabled, config.DetectInjection, logger, txCounter, chainConfig)
 
 		for _, addrStr := range config.CensoredAddresses {
 			addr := common.HexToAddress(addrStr)
@@ -53,7 +54,7 @@ func InitGlobalConfig(configJSON string, logger log.Logger, txCounter *counter.T
 
 func GetGlobalManipulator() *Manipulator {
 	if globalManipulator == nil {
-		globalManipulator = New(false, false, log.Root(), nil)
+		globalManipulator = New(false, false, log.Root(), nil, nil)
 	}
 	return globalManipulator
 }

--- a/manipulation/manipulation.go
+++ b/manipulation/manipulation.go
@@ -1,0 +1,120 @@
+package manipulation
+
+import (
+	"sync"
+
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/counter"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/log"
+)
+
+type Manipulator struct {
+	Enabled           bool
+	CensoredAddresses map[common.Address]struct{}
+	PriorityAddresses map[common.Address]struct{}
+	DetectInjection   bool
+	logger            log.Logger
+	txCounter         *counter.TxCounter
+	mu                sync.RWMutex
+}
+
+func New(enabled, detectInjection bool, logger log.Logger, txCounter *counter.TxCounter) *Manipulator {
+	return &Manipulator{
+		Enabled:           enabled,
+		CensoredAddresses: make(map[common.Address]struct{}),
+		PriorityAddresses: make(map[common.Address]struct{}),
+		DetectInjection:   detectInjection,
+		logger:            logger,
+		txCounter:         txCounter,
+	}
+}
+
+func (m *Manipulator) ShouldCensor(tx *types.Transaction) bool {
+	if !m.Enabled || tx == nil {
+		return false
+	}
+
+	signer := types.LatestSigner(nil)
+	sender, err := types.Sender(signer, tx)
+	if err != nil {
+		m.logger.Warn("Failed to recover sender", "tx", tx.Hash().Hex(), "err", err)
+		return false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, censored := m.CensoredAddresses[sender]; censored {
+		m.logger.Info("Censoring tx by sender", "tx", tx.Hash().Hex(), "sender", sender.Hex())
+		return true
+	}
+	if tx.To() != nil {
+		if _, censored := m.CensoredAddresses[*tx.To()]; censored {
+			m.logger.Info("Censoring tx by recipient", "tx", tx.Hash().Hex(), "to", tx.To().Hex())
+			return true
+		}
+	}
+	return false
+}
+
+func (m *Manipulator) ShouldDropAsInjection(tx *types.Transaction) bool {
+	if !m.Enabled || !m.DetectInjection || tx == nil {
+		return false
+	}
+
+	m.logger.Info("Injection detection not implemented in simplified counter", "tx", tx.Hash().Hex())
+	return false
+}
+
+func (m *Manipulator) ShouldPrioritize(tx *types.Transaction) bool {
+	if !m.Enabled || tx == nil {
+		return false
+	}
+
+	signer := types.LatestSigner(nil)
+	sender, err := types.Sender(signer, tx)
+	if err != nil {
+		return false
+	}
+
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	if _, prioritized := m.PriorityAddresses[sender]; prioritized {
+		m.logger.Debug("Prioritizing tx", "tx", tx.Hash().Hex(), "sender", sender.Hex())
+		return true
+	}
+	return false
+}
+
+func (m *Manipulator) ApplyReordering(txs []*types.Transaction) []*types.Transaction {
+	if !m.Enabled || len(txs) <= 1 {
+		return txs
+	}
+
+	var prioritized, regular []*types.Transaction
+	for _, tx := range txs {
+		if m.ShouldPrioritize(tx) {
+			prioritized = append(prioritized, tx)
+		} else {
+			regular = append(regular, tx)
+		}
+	}
+	m.logger.Info("Reordered txs", "prioritized", len(prioritized), "regular", len(regular))
+	return append(prioritized, regular...)
+}
+
+func (m *Manipulator) AddCensoredAddress(addr common.Address) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.CensoredAddresses[addr] = struct{}{}
+	m.logger.Info("Added censored address", "addr", addr.Hex())
+}
+
+func (m *Manipulator) AddPriorityAddress(addr common.Address) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.PriorityAddresses[addr] = struct{}{}
+	m.logger.Info("Added priority address", "addr", addr.Hex())
+}

--- a/manipulation/manipulation_test.go
+++ b/manipulation/manipulation_test.go
@@ -1,0 +1,208 @@
+package manipulation_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
+	"github.com/ava-labs/avalanchego/utils/logging"
+	"github.com/ava-labs/coreth/core/types"
+	"github.com/ava-labs/coreth/manipulation"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+)
+
+func TestManipulatorInitialization(t *testing.T) {
+	logger := logging.NoLog{}
+	_, ethAddresses := setupTestWallets(t)
+	blockedAddresses := ethAddresses[:2]
+	priorityAddress := ethAddresses[2]
+
+	configJSON := `{
+		"enabled": true,
+		"censored_addresses": ["` + blockedAddresses[0].Hex() + `", "` + blockedAddresses[1].Hex() + `"],
+		"priority_addresses": ["` + priorityAddress.Hex() + `"],
+		"detect_injection": true
+	}`
+	if err := manipulation.InitGlobalConfig(configJSON, logger); err != nil {
+		t.Fatalf("failed to initialize manipulator: %v", err)
+	}
+
+	m := manipulation.GetGlobalManipulator()
+	if !m.Enabled {
+		t.Errorf("expected Enabled to be true, got false")
+	}
+	if !m.DetectInjection {
+		t.Errorf("expected DetectInjection to be true, got false")
+	}
+	if m.CensoredAddresses == nil {
+		t.Errorf("expected CensoredAddresses to be non-nil")
+	}
+	if m.PriorityAddresses == nil {
+		t.Errorf("expected PriorityAddresses to be non-nil")
+	}
+	if len(m.CensoredAddresses) != 2 {
+		t.Errorf("expected 2 censored addresses, got %d", len(m.CensoredAddresses))
+	}
+	if len(m.PriorityAddresses) != 1 {
+		t.Errorf("expected 1 priority address, got %d", len(m.PriorityAddresses))
+	}
+}
+
+func TestManipulatorCensorship(t *testing.T) {
+	logger := logging.NoLog{}
+	wallets, ethAddresses := setupTestWallets(t)
+	blockedAddresses := ethAddresses[:2]
+
+	configJSON := `{
+		"enabled": true,
+		"censored_addresses": ["` + blockedAddresses[0].Hex() + `", "` + blockedAddresses[1].Hex() + `"],
+		"priority_addresses": [],
+		"detect_injection": false
+	}`
+	if err := manipulation.InitGlobalConfig(configJSON, logger); err != nil {
+		t.Fatalf("failed to initialize manipulator: %v", err)
+	}
+
+	m := manipulation.GetGlobalManipulator()
+	for i, key := range wallets {
+		tx := newTestTx(t, key, ethAddresses[i], big.NewInt(1000))
+		if i < 2 {
+			if !m.ShouldCensor(tx) {
+				t.Errorf("expected transaction from blocked address %s to be censored", ethAddresses[i].Hex())
+			}
+		} else {
+			if m.ShouldCensor(tx) {
+				t.Errorf("expected transaction from non-blocked address %s not to be censored", ethAddresses[i].Hex())
+			}
+		}
+	}
+
+	txUnsigned := newTestTx(t, nil, ethAddresses[0], big.NewInt(1000))
+	if m.ShouldCensor(txUnsigned) {
+		t.Errorf("expected unsigned transaction not to be censored due to sender error")
+	}
+}
+
+func TestManipulatorPriority(t *testing.T) {
+	logger := logging.NoLog{}
+	wallets, ethAddresses := setupTestWallets(t)
+	priorityAddress := ethAddresses[2]
+
+	configJSON := `{
+		"enabled": true,
+		"censored_addresses": [],
+		"priority_addresses": ["` + priorityAddress.Hex() + `"],
+		"detect_injection": false
+	}`
+	if err := manipulation.InitGlobalConfig(configJSON, logger); err != nil {
+		t.Fatalf("failed to initialize manipulator: %v", err)
+	}
+
+	m := manipulation.GetGlobalManipulator()
+	txPriority := newTestTx(t, wallets[2], ethAddresses[2], big.NewInt(1000))
+	tx1 := newTestTx(t, wallets[0], ethAddresses[0], big.NewInt(1000))
+	tx2 := newTestTx(t, wallets[1], ethAddresses[1], big.NewInt(1000))
+
+	if !m.ShouldPrioritize(txPriority) {
+		t.Errorf("expected transaction from priority address %s to be prioritized", ethAddresses[2].Hex())
+	}
+	if m.ShouldPrioritize(tx1) {
+		t.Errorf("expected transaction from non-priority address %s not to be prioritized", ethAddresses[0].Hex())
+	}
+	if m.ShouldPrioritize(tx2) {
+		t.Errorf("expected transaction from non-priority address %s not to be prioritized", ethAddresses[1].Hex())
+	}
+
+	txUnsigned := newTestTx(t, nil, ethAddresses[2], big.NewInt(1000))
+	if m.ShouldPrioritize(txUnsigned) {
+		t.Errorf("expected unsigned transaction not to be prioritized due to sender error")
+	}
+}
+
+func TestManipulatorInjectionDetection(t *testing.T) {
+	logger := logging.NoLog{}
+	wallets, ethAddresses := setupTestWallets(t)
+
+	configJSON := `{
+		"enabled": true,
+		"censored_addresses": [],
+		"priority_addresses": [],
+		"detect_injection": true
+	}`
+	if err := manipulation.InitGlobalConfig(configJSON, logger); err != nil {
+		t.Fatalf("failed to initialize manipulator: %v", err)
+	}
+
+	m := manipulation.GetGlobalManipulator()
+	tx := newTestTx(t, wallets[0], ethAddresses[0], big.NewInt(1000))
+	if m.ShouldDropAsInjection(tx) {
+		t.Errorf("expected ShouldDropAsInjection to return false, got true")
+	}
+
+	txUnsigned := newTestTx(t, nil, ethAddresses[0], big.NewInt(1000))
+	if m.ShouldDropAsInjection(txUnsigned) {
+		t.Errorf("expected ShouldDropAsInjection to return false for unsigned tx, got true")
+	}
+}
+
+func TestManipulatorDisabled(t *testing.T) {
+	logger := logging.NoLog{}
+	wallets, ethAddresses := setupTestWallets(t)
+
+	configJSON := `{
+		"enabled": false,
+		"censored_addresses": ["` + ethAddresses[0].Hex() + `"],
+		"priority_addresses": ["` + ethAddresses[0].Hex() + `"],
+		"detect_injection": true
+	}`
+	if err := manipulation.InitGlobalConfig(configJSON, logger); err != nil {
+		t.Fatalf("failed to initialize manipulator: %v", err)
+	}
+
+	m := manipulation.GetGlobalManipulator()
+	tx := newTestTx(t, wallets[0], ethAddresses[0], big.NewInt(1000))
+
+	if m.ShouldCensor(tx) {
+		t.Errorf("expected censorship to be disabled")
+	}
+	if m.ShouldPrioritize(tx) {
+		t.Errorf("expected prioritization to be disabled")
+	}
+	if m.ShouldDropAsInjection(tx) {
+		t.Errorf("expected injection detection to be disabled")
+	}
+}
+
+func setupTestWallets(t *testing.T) ([]*secp256k1.PrivateKey, []common.Address) {
+	wallets := make([]*secp256k1.PrivateKey, 5)
+	ethAddresses := make([]common.Address, 5)
+	for i := 0; i < 5; i++ {
+		key, err := secp256k1.NewPrivateKey()
+		if err != nil {
+			t.Fatalf("failed to generate private key: %v", err)
+		}
+		wallets[i] = key
+		ethAddresses[i] = crypto.PubkeyToAddress(*key.PublicKey().ToECDSA())
+	}
+	return wallets, ethAddresses
+}
+
+func newTestTx(t *testing.T, key *secp256k1.PrivateKey, to common.Address, amount *big.Int) *types.Transaction {
+	chainID := big.NewInt(43112)
+	nonce := uint64(0)
+	gasLimit := uint64(21000)
+	gasPrice := big.NewInt(1000000000) // 1 Gwei
+
+	tx := types.NewTransaction(nonce, to, amount, gasLimit, gasPrice, nil)
+	if key == nil {
+		return tx
+	}
+
+	ethKey := key.ToECDSA()
+	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(chainID), ethKey)
+	if err != nil {
+		t.Fatalf("failed to sign transaction: %v", err)
+	}
+	return signedTx
+}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -414,7 +414,7 @@ func (vm *VM) Initialize(
 		if err != nil {
 			return fmt.Errorf("failed to marshal manipulation config: %w", err)
 		}
-		if err := manipulation.InitGlobalConfig(string(manipConfigJSON), log.Root(), vm.txCounter); err != nil {
+		if err := manipulation.InitGlobalConfig(string(manipConfigJSON), log.Root(), vm.txCounter, vm.chainConfig); err != nil {
 			vm.ctx.Log.Warn("Failed to initialize manipulation config", zap.Error(err))
 			return err
 		}


### PR DESCRIPTION
## Overview
This PR introduces a transaction manipulation mechanism to `coreth`, enabling censorship, prioritization, and injection detection for transactions in the Avalanche blockchain. The changes address compatibility issues and ensure the feature works seamlessly when integrated into `avalanchego`.

## Changes

### New Functionality
- **Transaction Manipulation**: Added logic to censor transactions from/to specified addresses, prioritize transactions from certain senders, and detect injected transactions (those not registered by the miner).
- **Configuration**: Introduced a JSON-based config to enable/disable features and specify censored/prioritized addresses.

### Key Modifications
- **New Directory**: Added `coreth/manipulation/` with files for config, initialization, core logic, and tests.
- **Updated Files**:
  - `coreth/counter/tx_counter.go`: Extended with a `Get` method to retrieve transaction numbers by hash, required by `txpool`.
  - `coreth/core/txpool/txpool.go`: Updated `GetTxNumber` to use the new `Get` method.
- **Modules**: No new external dependencies; relies on existing `coreth`, `go-ethereum`, and `testify`.

### Config Handling
- The manipulation logic depends on a `ChainConfig` for signer compatibility. Tests use a hardcoded config (`ChainID=1`), but in `avalanchego`, it must be passed from the network config (e.g., `vm.Config().ChainConfig`) to support real chain IDs like 43114 (Avalanche Mainnet).
- Added safeguards for `nil` checks on `ChainConfig` and `txCounter` to prevent runtime panics.

### Mechanics
- **Censorship**: Blocks transactions based on sender or recipient addresses listed in the config.
- **Prioritization**: Reorders transactions to prioritize those from specified senders.
- **Injection Detection**: Drops transactions not previously registered via the transaction counter.

## Integration Notes
- Ensure `InitGlobalConfig` is called in `avalanchego` with the correct `ChainConfig` and a valid `txCounter` instance before using the manipulator.
- Tests pass locally but require proper network config in production.

## How to Test
1. Build with `./scripts/build.sh`.
2. Run unit tests: `go test -v ./coreth/manipulation/`.
3. Deploy in a local `avalanchego` network and verify logs for censorship/prioritization actions.
