### PR TITLE
wip(all): Enable Firewood for bootstrapping nodes

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/customtypes"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
+	"github.com/ava-labs/coreth/triedb/firewooddb"
 	"github.com/ava-labs/coreth/triedb/hashdb"
 	"github.com/ava-labs/coreth/triedb/pathdb"
 	"github.com/ava-labs/libevm/common"
@@ -211,6 +212,11 @@ func (c *CacheConfig) triedbConfig() *triedb.Config {
 			StateHistory:   c.StateHistory,
 			CleanCacheSize: c.TrieCleanLimit * 1024 * 1024,
 			DirtyCacheSize: c.TrieDirtyLimit * 1024 * 1024,
+		}.BackendConstructor
+	}
+	if c.StateScheme == customrawdb.FirewoodScheme {
+		config.DBOverride = firewooddb.Config{
+			// TODO: Fill in
 		}.BackendConstructor
 	}
 	return config

--- a/plugin/evm/config/config.go
+++ b/plugin/evm/config/config.go
@@ -242,6 +242,9 @@ type Config struct {
 
 	// RPC settings
 	HttpBodyLimit uint64 `json:"http-body-limit"`
+
+	// Database Scheme
+	StateScheme string `json:"state-scheme"`
 }
 
 // TxPoolConfig contains the transaction pool config to be passed

--- a/plugin/evm/customrawdb/database_ext.go
+++ b/plugin/evm/customrawdb/database_ext.go
@@ -5,6 +5,7 @@ package customrawdb
 
 import (
 	"bytes"
+	"fmt"
 
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -60,4 +61,25 @@ func InspectDatabase(db ethdb.Database, keyPrefix, keyStart []byte) error {
 	}
 
 	return rawdb.InspectDatabase(db, keyPrefix, keyStart, options...)
+}
+
+func ParseStateSchemeExt(provided string, disk ethdb.Database) (string, error) {
+	// Check for eth scheme
+	scheme, err := rawdb.ParseStateScheme(provided, disk)
+	if err == nil {
+		// Found valid eth scheme
+		return scheme, nil
+	} else if rawdb.ReadStateScheme(disk) != "" {
+		// Valid scheme on disk mismatched
+		return scheme, err
+	}
+
+	// Check for custom scheme
+	if provided == FirewoodScheme {
+		// TODO: Check if the database is a firewood database
+		// Assume valid scheme for now
+		return FirewoodScheme, nil
+	}
+
+	return "", fmt.Errorf("Unknown state scheme %q", provided)
 }

--- a/plugin/evm/customrawdb/schema_ext.go
+++ b/plugin/evm/customrawdb/schema_ext.go
@@ -8,6 +8,8 @@ import (
 	"github.com/ava-labs/libevm/common"
 )
 
