### PR TITLE
build_firewood shell script improvements

### DIFF
--- a/scripts/build_firewood.sh
+++ b/scripts/build_firewood.sh
@@ -15,45 +15,66 @@ FIREWOOD_PATH=${FIREWOOD_PATH:-"./build/firewood"}
 FIREWOOD_VERSION=${FIREWOOD_VERSION:-"main"}
 FIREWOOD_IGNORE_CHECKOUT=${FIREWOOD_IGNORE_CHECKOUT:-"false"}
 
+check_prerequisites() {
+    returnval=0
+    for exe in "$@"; do
+        if ! command -v "$exe" >/dev/null 2>&1; then
+            echo "❌ $exe is not on your path"
+            returnval=1
+        fi
+    done
+
+    return $returnval
+}
+
 import_firewood() {
-    local original_dir=$(pwd)
     local firewood_remote="${1}"
     local firewood_path="${2}"
     local firewood_version="${3}"
     if [[ -d ${firewood_path} ]]; then
-        echo "Firewood repo already exists: ${firewood_path}"
+        echo "✅ Firewood repo directory already exists at ${firewood_path}"
+        if ! [[ -f "${firewood_path}/Cargo.toml" ]]; then
+            echo "❌ The directory doesn't contain a valid Cargo.toml"
+            return 1
+        fi
     else
-        echo "Cloning Firewood from GitHub..."
+        echo "Cloning Firewood from ${firewood_remote}..."
         git clone "${firewood_remote}" "${firewood_path}"
     fi
 
-    cd "${firewood_path}" || { echo "Failed to enter firewood_path: ${firewood_path}"; return 1; }
-    git fetch origin ${firewood_version}
-    git checkout ${firewood_version}
-    git reset --hard origin/${firewood_version}
-    cd ${original_dir} || { echo "Failed to return to original directory: ${original_dir}"; return 1; }
+    pushd "${firewood_path}" || { echo "Failed to enter firewood_path: ${firewood_path}"; return 1; }
+    if ! [[ -z $(git status --porcelain) ]]; then
+        echo "❌ Refusing to touch a changed repository; please stash or commit your changes first"
+        return 1
+    fi
+
+    git fetch origin "${firewood_version}" || return 1
+    git checkout "${firewood_version}" || return 1
+    git reset --hard "origin/${firewood_version}" || return 1
+    popd
+
     echo "Firewood repo is at version: $(git -C ${firewood_path} rev-parse HEAD)"
 }
 
 # Takes 1 positional argument for the firewood path
 build_firewood() {
-    local original_dir
-    original_dir=$(pwd) # Save the current directory
-    cd "${1}" || { echo "Failed to enter FIREWOOD_PATH: ${1}"; return 1; }
+    pushd "${1}" || { echo "Failed to enter FIREWOOD_PATH: ${1}"; return 1; }
 
     # Run cargo build
     cargo build --release --features ethhash
     local build_status=$?
 
     # Return to the original directory
-    cd "${original_dir}" || { echo "Failed to return to original directory: ${original_dir}"; return 1; }
+    popd
 
     return ${build_status} # Return the status of the cargo build
 }
 
+check_prerequisites cargo git || exit 1
+
 if [[ "${FIREWOOD_IGNORE_CHECKOUT}" == "false" ]]; then
     echo "Checking out Firewood..."
-    import_firewood ${FIREWOOD_REMOTE} ${FIREWOOD_PATH} ${FIREWOOD_VERSION}
+    import_firewood ${FIREWOOD_REMOTE} ${FIREWOOD_PATH} ${FIREWOOD_VERSION} || exit 1
 else
     echo "Skipping Firewood checkout..."
 fi


### PR DESCRIPTION
- Added check_prerequisites to verify that cargo and git are on the path before starting
- Sanity checked the firewood repo (must contain Cargo.toml)
- If the repo existed and contains changes, don't clobber them
- Correctly handle failures from build_firewood and install_firewood
- Quote pwd return values in case they contain something nasty like spaces
- use pushd and popd instead of saving off the directory

## Why this should be merged

- Reports errors earlier than letting commands fail
- Makes sure the firewood repo is sane before starting
- Doesn't clobber lost work
- If one step fails, we should fail instead of continuing
- pwd could contain something bad, this handles that case
- pushd and popd are more ergonomic

## How this works

Self-explanatory

## How this was tested

Ran PATH=/bin scripts/build_firewood.sh which fails because it can't find git or cargo
Ran PATH=/bin:/usr/bin scripts/build_firewood.sh which fails because it can't find cargo
Modified the firewood repo and reran, which failed because the repo was not pristine

## Need to be documented?

No

## Need to update RELEASES.md?

Not for this change; the base may need to change it