### PR TITLE
bump avalanchego to master (5381d56)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run e2e tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@d8bfb84e85957e16c6e5bab105f61e29485f369c
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@5381d56b9c886a667d21ed3be04c889753b418f1
         with:
           run: ./scripts/tests.e2e.sh
           prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.6
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250421193253-d8bfb84e8595
+	github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250502194934-5381d56b9c88
 	github.com/ava-labs/libevm v1.13.14-0.2.0.release
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250421193253-d8bfb84e8595 h1:sazRMIAL0gAJGyhZCkO8zPTVFufwuxPHQoPfmP6qLko=
-github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250421193253-d8bfb84e8595/go.mod h1:6cFD9bIDPn9aDPzTvAjBndeqURKA1C9c4aEeIcvS0Ms=
+github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250502194934-5381d56b9c88 h1:EELWYBUlN4JyYKte+Yjvt+Ee4U6Od0O9TD7/UZ7JNLo=
+github.com/ava-labs/avalanchego v1.13.1-rc.0.0.20250502194934-5381d56b9c88/go.mod h1:MoyseoQnf1GKHOiNfC/PnuqPtQsP76V+tPb7Qr3YGSw=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/plugin/evm/atomic/mempool.go
+++ b/plugin/evm/atomic/mempool.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"sync"
 