+const FirewoodScheme = "firewood"
+
 var (
 	// snapshotBlockHashKey tracks the block hash of the last snapshot.
 	snapshotBlockHashKey = []byte("SnapshotBlockHash")

--- a/triedb/firewooddb/database.go
+++ b/triedb/firewooddb/database.go
@@ -4,6 +4,7 @@
 package firewooddb
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
@@ -16,26 +17,49 @@ import (
 	"github.com/ava-labs/libevm/triedb/database"
 )
 
+type ProposalContext struct {
+	// The actual proposal
+	Proposal IProposal
+	// The parent of the proposal
+	Parent common.Hash
+	// The block number of the proposal
+	Block uint64
+}
+
+// DbView is a view of the database at a given revision.
+type IDbView interface {
+	// Returns the data stored at the given key at this revision
+	Get(key []byte) ([]byte, error)
+	// Returns the hash of this view
+	Hash() []byte
+}
+
+type IProposal interface {
+	// All proposals support read operations
+	IDbView
+	// Propose takes a root and a set of keys-values and creates a new proposal
+	// and returns the new root.
+	// If values[i] is nil, the key is deleted.
+	Propose(keys [][]byte, values [][]byte) (IProposal, error)
+	// Commit commits the proposal as a new revision
+	Commit() error
+	// Drop drops the proposal; this object may no longer be used after this call.
+	Drop() error
+}
+
 type IFirewood interface {
-	// Returns whether a given root is available
-	HasRoot(root []byte) bool
-
-	// Returns the data stored at a given node.
-	Get(root []byte, key []byte) ([]byte, error)
-
+	// Read operations on the current database root,
+	// including the current database hash.
+	IDbView
 	// Update takes a root and a set of keys-values and creates a new proposal
 	// and returns the new root.
 	// If values[i] is nil, the key is deleted.
-	Update(parent []byte, keys [][]byte, values [][]byte) ([]byte, error)
-
-	// Commit commits a proposal as a revision to the database.
-	Commit(root []byte) error
-
-	// Drop deletes a proposal from the database.
-	// This may be called on a revision that has already been dropped.
-	// An error should not be returned in this case.
-	Drop(root []byte) error
-
+	Propose(keys [][]byte, values [][]byte) (IProposal, error)
+	// Returns the cuurrent root of the database.
+	Root() []byte
+	// Revision returns a new proposal that is a copy of the current database
+	// at this revision.
+	Revision(root []byte) (IDbView, error)
 	// Close closes the database and releases all resources.
 	Close() error
 }
@@ -57,29 +81,32 @@ func (c Config) BackendConstructor(diskdb ethdb.Database) triedb.DBOverride {
 var Defaults = &Config{}
 
 type Database struct {
-	fw IFirewood
+	fwDisk    IFirewood
+	proposals map[common.Hash][]*ProposalContext
 }
 
 func New(diskdb ethdb.Database, config *Config) *Database {
-	return &Database{}
+	return &Database{
+		fwDisk:    nil, // TODO: Initialize with the actual Firewood database.
+		proposals: make(map[common.Hash][]*ProposalContext),
+	}
 }
 
-// Initialized returns an indicator if the state data is already initialized
-// according to the state scheme.
+// Scheme returns the scheme of the database.
 func (db *Database) Scheme() string {
 	return customrawdb.FirewoodScheme
 }
 
+// Initialized indicates whether the most recent root of the database
+// matches the given root.
 func (db *Database) Initialized(root common.Hash) bool {
-	return db.fw.HasRoot(root.Bytes())
+	return common.BytesToHash(db.fwDisk.Root()) == root
 }
 
+// Update takes a root and a set of keys-values and creates a new proposal.
+// It will not be committed until the Commit method is called.
 func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set) error {
-	// Assert we have the parent root
-	if !db.Initialized(parent) {
-		return fmt.Errorf("firewooddb: requested parent root %s not found", parent.Hex())
-	}
-
+	// Create key-value pairs for the nodes in bytes.
 	flattenedNodes := nodes.Flatten()
 	var keys [][]byte
 	var values [][]byte
@@ -98,36 +125,105 @@ func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, n
 	}
 
 	// Firewood ffi does not accept empty bashes, so if the keys are empty, the root is returned.
+	// Empty blocks are not allowed in coreth anyway.
 	if len(keys) == 0 {
-		return nil
+		return errors.New("firewooddb: no keys to update")
 	}
-
-	bytes, err := db.fw.Update(parent.Bytes(), keys, values)
+	// Create a new proposal with the given keys and values.
+	p, err := db.propose(parent, block, keys, values)
+	// If we were unable to create a new proposal, return an error.
 	if err != nil {
 		log.Error("Failed to update trie", "parent", parent, "err", err)
 	}
-	newRoot := common.BytesToHash(bytes)
 
+	// Assert that the proposal has the correct root.
+	newRoot := common.BytesToHash(p.Hash())
 	if newRoot != root {
 		log.Error("Firewood update returned unexpected root", "expected", root, "actual", newRoot)
 		return fmt.Errorf("firewooddb: firewood update returned unexpected root %s, expected %s", newRoot.Hex(), root.Hex())
 	}
+
+	// Store the proposal context.
+	pContext := &ProposalContext{
+		Proposal: p,
+		Parent:   parent,
+		Block:    block,
+	}
+	db.proposals[root] = append(db.proposals[root], pContext)
+
 	return nil
 }
 
