### PR TITLE
Remove deadcode from old vm interfaces

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/upgrade"
 	avalanchegoConstants "github.com/ava-labs/avalanchego/utils/constants"
-	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/coreth/plugin/evm/customtypes"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -90,6 +89,7 @@ import (
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/formatting/address"
+	"github.com/ava-labs/avalanchego/utils/logging"
 	"github.com/ava-labs/avalanchego/utils/perms"
 	"github.com/ava-labs/avalanchego/utils/profiler"
 	"github.com/ava-labs/avalanchego/utils/set"


### PR DESCRIPTION
## Why this should be merged

This PR removes deadcode from the Coreth VM that's left over from old VM interfaces.

## How this works

Deletes unused code.

## How this was tested

Existing test coverage.

## Need to be documented?

No

## Need to update RELEASES.md?

No