-	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
@@ -67,7 +67,7 @@ type Mempool struct {
 	issuedTxs map[ids.ID]*Tx
 	// discardedTxs is an LRU Cache of transactions that have been discarded after failing
 	// verification.
-	discardedTxs *cache.LRU[ids.ID, *Tx]
+	discardedTxs *lru.Cache[ids.ID, *Tx]
 	// Pending is a channel of length one, which the mempool ensures has an item on
 	// it as long as there is an unissued transaction remaining in [txs]
 	Pending chan struct{}
@@ -98,7 +98,7 @@ func NewMempool(ctx *snow.Context, registerer prometheus.Registerer, maxSize int
 	return &Mempool{
 		ctx:          ctx,
 		issuedTxs:    make(map[ids.ID]*Tx),
-		discardedTxs: &cache.LRU[ids.ID, *Tx]{Size: discardedTxsCacheSize},
+		discardedTxs: lru.NewCache[ids.ID, *Tx](discardedTxsCacheSize),
 		currentTxs:   make(map[ids.ID]*Tx),
 		Pending:      make(chan struct{}, 1),
 		txHeap:       newTxHeap(maxSize),

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -919,7 +919,7 @@ func TestExportTxSemanticVerify(t *testing.T) {
 			Rules:        test.rules,
 			Bootstrapped: vm.bootstrapped.Get(),
 			BlockFetcher: vm,
-			SecpCache:    &vm.secpCache,
+			SecpCache:    vm.secpCache,
 		}
 
 		t.Run(test.name, func(t *testing.T) {
@@ -1786,7 +1786,7 @@ func TestNewExportTx(t *testing.T) {
 				Rules:        vm.currentRules(),
 				Bootstrapped: vm.bootstrapped.Get(),
 				BlockFetcher: vm,
-				SecpCache:    &vm.secpCache,
+				SecpCache:    vm.secpCache,
 			}
 
 			if err := exportTx.SemanticVerify(backend, tx, parent, parent.ethBlock.BaseFee()); err != nil {
@@ -1994,7 +1994,7 @@ func TestNewExportTxMulticoin(t *testing.T) {
 				Rules:        vm.currentRules(),
 				Bootstrapped: vm.bootstrapped.Get(),
 				BlockFetcher: vm,
-				SecpCache:    &vm.secpCache,
+				SecpCache:    vm.secpCache,
 			}
 
 			if err := exportTx.SemanticVerify(backend, tx, parent, parent.ethBlock.BaseFee()); err != nil {

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -123,7 +123,7 @@ func executeTxTest(t *testing.T, test atomicTxTest) {
 		Rules:        rules,
 		Bootstrapped: vm.bootstrapped.Get(),
 		BlockFetcher: vm,
-		SecpCache:    &vm.secpCache,
+		SecpCache:    vm.secpCache,
 	}
 	if err := tx.UnsignedAtomicTx.SemanticVerify(backend, tx, lastAcceptedBlock, baseFee); len(test.semanticVerifyErr) == 0 && err != nil {
 		t.Fatalf("SemanticVerify failed unexpectedly due to: %s", err)

--- a/warp/backend.go
+++ b/warp/backend.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
@@ -57,7 +58,7 @@ type backend struct {
 	warpSigner                avalancheWarp.Signer
 	blockClient               BlockClient
 	signatureCache            cache.Cacher[ids.ID, []byte]
-	messageCache              *cache.LRU[ids.ID, *avalancheWarp.UnsignedMessage]
+	messageCache              *lru.Cache[ids.ID, *avalancheWarp.UnsignedMessage]
 	offchainAddressedCallMsgs map[ids.ID]*avalancheWarp.UnsignedMessage
 	stats                     *verifierStats
 }
@@ -79,7 +80,7 @@ func NewBackend(
 		warpSigner:                warpSigner,
 		blockClient:               blockClient,
 		signatureCache:            signatureCache,
-		messageCache:              &cache.LRU[ids.ID, *avalancheWarp.UnsignedMessage]{Size: messageCacheSize},
+		messageCache:              lru.NewCache[ids.ID, *avalancheWarp.UnsignedMessage](messageCacheSize),
 		stats:                     newVerifierStats(),
 		offchainAddressedCallMsgs: make(map[ids.ID]*avalancheWarp.UnsignedMessage),
 	}

--- a/warp/backend_test.go
+++ b/warp/backend_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
@@ -44,7 +44,7 @@ func TestAddAndGetValidMessage(t *testing.T) {
 	sk, err := localsigner.New()
 	require.NoError(t, err)
 	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 500}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](500)
 	backend, err := NewBackend(networkID, sourceChainID, warpSigner, nil, db, messageSignatureCache, nil)
 	require.NoError(t, err)
 
@@ -67,7 +67,7 @@ func TestAddAndGetUnknownMessage(t *testing.T) {
 	sk, err := localsigner.New()
 	require.NoError(t, err)
 	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 500}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](500)
 	backend, err := NewBackend(networkID, sourceChainID, warpSigner, nil, db, messageSignatureCache, nil)
 	require.NoError(t, err)
 
@@ -86,7 +86,7 @@ func TestGetBlockSignature(t *testing.T) {
 	sk, err := localsigner.New()
 	require.NoError(err)
 	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 500}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](500)
 	backend, err := NewBackend(networkID, sourceChainID, warpSigner, blockClient, db, messageSignatureCache, nil)
 	require.NoError(err)
 
@@ -113,7 +113,7 @@ func TestZeroSizedCache(t *testing.T) {
 	warpSigner := avalancheWarp.NewSigner(sk, networkID, sourceChainID)
 
 	// Verify zero sized cache works normally, because the lru cache will be initialized to size 1 for any size parameter <= 0.
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 0}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](0)
 	backend, err := NewBackend(networkID, sourceChainID, warpSigner, nil, db, messageSignatureCache, nil)
 	require.NoError(t, err)
 
@@ -173,7 +173,7 @@ func TestOffChainMessages(t *testing.T) {
 			require := require.New(t)
 			db := memdb.New()
 
-			messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 0}
+			messageSignatureCache := lru.NewCache[ids.ID, []byte](0)
 			backend, err := NewBackend(networkID, sourceChainID, warpSigner, nil, db, messageSignatureCache, test.offchainMessages)
 			require.ErrorIs(err, test.err)
 			if test.check != nil {

--- a/warp/handlers/signature_request_test.go
+++ b/warp/handlers/signature_request_test.go
@@ -7,7 +7,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/utils/crypto/bls"
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/coreth/utils"
 	"github.com/ava-labs/coreth/warp"
 	"github.com/ava-labs/coreth/warp/warptest"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -36,7 +37,7 @@ func TestMessageSignatureHandler(t *testing.T) {
 	offchainMessage, err := avalancheWarp.NewUnsignedMessage(snowCtx.NetworkID, snowCtx.ChainID, addressedPayload.Bytes())
 	require.NoError(t, err)
 
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 100}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](100)
 	backend, err := warp.NewBackend(snowCtx.NetworkID, snowCtx.ChainID, warpSigner, warptest.EmptyBlockClient, database, messageSignatureCache, [][]byte{offchainMessage.Bytes()})
 	require.NoError(t, err)
 
@@ -139,7 +140,7 @@ func TestBlockSignatureHandler(t *testing.T) {
 	warpSigner := avalancheWarp.NewSigner(blsSecretKey, snowCtx.NetworkID, snowCtx.ChainID)
 	blkID := ids.GenerateTestID()
 	blockClient := warptest.MakeBlockClient(blkID)
-	messageSignatureCache := &cache.LRU[ids.ID, []byte]{Size: 100}
+	messageSignatureCache := lru.NewCache[ids.ID, []byte](100)
 	backend, err := warp.NewBackend(
 		snowCtx.NetworkID,
 		snowCtx.ChainID,

--- a/warp/verifier_backend_test.go
+++ b/warp/verifier_backend_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/ava-labs/avalanchego/cache"
+	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/database/memdb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
@@ -97,7 +98,7 @@ func TestAddressedCallSignatures(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				var sigCache cache.Cacher[ids.ID, []byte]
 				if withCache {
-					sigCache = &cache.LRU[ids.ID, []byte]{Size: 100}
+					sigCache = lru.NewCache[ids.ID, []byte](100)
 				} else {
 					sigCache = &cache.Empty[ids.ID, []byte]{}
 				}
@@ -209,7 +210,7 @@ func TestBlockSignatures(t *testing.T) {
 			t.Run(name, func(t *testing.T) {
 				var sigCache cache.Cacher[ids.ID, []byte]
 				if withCache {
-					sigCache = &cache.LRU[ids.ID, []byte]{Size: 100}
+					sigCache = lru.NewCache[ids.ID, []byte](100)
 				} else {
 					sigCache = &cache.Empty[ids.ID, []byte]{}
 				}


### PR DESCRIPTION
This pull request introduces several updates to improve the codebase by replacing the custom LRU cache implementation with a more streamlined `lru.Cache` and refactoring the `secpCache` to use a pointer-based implementation. Additionally, it includes minor dependency updates and import optimizations.

### Cache Refactoring
* Replaced `cache.LRU` with `lru.Cache` across multiple files for better maintainability and consistency:
  - Updated `discardedTxs` in `plugin/evm/atomic/mempool.go` to use `lru.NewCache` instead of `cache.LRU`. [[1]](diffhunk://#diff-c12ee7e53adb00b1d1cdf4206cfa5139bd1a3f2421a895addf7d0731403403c5L70-R70) [[2]](diffhunk://#diff-c12ee7e53adb00b1d1cdf4206cfa5139bd1a3f2421a895addf7d0731403403c5L101-R101)
  - Refactored `warpSignatureCache` in `plugin/evm/vm.go` to use `lru.NewCache`.
  - Updated `messageCache` in `warp/backend.go` to use `lru.NewCache`. [[1]](diffhunk://#diff-be66b853aa52c434887db29553e039e5536b325b159de2d4df44d2e8fb345930L60-R61) [[2]](diffhunk://#diff-be66b853aa52c434887db29553e039e5536b325b159de2d4df44d2e8fb345930L82-R83)
  - Replaced `messageSignatureCache` in various test files (`warp/backend_test.go`, `warp/handlers/signature_request_test.go`, `warp/verifier_backend_test.go`) with `lru.NewCache`. [[1]](diffhunk://#diff-3a69b001767fa655e727b1d3763e0d128c2145db8b6dca70474c22aa08eb2a9fL47-R47) [[2]](diffhunk://#diff-4d0ad5b856387f529805e159cfce54b82b4a1357eed81bb801426e36e4f2d506L39-R40) [[3]](diffhunk://#diff-71ba0931b47ff7554245a4ea01a15871b5dc4312ee4ae9a8bf2316264718c617L100-R101)

### `secpCache` Refactoring
* Changed `secpCache` in `plugin/evm/vm.go` to use a pointer-based `secp256k1.RecoverCache` instead of embedding it directly:
  - Modified the `VM` struct to hold a pointer to `secp256k1.RecoverCache`.
  - Updated the initialization of `secpCache` to use `secp256k1.NewRecoverCache`.
  - Adjusted references to `secpCache` in various methods and tests to remove pointer dereferencing. [[1]](diffhunk://#diff-c6f6c8cf23afc8fadcb64453bf00e0f2c2cd075f6354852e2a1a424b0fbed8c2L922-R922) [[2]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L1631-R1628) [[3]](diffhunk://#diff-3be5ea9687f8af021d9baaa6584d174a7975b181b604e1a759e4ad2e40136912L1670-R1667)

### Dependency Updates
* Updated the `github.com/ava-labs/avalanchego` dependency in `go.mod` to a newer version.
87f529805e159cfce54b82b4a1357eed81bb801426e36e4f2d506R22)
