### PR TITLE
docs: add releasing document

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,7 @@ To support these changes, there have been a number of changes to the C-Chain blo
 * `BaseFee`: Added by EIP-1559 to represent the base fee of the block (present in Ethereum as of EIP-1559)
 * `ExtDataGasUsed`: amount of gas consumed by the atomic transactions in the block
 * `BlockGasCost`: surcharge for producing a block faster than the target rate
+
+## Releasing
+
+See [docs/releasing/README.md](docs/releasing/README.md) for the release process.

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -1,0 +1,80 @@
+# Releasing
+
+## When to release
+
+- When Coreth needs to release a new feature or bug fix.
+
+## Procedure
+
+### Release candidate
+
+ℹ️ you should always create a release candidate first, and only if everything is fine, you can create a release.
+
+In this section, we create a release candidate `v0.15.0-rc.0`. We therefore assign these environment variables to simplify copying instructions:
+
+```bash
+export VERSION_RC=v0.15.0-rc.0
+export VERSION=v0.15.0
+```
+
+1. Create your branch, usually from the tip of the `master` branch:
+
+    ```bash
+    git fetch origin master:master
+    git checkout master
+    git checkout -b "releases/$VERSION_RC"
+    ```
+
+1. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
+1. Ensure the AvalancheGo version used in [go.mod](../../go.mod) is [its last release](https://github.com/ava-labs/avalanchego/releases). If not, upgrade it with, for example:
+
+    ```bash
+    go get github.com/ava-labs/avalanchego@v1.13.0
+    go mod tidy
+    ```
+
+    And fix any errors that may arise from the upgrade. If it requires significant changes, you may want to create a separate PR for the upgrade and wait for it to be merged before continuing with this procedure.
+1. Update the [RELEASES.md](../../RELEASES.md) file with the new version.
+1. Commit your changes and push the branch
+
+    ```bash
+    git add .
+    git commit -S -m "chore: release $VERSION_RC"
+    git push -u origin "releases/$VERSION_RC"
+    ```
+
+1. Create a pull request (PR) from your branch targeting master, for example using [`gh`](https://cli.github.com/):
+
+    ```bash
+    gh pr create --repo github.com/ava-labs/subnet-evm --base master --title "chore: release $VERSION_RC"
+    ```
+
+1. Once the PR checks pass, squash and merge it
+1. Update your master branch, create a tag and push it:
+
+    ```bash
+    git checkout master
+    git fetch origin master:master
+    git tag "$VERSION_RC"
+    git push -u origin "$VERSION_RC"
+    ```
+
+Once the tag is created, you need to test it on the Fuji testnet.
+
+### Release
+
+If a successful release candidate was created, you can now create a release.
+
+Following the previous example in the [Release candidate section](#release-candidate), we will create a release `v0.15.0` indicated by the `$VERSION` variable.
+
+1. Head to the last release candidate pull request, and **restore** the deleted branch at the bottom of the Github page.
+1. Create a new release through the [Github web interface](https://github.com/ava-labs/subnet-evm/releases/new)
+    1. In the "Choose a tag" box, enter `$VERSION` (`v0.15.0`)
+    1. In the "Target", pick the previously restored last release candidate branch `releases/${VERSION_RC}`, for example `releases/v0.15.0-rc.0`.
+    Do not select `master` as the target branch to prevent adding new master branch commits to the release.
+    1. Pick the previous release, for example as `v0.14.0` in our case, since the default would be the last release candidate.
+    1. Set the "Release title" to `$VERSION` (`v0.15.0`)
+    1. Set the description (breaking changes, features, fixes, documentation); you might want to use the [RELEASES.md](../../RELEASES.md) document.
+    1. Only tick the box "Set as the latest release"
+    1. Click on the "Create release" button
+1. Create a pull request upgrading the coreth dependency on [AvalancheGo](https://github.com/ava-labs/avalanchego).

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -21,7 +21,7 @@ export VERSION=v0.15.0
     git checkout -b "releases/$VERSION_RC"
     ```
 
-1. Update the [RELEASES.md](../../RELEASES.md) file with the new release version `$VERSION`.
+1. Update the [RELEASES.md](../../RELEASES.md) file by renaming the "Pending" section to the new release version `$VERSION` and creating a new "Pending" section at the top.
 1. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
 1. Because AvalancheGo and coreth depend on each other, and that we create releases of AvalancheGo before coreth, you can use a recent commit hash or recent release candidate of AvalancheGo in your `go.mod` file.
 1. Commit your changes and push the branch

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -1,9 +1,5 @@
 # Releasing
 
-## When to release
-
-- When Coreth needs to release a new feature or bug fix.
-
 ## Procedure
 
 ### Release candidate

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -101,6 +101,8 @@ Following the previous example in the [Release candidate section](#release-candi
         1. Set the description using this format:
 
             ```markdown
+            This is the Coreth version used in AvalancheGo@v1.13.1
+
             # Breaking changes
 
             # Features
@@ -117,7 +119,9 @@ Following the previous example in the [Release candidate section](#release-candi
 
         ```bash
         PREVIOUS_VERSION=v0.14.0
-        NOTES="# Breaking changes
+        NOTES="This is the Coreth version used in AvalancheGo@v1.13.1
+
+        # Breaking changes
 
         # Features
 

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -23,14 +23,7 @@ export VERSION=v0.15.0
 
 1. Update the [RELEASES.md](../../RELEASES.md) file with the new release version `$VERSION`.
 1. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
-1. Ensure the AvalancheGo version used in [go.mod](../../go.mod) is [its last release](https://github.com/ava-labs/avalanchego/releases). If not, upgrade it with, for example:
-
-    ```bash
-    go get github.com/ava-labs/avalanchego@v1.13.0
-    go mod tidy
-    ```
-
-    And fix any errors that may arise from the upgrade. If it requires significant changes, you may want to create a separate PR for the upgrade and wait for it to be merged before continuing with this procedure.
+1. Because AvalancheGo and coreth depend on each other, and that we create releases of AvalancheGo before coreth, you can use a recent commit hash or recent release candidate of AvalancheGo in your `go.mod` file.
 1. Commit your changes and push the branch
 
     ```bash
@@ -69,11 +62,11 @@ export VERSION=v0.15.0
     git push origin "$VERSION_RC"
     ```
 
-1. Once the release candidate tag is created, create a pull request on the AvalancheGo repository, bumping the coreth dependency to use this release candidate. Once proven stable, you can create a release.
+1. Once the release candidate tag is created, create a pull request on the AvalancheGo repository, bumping the coreth dependency to use this release candidate. Once proven stable, an AvalancheGo release should be created, after which you can create a coreth release.
 
 ### Release
 
-If a successful release candidate was created, you can now create a release.
+If a successful release candidate was created and integrated in a release of AvalancheGo, you can now create a release.
 
 Following the previous example in the [Release candidate section](#release-candidate) we will create a release `v0.15.0` indicated by the `$VERSION` variable.
 
@@ -129,4 +122,4 @@ Following the previous example in the [Release candidate section](#release-candi
         gh release create "$VERSION" --notes-start-tag "$PREVIOUS_VERSION" --notes-from-tag "$VERSION" --title "$VERSION" --notes "$NOTES" --verify-tag
         ```
 
-1. Create a pull request upgrading the coreth dependency on [AvalancheGo](https://github.com/ava-labs/avalanchego).
+Note this release will likely never be used in AvalancheGo, which should always be using release candidates to accelerate the development process. However it is still useful to have a release to indicate the last stable version of coreth.

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -23,7 +23,7 @@ export VERSION=v0.15.0
 
 1. Update the [RELEASES.md](../../RELEASES.md) file by renaming the "Pending" section to the new release version `$VERSION` and creating a new "Pending" section at the top.
 1. Modify the [plugin/evm/version.go](../../plugin/evm/version.go) `Version` global string variable and set it to the desired `$VERSION`.
-1. Because AvalancheGo and coreth depend on each other, and that we create releases of AvalancheGo before coreth, you can use a recent commit hash or recent release candidate of AvalancheGo in your `go.mod` file.
+1. Because AvalancheGo and coreth depend on each other, and that we create releases of AvalancheGo before coreth, you can use a recent commit hash or recent release candidate of AvalancheGo in your `go.mod` file. Coreth releases should be tightly coordinated with AvalancheGo releases.
 1. Commit your changes and push the branch
 
     ```bash

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -35,13 +35,6 @@ export VERSION=v0.15.0
     ```
 
     And fix any errors that may arise from the upgrade. If it requires significant changes, you may want to create a separate PR for the upgrade and wait for it to be merged before continuing with this procedure.
-1. Specify the AvalancheGo compatibility in the [README.md relevant section](../../README.md#avalanchego-compatibility). For example we would add:
-
-    ```text
-    ...
-    [v0.7.3] AvalancheGo@v1.12.2/1.13.0-fuji/1.13.0 (Protocol Version: 39)
-    ```
-
 1. Commit your changes and push the branch
 
     ```bash


### PR DESCRIPTION
## Why this should be merged

Clarify when, and how to create a release.

↪️  [**Rendered readme**](https://github.com/ava-labs/coreth/blob/qdm12/docs/releasing/docs/releasing/README.md)

## How this works

- [x] When to create a release
- [x] RC release procedure
  - [x] Git tag publishing
  - [x] Testing
- [x] Release procedure (non-RC)

## How this was tested

Will be tested on next release v0.15.0. Maybe we should merge this post-v0.15.0 to make it contain everything.

## Need to be documented?

Yes, linked from root README.md

## Need to update RELEASES.md?
