### PR TITLE
Simplify `eth_suggestPriceOptions` handling of `baseFee`s

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -5,6 +5,8 @@
 - Major refactor to use [`libevm`](https://github.com/ava-labs/libevm) for EVM execution, database access, types & chain configuration. This improves maintainability and enables keeping up with upstream changes more easily.
 - Add metrics for ACP-176
 
+- Removed the `"price-options-max-base-fee"` config flag
+
 ## [v0.15.0](https://github.com/ava-labs/coreth/releases/tag/v0.15.0)
 
 - Bump golang version to v1.23.6
@@ -13,7 +15,7 @@
 - Add `GasTarget` to the chain config to allow modifying the chain's `GasTarget` based on the ACP-176 rules
 
 - Added `eth_suggestPriceOptions` API to suggest gas prices (slow, normal, fast) based on the current network conditions
-- Added `"po-slow-fee-percentage"`, `"po-fast-fee-percentage"`, `"po-max-base-fee"`, and `"po-max-tip"` config flags to configure the new `eth_suggestPriceOptions` API
+- Added `"price-options-slow-fee-percentage"`, `"price-options-fast-fee-percentage"`, `"price-options-max-base-fee"`, and `"price-options-max-tip"` config flags to configure the new `eth_suggestPriceOptions` API
 
 ## [v0.14.1](https://github.com/ava-labs/coreth/releases/tag/v0.14.1)
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,7 +4,6 @@
 
 - Major refactor to use [`libevm`](https://github.com/ava-labs/libevm) for EVM execution, database access, types & chain configuration. This improves maintainability and enables keeping up with upstream changes more easily.
 - Add metrics for ACP-176
-
 - Removed the `"price-options-max-base-fee"` config flag
 
 ## [v0.15.0](https://github.com/ava-labs/coreth/releases/tag/v0.15.0)

--- a/plugin/evm/config/config.go
+++ b/plugin/evm/config/config.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
-	"github.com/ava-labs/coreth/plugin/evm/upgrade/etna"
 	"github.com/ava-labs/coreth/utils"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/common/hexutil"
@@ -68,7 +67,6 @@ const (
 	// Price Option Defaults
 	defaultPriceOptionSlowFeePercentage = uint64(95)
 	defaultPriceOptionFastFeePercentage = uint64(105)
-	defaultPriceOptionMaxBaseFee        = uint64(100 * utils.GWei)
 	defaultPriceOptionMaxTip            = uint64(20 * utils.GWei)
 )
 
@@ -152,7 +150,6 @@ type Config struct {
 	// Price Option Settings
 	PriceOptionSlowFeePercentage uint64 `json:"price-options-slow-fee-percentage"`
 	PriceOptionFastFeePercentage uint64 `json:"price-options-fast-fee-percentage"`
-	PriceOptionMaxBaseFee        uint64 `json:"price-options-max-base-fee"`
 	PriceOptionMaxTip            uint64 `json:"price-options-max-tip"`
 
 	TxPoolPriceLimit   uint64   `json:"tx-pool-price-limit"`
@@ -318,7 +315,6 @@ func (c *Config) SetDefaults(txPoolConfig TxPoolConfig) {
 	// Price Option Settings
 	c.PriceOptionSlowFeePercentage = defaultPriceOptionSlowFeePercentage
 	c.PriceOptionFastFeePercentage = defaultPriceOptionFastFeePercentage
-	c.PriceOptionMaxBaseFee = defaultPriceOptionMaxBaseFee
 	c.PriceOptionMaxTip = defaultPriceOptionMaxTip
 }
 
@@ -370,10 +366,6 @@ func (c *Config) Validate(networkID uint32) error {
 
 	if c.PushGossipPercentStake < 0 || c.PushGossipPercentStake > 1 {
 		return fmt.Errorf("push-gossip-percent-stake is %f but must be in the range [0, 1]", c.PushGossipPercentStake)
-	}
-
-	if c.PriceOptionMaxBaseFee < etna.MinBaseFee {
-		return fmt.Errorf("max base fee %d is less than the minimum base fee %d", c.PriceOptionMaxBaseFee, etna.MinBaseFee)
 	}
 	return nil
 }

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -476,7 +476,6 @@ func (vm *VM) Initialize(
 	vm.ethConfig.RPCTxFeeCap = vm.config.RPCTxFeeCap
 	vm.ethConfig.PriceOptionConfig.SlowFeePercentage = vm.config.PriceOptionSlowFeePercentage
 	vm.ethConfig.PriceOptionConfig.FastFeePercentage = vm.config.PriceOptionFastFeePercentage
-	vm.ethConfig.PriceOptionConfig.MaxBaseFee = vm.config.PriceOptionMaxBaseFee
 	vm.ethConfig.PriceOptionConfig.MaxTip = vm.config.PriceOptionMaxTip
 
 	vm.ethConfig.TxPool.NoLocals = !vm.config.LocalTxsEnabled


### PR DESCRIPTION
## Why this should be merged

1. Fortuna has been activated, so the `.IsFortuna` check is no longer needed.
2. Previously, the base fee was set between [80%, 120%] of the chain values (with min and max values enforced). Post activation of Fortuna, the price has been extremely stable. This means that issuing a transaction at 80% of the base fee is all but guaranteed not to be included on chain. The base fee is now always set at 200% of the chain base fee.

## How this works

- Cleans up code that isn't needed.
- The base fee is not the fee that is actually paid by the end user, so it is safe to over-estimate.

## How this was tested

- [x] Locally
- [X] Unit tests

## Need to be documented?

I don't think the configs that are being changed are documented anywhere... But if they are, they should be updated.

## Need to update RELEASES.md?

Done.