### PR TITLE
test(core/genesis): fix UT to be sensitive to `SetEthUpgrades`

### DIFF
--- a/core/genesis_extra_test.go
+++ b/core/genesis_extra_test.go
@@ -47,8 +47,8 @@ func TestGenesisEthUpgrades(t *testing.T) {
 		&params.ChainConfig{
 			ChainID:             big.NewInt(43114), // Specifically refers to mainnet for this UT
 			HomesteadBlock:      big.NewInt(0),
-			DAOForkBlock:        nil,
-			DAOForkSupport:      false,
+			DAOForkBlock:        big.NewInt(0),
+			DAOForkSupport:      true,
 			EIP150Block:         big.NewInt(0),
 			EIP155Block:         big.NewInt(0),
 			EIP158Block:         big.NewInt(0),

--- a/core/genesis_extra_test.go
+++ b/core/genesis_extra_test.go
@@ -45,8 +45,13 @@ func TestGenesisEthUpgrades(t *testing.T) {
 	db := rawdb.NewMemoryDatabase()
 	preEthUpgrades := params.WithExtra(
 		&params.ChainConfig{
-			ChainID:             big.NewInt(43114), // Specifically refers to mainnet for this UT
-			HomesteadBlock:      big.NewInt(0),
+			ChainID:        big.NewInt(43114), // Specifically refers to mainnet for this UT
+			HomesteadBlock: big.NewInt(0),
+			// For this test to be a proper regression test, DAOForkBlock and
+			// DAOForkSupport should be set to match the values in
+			// [params.SetEthUpgrades]. Otherwise, in case of a regression, the test
+			// would pass as there would be a mismatch at genesis, which is
+			// incorrectly considered a success.
 			DAOForkBlock:        big.NewInt(0),
 			DAOForkSupport:      true,
 			EIP150Block:         big.NewInt(0),


### PR DESCRIPTION
Prior to this change, the unit test will still pass if the line:
```
params.SetEthUpgrades(storedcfg)
```
is removed from genesis.go.

This is because `RewindToBlock` and `RewindToTime` are overloaded where 0 both means "rewind to genesis" and that "block number or timestamp is not used for setting the fork" (i.e, the other one is used).

If the line is removed it will conflict on the DAO fork block / flag, then rewind to genesis, then the UT will pass, which defeats the purpose of this UT.