+// propose creates a new proposal with the given keys and values.
+// If the parent cannot be found, an error will be returned.
+func (db *Database) propose(parent common.Hash, block uint64, keys [][]byte, values [][]byte) (p IProposal, err error) {
+	// If parent is root, we should propose from the db.
+	if db.Initialized(parent) {
+		p, err = db.fwDisk.Propose(keys, values)
+	} else {
+		// If the parent is not the root of the database,
+		// we need to find the parent proposal.
+		possibleProposals, ok := db.proposals[parent]
+		if !ok {
+			return nil, fmt.Errorf("firewooddb: parent proposal not found for %s", parent.Hex())
+		}
+
+		// Find the proposal with the correct parent height.
+		var parentProposal *ProposalContext
+		for _, proposal := range possibleProposals {
+			if proposal.Block == block-1 {
+				parentProposal = proposal
+				break
+			}
+		}
+		if parentProposal == nil {
+			return nil, fmt.Errorf("firewooddb: parent proposal not found for %s of correct height", parent.Hex())
+		}
+
+		// Create a new proposal from the parent proposal.
+		p, err = parentProposal.Proposal.Propose(keys, values)
+	}
+	return p, err
+}
+
 func (db *Database) Close() error {
-	return db.fw.Close()
+	return db.fwDisk.Close()
 }
 
 // Commit persists a proposal as a revision to the database.
 func (db *Database) Commit(root common.Hash, report bool) error {
+	// Find the proposal with the given root.
+	// I.e. the proposal in which the parent root is the root of the database.
+	var p IProposal
+	diskRoot := common.BytesToHash(db.fwDisk.Root())
+	for _, pCtx := range db.proposals[root] {
+		if pCtx.Parent == diskRoot {
+			p = pCtx.Proposal
+			break
+		}
+	}
+	if p == nil {
+		return fmt.Errorf("firewooddb: proposal not found for %s", root.Hex())
+	}
+
+	// Commit the proposal to the database.
+	if err := p.Commit(); err != nil {
+		log.Error("Failed to commit trie", "node", root, "err", err)
+	}
+
 	logger := log.Info
 	if !report {
 		logger = log.Debug
 	}
 	logger("Persisted trie from memory database", "node", root)
-	if err := db.fw.Commit(root.Bytes()); err != nil {
-		log.Error("Failed to commit trie", "node", root, "err", err)
+
+	// Committing removed the proposal in the backend.
+	// We can now drop our reference to it.
+	for i, pCtx := range db.proposals[root] {
+		if pCtx.Proposal == p {
+			db.proposals[root] = append(db.proposals[root][:i], db.proposals[root][i+1:]...)
+			break
+		}
 	}
 	return nil
 }
@@ -135,7 +231,7 @@ func (db *Database) Commit(root common.Hash, report bool) error {
 // Size returns the storage size of diff layer nodes above the persistent disk
 // layer and the dirty nodes buffered within the disk layer
 func (db *Database) Size() (common.StorageSize, common.StorageSize) {
-	// TODO: Do we even need this? Only used for metrics and Commit intervals (but commits are no-ops)
+	// TODO: Do we even need this? Only used for metrics and Commit intervals in APIs.
 	return 0, 0
 }
 
@@ -146,7 +242,23 @@ func (db *Database) Reference(_ common.Hash) error {
 
 // Dereference drops a proposal from the database.
 func (db *Database) Dereference(root common.Hash) error {
-	return db.fw.Drop(root.Bytes())
+	// Find the proposal of given root with maximal height.
+	// TODO: Ensure `Reject` calls will not generate orphans in the tree.
+	var p IProposal
+	currentHeight := uint64(0)
+	for _, pCtx := range db.proposals[root] {
+		if pCtx.Block > currentHeight {
+			currentHeight = pCtx.Block
+			p = pCtx.Proposal
+		}
+	}
+
+	// If the proposal is not found in our map, return an error.
+	// The map has been corrupted.
+	if p == nil {
+		return fmt.Errorf("firewooddb: proposal not found for %s", root.Hex())
+	}
+	return p.Drop()
 }
 
 // Cap iteratively flushes old but still referenced trie nodes until the total
@@ -157,12 +269,34 @@ func (db *Database) Cap(limit common.StorageSize) error {
 	return nil
 }
 
+// viewAtRoot returns a view of the database at the given root.
+// An error will be returned if the requested state is not available.
+func (db *Database) viewAtRoot(root common.Hash) (IDbView, error) {
+	view, err := db.fwDisk.Revision(root.Bytes())
+	if err != nil {
+		return nil, fmt.Errorf("firewooddb: error retrieving revision forstate root %s", root.Hex())
+	}
+
+	if view != nil {
+		// Check revisions
+		return view, nil
+	}
+
+	// Check if the state root corresponds with a proposal.
+	// Any proposal with the same root is permissible.
+
+	return nil, fmt.Errorf("firewooddb: requested state root %s not found", root.Hex())
+}
+
 // Reader retrieves a node reader belonging to the given state root.
 // An error will be returned if the requested state is not available.
 func (db *Database) Reader(root common.Hash) (database.Reader, error) {
-	if !db.Initialized(root) {
+	// Check if we can currently read the requested root
+	_, err := db.viewAtRoot(root)
+	if err != nil {
 		return nil, fmt.Errorf("firewooddb: requested state root %s not found", root.Hex())
 	}
+
 	return &reader{db: db, root: root}, nil
 }
 
@@ -180,11 +314,17 @@ func (reader *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]
 		return nil, nil
 	}
 
+	// Ensure we have access to the requested root
+	view, err := reader.db.viewAtRoot(reader.root)
+	if err != nil {
+		return nil, fmt.Errorf("firewooddb: requested state root %s not found", reader.root.Hex()) // TODO: Should we return the error?
+	}
+
 	key := path
 	if owner != (common.Hash{}) {
 		key = append(owner.Bytes(), path...) // TODO: Is this right?
 	}
-	blob, err := reader.db.fw.Get(reader.root.Bytes(), key)
+	blob, err := view.Get(key)
 	if err != nil {
 		return nil, nil
 	}

--- a/triedb/firewooddb/database.go
+++ b/triedb/firewooddb/database.go
@@ -1,0 +1,192 @@
+// (c) 2025, Ava Labs, Inc.
+// See the file LICENSE for licensing terms.
+
+package firewooddb
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/log"
+	"github.com/ava-labs/libevm/trie/trienode"
+	"github.com/ava-labs/libevm/trie/triestate"
+	"github.com/ava-labs/libevm/triedb"
+	"github.com/ava-labs/libevm/triedb/database"
+)
+
+type IFirewood interface {
+	// Returns whether a given root is available
+	HasRoot(root []byte) bool
+
+	// Returns the data stored at a given node.
+	Get(root []byte, key []byte) ([]byte, error)
+
+	// Update takes a root and a set of keys-values and creates a new proposal
+	// and returns the new root.
+	// If values[i] is nil, the key is deleted.
+	Update(parent []byte, keys [][]byte, values [][]byte) ([]byte, error)
+
+	// Commit commits a proposal as a revision to the database.
+	Commit(root []byte) error
+
+	// Drop deletes a proposal from the database.
+	// This may be called on a revision that has already been dropped.
+	// An error should not be returned in this case.
+	Drop(root []byte) error
+
+	// Close closes the database and releases all resources.
+	Close() error
+}
+
+// Config contains the settings for database.
+type Config struct {
+	Create            bool
+	NodeCacheEntries  uint
+	Revisions         uint
+	ReadCacheStrategy uint8
+	MetricsPort       uint16
+}
+
+func (c Config) BackendConstructor(diskdb ethdb.Database) triedb.DBOverride {
+	return New(diskdb, &c)
+}
+
+// Defaults is the default setting for database if it's not specified.
+var Defaults = &Config{}
+
+type Database struct {
+	fw IFirewood
+}
+
+func New(diskdb ethdb.Database, config *Config) *Database {
+	return &Database{}
+}
+
+// Initialized returns an indicator if the state data is already initialized
+// according to the state scheme.
+func (db *Database) Scheme() string {
+	return customrawdb.FirewoodScheme
+}
+
+func (db *Database) Initialized(root common.Hash) bool {
+	return db.fw.HasRoot(root.Bytes())
+}
+
+func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set) error {
+	// Assert we have the parent root
+	if !db.Initialized(parent) {
+		return fmt.Errorf("firewooddb: requested parent root %s not found", parent.Hex())
+	}
+
+	flattenedNodes := nodes.Flatten()
+	var keys [][]byte
+	var values [][]byte
+
+	for owner, set := range flattenedNodes {
+		for _, n := range set {
+			var key []byte
+			if owner == (common.Hash{}) {
+				key = n.Hash.Bytes()
+			} else {
+				key = append(owner.Bytes(), n.Hash.Bytes()...)
+			}
+			keys = append(keys, key)
+			values = append(values, n.Blob)
+		}
+	}
+
+	// Firewood ffi does not accept empty bashes, so if the keys are empty, the root is returned.
+	if len(keys) == 0 {
+		return nil
+	}
+
+	bytes, err := db.fw.Update(parent.Bytes(), keys, values)
+	if err != nil {
+		log.Error("Failed to update trie", "parent", parent, "err", err)
+	}
+	newRoot := common.BytesToHash(bytes)
+
+	if newRoot != root {
+		log.Error("Firewood update returned unexpected root", "expected", root, "actual", newRoot)
+		return fmt.Errorf("firewooddb: firewood update returned unexpected root %s, expected %s", newRoot.Hex(), root.Hex())
+	}
+	return nil
+}
+
+func (db *Database) Close() error {
+	return db.fw.Close()
+}
+
+// Commit persists a proposal as a revision to the database.
+func (db *Database) Commit(root common.Hash, report bool) error {
+	logger := log.Info
+	if !report {
+		logger = log.Debug
+	}
+	logger("Persisted trie from memory database", "node", root)
+	if err := db.fw.Commit(root.Bytes()); err != nil {
+		log.Error("Failed to commit trie", "node", root, "err", err)
+	}
+	return nil
+}
+
+// Size returns the storage size of diff layer nodes above the persistent disk
+// layer and the dirty nodes buffered within the disk layer
+func (db *Database) Size() (common.StorageSize, common.StorageSize) {
+	// TODO: Do we even need this? Only used for metrics and Commit intervals (but commits are no-ops)
+	return 0, 0
+}
+
+// This isn't called anywhere in coreth
+func (db *Database) Reference(_ common.Hash) error {
+	return fmt.Errorf("firewooddb: Reference not implemented")
+}
+
+// Dereference drops a proposal from the database.
+func (db *Database) Dereference(root common.Hash) error {
+	return db.fw.Drop(root.Bytes())
+}
+
+// Cap iteratively flushes old but still referenced trie nodes until the total
+// memory usage goes below the given threshold. The held pre-images accumulated
+// up to this point will be flushed in case the size exceeds the threshold.
+func (db *Database) Cap(limit common.StorageSize) error {
+	// Firewood does not support capping
+	return nil
+}
+
+// Reader retrieves a node reader belonging to the given state root.
+// An error will be returned if the requested state is not available.
+func (db *Database) Reader(root common.Hash) (database.Reader, error) {
+	if !db.Initialized(root) {
+		return nil, fmt.Errorf("firewooddb: requested state root %s not found", root.Hex())
+	}
+	return &reader{db: db, root: root}, nil
+}
+
+// reader is a state reader of Database which implements the Reader interface.
+type reader struct {
+	db   *Database
+	root common.Hash
+}
+
+// Node retrieves the trie node with the given node hash. No error will be
+// returned if the node is not found.
+func (reader *reader) Node(owner common.Hash, path []byte, hash common.Hash) ([]byte, error) {
+	// No reason to return the metaroot
+	if hash == (common.Hash{}) {
+		return nil, nil
+	}
+
+	key := path
+	if owner != (common.Hash{}) {
+		key = append(owner.Bytes(), path...) // TODO: Is this right?
+	}
+	blob, err := reader.db.fw.Get(reader.root.Bytes(), key)
+	if err != nil {
+		return nil, nil
+	}
+	return blob, nil
+}

--- a/triedb/firewooddb/database.go
+++ b/triedb/firewooddb/database.go
@@ -20,10 +20,14 @@ import (
 type ProposalContext struct {
 	// The actual proposal
 	Proposal IProposal
-	// The parent of the proposal
-	Parent common.Hash
+	// The root of the proposal
+	Root common.Hash
 	// The block number of the proposal
 	Block uint64
+	// The parent of the proposal
+	Parent *ProposalContext
+	// The children of the proposal
+	Children []*ProposalContext
 }
 
 // DbView is a view of the database at a given revision.
@@ -81,14 +85,24 @@ func (c Config) BackendConstructor(diskdb ethdb.Database) triedb.DBOverride {
 var Defaults = &Config{}
 
 type Database struct {
-	fwDisk    IFirewood
-	proposals map[common.Hash][]*ProposalContext
+	fwDisk IFirewood
+
+	// TODO: These need mutex protection
+	proposalMap  map[common.Hash][]*ProposalContext
+	proposalTree *ProposalContext
 }
 
 func New(diskdb ethdb.Database, config *Config) *Database {
 	return &Database{
-		fwDisk:    nil, // TODO: Initialize with the actual Firewood database.
-		proposals: make(map[common.Hash][]*ProposalContext),
+		fwDisk:      nil, // TODO: Initialize with the actual Firewood database.
+		proposalMap: make(map[common.Hash][]*ProposalContext),
+		proposalTree: &ProposalContext{
+			Proposal: nil,
+			Root:     common.Hash{},
+			Block:    0,
+			Parent:   nil,
+			Children: nil,
+		},
 	}
 }
 
@@ -100,6 +114,7 @@ func (db *Database) Scheme() string {
 // Initialized indicates whether the most recent root of the database
 // matches the given root.
 func (db *Database) Initialized(root common.Hash) bool {
+	// Shouldn't use proposal tree root here, since it may be empty.
 	return common.BytesToHash(db.fwDisk.Root()) == root
 }
 
@@ -129,61 +144,62 @@ func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, n
 	if len(keys) == 0 {
 		return errors.New("firewooddb: no keys to update")
 	}
-	// Create a new proposal with the given keys and values.
-	p, err := db.propose(parent, block, keys, values)
-	// If we were unable to create a new proposal, return an error.
-	if err != nil {
-		log.Error("Failed to update trie", "parent", parent, "err", err)
-	}
-
-	// Assert that the proposal has the correct root.
-	newRoot := common.BytesToHash(p.Hash())
-	if newRoot != root {
-		log.Error("Firewood update returned unexpected root", "expected", root, "actual", newRoot)
-		return fmt.Errorf("firewooddb: firewood update returned unexpected root %s, expected %s", newRoot.Hex(), root.Hex())
-	}
-
-	// Store the proposal context.
-	pContext := &ProposalContext{
-		Proposal: p,
-		Parent:   parent,
-		Block:    block,
-	}
-	db.proposals[root] = append(db.proposals[root], pContext)
-
-	return nil
+	return db.propose(root, parent, block, keys, values)
 }
 
 // propose creates a new proposal with the given keys and values.
 // If the parent cannot be found, an error will be returned.
-func (db *Database) propose(parent common.Hash, block uint64, keys [][]byte, values [][]byte) (p IProposal, err error) {
+func (db *Database) propose(root common.Hash, parent common.Hash, block uint64, keys [][]byte, values [][]byte) error {
 	// If parent is root, we should propose from the db.
-	if db.Initialized(parent) {
-		p, err = db.fwDisk.Propose(keys, values)
-	} else {
-		// If the parent is not the root of the database,
-		// we need to find the parent proposal.
-		possibleProposals, ok := db.proposals[parent]
-		if !ok {
-			return nil, fmt.Errorf("firewooddb: parent proposal not found for %s", parent.Hex())
+	// Special case: before state syncing, we initialize the database with the empty hash.
+	// This is the only time we can propose a different parent root, since all syncing changes
+	// are directly written to disk.
+	if db.Initialized(parent) && (db.proposalTree.Root == common.Hash{} || db.proposalTree.Block == block-1) {
+		p, err := db.fwDisk.Propose(keys, values)
+		if err != nil {
+			return fmt.Errorf("firewooddb: error proposing from root %s", parent.Hex())
 		}
 
-		// Find the proposal with the correct parent height.
-		var parentProposal *ProposalContext
-		for _, proposal := range possibleProposals {
-			if proposal.Block == block-1 {
-				parentProposal = proposal
-				break
-			}
+		// Store the proposal context.
+		pContext := &ProposalContext{
+			Proposal: p,
+			Root:     root,
+			Block:    block,
+			Parent:   db.proposalTree,
 		}
-		if parentProposal == nil {
-			return nil, fmt.Errorf("firewooddb: parent proposal not found for %s of correct height", parent.Hex())
-		}
-
-		// Create a new proposal from the parent proposal.
-		p, err = parentProposal.Proposal.Propose(keys, values)
+		db.proposalMap[root] = append(db.proposalMap[root], pContext)
+		db.proposalTree.Children = append(db.proposalTree.Children, pContext)
+		return nil
 	}
-	return p, err
+
+	// If the parent is not the root of the database,
+	// we need to find all possible parent proposals.
+	possibleProposals, ok := db.proposalMap[parent]
+	if !ok {
+		return fmt.Errorf("firewooddb: parent proposal not found for %s", parent.Hex())
+	}
+
+	// Find all proposals with the correct parent height.
+	// We must create a new proposal for each one.
+	for _, parentProposal := range possibleProposals {
+		if parentProposal.Block == block-1 {
+			p, err := parentProposal.Proposal.Propose(keys, values)
+			if err != nil {
+				return fmt.Errorf("firewooddb: error proposing from parent proposal %s", parent.Hex())
+			}
+			// Store the proposal context.
+			pContext := &ProposalContext{
+				Proposal: p,
+				Root:     root,
+				Block:    block,
+				Parent:   parentProposal,
+			}
+			db.proposalMap[root] = append(db.proposalMap[root], pContext)
+			parentProposal.Children = append(parentProposal.Children, pContext)
+		}
+	}
+
+	return nil
 }
 
 func (db *Database) Close() error {
@@ -194,21 +210,21 @@ func (db *Database) Close() error {
 func (db *Database) Commit(root common.Hash, report bool) error {
 	// Find the proposal with the given root.
 	// I.e. the proposal in which the parent root is the root of the database.
-	var p IProposal
-	diskRoot := common.BytesToHash(db.fwDisk.Root())
-	for _, pCtx := range db.proposals[root] {
-		if pCtx.Parent == diskRoot {
-			p = pCtx.Proposal
+	// If this isn't unique, they must be identical, and we can just take the first one.
+	var pCtx *ProposalContext
+	for _, possible := range db.proposalMap[root] {
+		if possible.Parent.Root == db.proposalTree.Root {
+			pCtx = possible
 			break
 		}
 	}
-	if p == nil {
+	if pCtx == nil {
 		return fmt.Errorf("firewooddb: proposal not found for %s", root.Hex())
 	}
 
 	// Commit the proposal to the database.
-	if err := p.Commit(); err != nil {
-		log.Error("Failed to commit trie", "node", root, "err", err)
+	if err := pCtx.Proposal.Commit(); err != nil {
+		return fmt.Errorf("firewooddb: error committing proposal %s", root.Hex())
 	}
 
 	logger := log.Info
@@ -218,11 +234,24 @@ func (db *Database) Commit(root common.Hash, report bool) error {
 	logger("Persisted trie from memory database", "node", root)
 
 	// Committing removed the proposal in the backend.
-	// We can now drop our reference to it.
-	for i, pCtx := range db.proposals[root] {
-		if pCtx.Proposal == p {
-			db.proposals[root] = append(db.proposals[root][:i], db.proposals[root][i+1:]...)
+	// We can now remove our reference and promote the context.
+	otherChildren := db.proposalTree.Children
+	db.proposalTree = pCtx
+	db.proposalTree.Parent = nil // We should not index historical revisions here.
+	// Remove the proposal from the map.
+	rootList := db.proposalMap[root]
+	for i, p := range rootList {
+		if p == pCtx { // pointer comparison
+			rootList = append(rootList[:i], rootList[i+1:]...) // There could be other proposals with the same root.
 			break
+		}
+	}
+	db.proposalMap[root] = rootList
+
+	for _, childCtx := range otherChildren {
+		// TODO: Depending on FFI, we may want to dereference the committed proposal as well.
+		if childCtx != pCtx {
+			db.dereference(childCtx)
 		}
 	}
 	return nil
@@ -242,23 +271,61 @@ func (db *Database) Reference(_ common.Hash) error {
 
 // Dereference drops a proposal from the database.
 func (db *Database) Dereference(root common.Hash) error {
-	// Find the proposal of given root with maximal height.
-	// TODO: Ensure `Reject` calls will not generate orphans in the tree.
-	var p IProposal
-	currentHeight := uint64(0)
-	for _, pCtx := range db.proposals[root] {
-		if pCtx.Block > currentHeight {
-			currentHeight = pCtx.Block
-			p = pCtx.Proposal
+	// Find the proposal of given root.
+	var pCtx *ProposalContext
+	count := 0
+	for _, possible := range db.proposalMap[root] {
+		pCtx = possible
+		count++
+	}
+
+	// If there are multiple proposals with the same root, we cannot dereference,
+	// as we do not know the parent or height.
+	if count > 1 {
+		log.Debug("Cannot dereference root with multiple proposals", "root", root.Hex(), "count", count)
+		return nil // will be cleaned up eventually on later commit
+	} else if count == 0 {
+		log.Debug("No proposal to dereference found", "root", root.Hex())
+		return nil // no error, may have already been dropped
+	}
+
+	return db.dereference(pCtx)
+}
+
+func (db *Database) dereference(pCtx *ProposalContext) error {
+	// Base case: if there are children, we need to dereference them first.
+	for _, child := range pCtx.Children {
+		if err := db.dereference(child); err != nil {
+			return fmt.Errorf("firewooddb: error dereferencing child proposal %s", child.Root.Hex())
 		}
 	}
 
-	// If the proposal is not found in our map, return an error.
-	// The map has been corrupted.
-	if p == nil {
-		return fmt.Errorf("firewooddb: proposal not found for %s", root.Hex())
+	// Drop the proposal in the backend.
+	if err := pCtx.Proposal.Drop(); err != nil {
+		return fmt.Errorf("firewooddb: error dropping proposal %s", pCtx.Root.Hex())
 	}
-	return p.Drop()
+
+	// Remove the proposal from the map.
+	rootList := db.proposalMap[pCtx.Root]
+	for i, p := range rootList {
+		if p == pCtx { // pointer comparison
+			rootList = append(rootList[:i], rootList[i+1:]...) // There could be other proposals with the same root.
+			break
+		}
+	}
+	db.proposalMap[pCtx.Root] = rootList
+
+	// Remove from parent's children.
+	if pCtx.Parent != nil {
+		for i, child := range pCtx.Parent.Children {
+			if child == pCtx { // pointer comparison
+				pCtx.Parent.Children = append(pCtx.Parent.Children[:i], pCtx.Parent.Children[i+1:]...)
+				break
+			}
+		}
+	}
+
+	return nil
 }
 
 // Cap iteratively flushes old but still referenced trie nodes until the total
@@ -274,18 +341,26 @@ func (db *Database) Cap(limit common.StorageSize) error {
 func (db *Database) viewAtRoot(root common.Hash) (IDbView, error) {
 	view, err := db.fwDisk.Revision(root.Bytes())
 	if err != nil {
-		return nil, fmt.Errorf("firewooddb: error retrieving revision forstate root %s", root.Hex())
+		return nil, fmt.Errorf("firewooddb: error retrieving revision for state root %s", root.Hex())
 	}
 
 	if view != nil {
-		// Check revisions
+		// Found valid revision
 		return view, nil
 	}
 
 	// Check if the state root corresponds with a proposal.
-	// Any proposal with the same root is permissible.
+	proposals, ok := db.proposalMap[root]
+	if !ok || len(proposals) == 0 {
+		return nil, fmt.Errorf("firewooddb: requested state root %s not found", root.Hex())
+	}
 
-	return nil, fmt.Errorf("firewooddb: requested state root %s not found", root.Hex())
+	// If there are multiple proposals with the same root, we can use the first one.
+	if len(proposals) > 1 {
+		log.Debug("Multiple proposals found for root", "root", root.Hex(), "count", len(proposals))
+	}
+	// Use the first proposal
+	return proposals[0].Proposal, nil
 }
 
 // Reader retrieves a node reader belonging to the given state root.


### PR DESCRIPTION
## Why this should be merged

DO NOT MERGE

## How this works

This interfaces with the Go FFI for Firewood and hooks into `triedb` to enable normal operations of the EVM. 

## How this was tested

WARNING - untested

## Need to be documented?

Yes - TBD.

## Need to update RELEASES.md?

No.
