### PR TITLE
fix(metrics/prometheus): add case for `StandardGaugeInfo` to skip

### DIFF
--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -57,7 +57,8 @@ func (g *Gatherer) Gather() (mfs []*dto.MetricFamily, err error) {
 }
 
 var (
-	errMetricSkip = errors.New("metric skipped")
+	errMetricSkip             = errors.New("metric skipped")
+	errMetricTypeNotSupported = errors.New("metric type is not supported")
 )
 
 func ptrTo[T any](x T) *T { return &x }
@@ -201,6 +202,6 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 		// TODO(qdm12) handle this somehow maybe with dto.MetricType_UNTYPED
 		return nil, fmt.Errorf("%w: %q is a %T", errMetricSkip, name, metric)
 	default:
-		return nil, fmt.Errorf("metric %q: type is not supported: %T", name, metric)
+		return nil, fmt.Errorf("%w: metric %q type %T", errMetricTypeNotSupported, name, metric)
 	}
 }

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -198,7 +198,7 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 				},
 			}},
 		}, nil
-	case *metrics.StandardGaugeInfo:
+	case metrics.GaugeInfo:
 		// TODO(qdm12) handle this somehow maybe with dto.MetricType_UNTYPED
 		return nil, fmt.Errorf("%w: %q is a %T", errMetricSkip, name, metric)
 	default:

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -197,7 +197,7 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 				},
 			}},
 		}, nil
-	case metrics.StandardGaugeInfo:
+	case *metrics.StandardGaugeInfo:
 		// TODO(qdm12) handle this somehow maybe with dto.MetricType_UNTYPED
 		return nil, fmt.Errorf("%w: %q is a %T", errMetricSkip, name, metric)
 	default:

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -197,6 +197,9 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 				},
 			}},
 		}, nil
+	case metrics.StandardGaugeInfo:
+		// TODO(qdm12) handle this somehow maybe with dto.MetricType_UNTYPED
+		return nil, fmt.Errorf("%w: %q is a %T", errMetricSkip, name, metric)
 	default:
 		return nil, fmt.Errorf("metric %q: type is not supported: %T", name, metric)
 	}

--- a/metrics/prometheus/prometheus_test.go
+++ b/metrics/prometheus/prometheus_test.go
@@ -90,8 +90,8 @@ func TestGatherer_Gather(t *testing.T) {
 	}
 	assert.Equal(t, want, familyStrings)
 
-	register(t, "unsupported", metrics.NewGaugeInfo())
+	register(t, "unsupported", metrics.NewHealthcheck(nil))
 	families, err = gatherer.Gather()
-	assert.EqualError(t, err, "metric \"unsupported\": type is not supported: *metrics.StandardGaugeInfo")
+	assert.ErrorIs(t, err, errMetricTypeNotSupported)
 	assert.Empty(t, families)
 }


### PR DESCRIPTION
## Why this should be merged

Case was missing in switch making all metrics registration error out.

## How this works

add a case to handle StandardGaugeInfo

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
