### PR TITLE
refactor: use the built-in max/min to simplify the code

### DIFF
--- a/core/bloombits/matcher.go
+++ b/core/bloombits/matcher.go
@@ -191,14 +191,8 @@ func (m *Matcher) Start(ctx context.Context, begin, end uint64, results chan uin
 				// Calculate the first and last blocks of the section
 				sectionStart := res.section * m.sectionSize
 
-				first := sectionStart
-				if begin > first {
-					first = begin
-				}
-				last := sectionStart + m.sectionSize - 1
-				if end < last {
-					last = end
-				}
+				first := max(begin, sectionStart)
+				last := min(end, sectionStart+m.sectionSize-1)
 				// Iterate over all the blocks in the section and return the matching ones
 				for i := first; i <= last; i++ {
 					// Skip the entire byte if no matches are found inside (and we're processing an entire byte!)

--- a/rpc/handler.go
+++ b/rpc/handler.go
@@ -437,10 +437,7 @@ func (h *handler) consumeLimit(procStart time.Time) {
 	}
 
 	stopTime := time.Now()
-	processingTime := stopTime.Sub(procStart)
-	if processingTime > h.deadlineContext {
-		processingTime = h.deadlineContext
-	}
+	processingTime := min(stopTime.Sub(procStart), h.deadlineContext)
 
 	h.limiter.ReserveN(stopTime, int(processingTime))
 }


### PR DESCRIPTION
## Why this should be merged

In Go 1.21, the standard library includes built-in [max/min](https://pkg.go.dev/builtin@go1.21.0#max) function, which can greatly simplify the code.

## How this works

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
