### PR TITLE
chore(acp176): change MinTargetPerSecond to be a variable

### DIFF
--- a/core/state_processor_test.go
+++ b/core/state_processor_test.go
@@ -156,7 +156,7 @@ func TestStateProcessorErrors(t *testing.T) {
 			{ // ErrGasLimitReached
 				txs: []*types.Transaction{
 					// This test was modified to account for ACP-176 gas limits
-					makeTx(key1, 0, common.Address{}, big.NewInt(0), acp176.MinMaxCapacity+1, big.NewInt(acp176.MinGasPrice), nil),
+					makeTx(key1, 0, common.Address{}, big.NewInt(0), uint64(acp176.MinMaxCapacity+1), big.NewInt(acp176.MinGasPrice), nil),
 				},
 				want: "could not apply tx 0 [0xb709565c056a68a4b4dc7714ae901a0f03663bb98f9fa58a10b88ec614362caf]: gas limit reached",
 			},

--- a/eth/gasprice/gasprice.go
+++ b/eth/gasprice/gasprice.go
@@ -64,7 +64,7 @@ const (
 var (
 	DefaultMaxPrice           = big.NewInt(150 * params.GWei)
 	DefaultMinPrice           = big.NewInt(acp176.MinGasPrice)
-	DefaultMinGasUsed         = big.NewInt(acp176.MinTargetPerSecond)
+	DefaultMinGasUsed         = new(big.Int).SetUint64(uint64(acp176.MinTargetPerSecond))
 	DefaultMaxLookbackSeconds = uint64(80)
 )
 

--- a/eth/gasprice/gasprice_test.go
+++ b/eth/gasprice/gasprice_test.go
@@ -403,7 +403,7 @@ func TestSuggestTipCapIncludesExtraDataGas(t *testing.T) {
 	applyGasPriceTest(t, suggestTipCapTest{
 		chainConfig:     params.TestChainConfig,
 		numBlocks:       1000,
-		extDataGasUsage: big.NewInt(acp176.MinMaxPerSecond - int64(params.TxGas)),
+		extDataGasUsage: new(big.Int).SetUint64(uint64(acp176.MinMaxPerSecond) - params.TxGas),
 		// The tip on the transaction is very large to pay the block gas cost.
 		genBlock: testGenBlock(t, 100_000, 1),
 		// The actual tip doesn't matter, we just want to ensure that the tip is

--- a/ethclient/simulated/options_test.go
+++ b/ethclient/simulated/options_test.go
@@ -50,7 +50,7 @@ func TestWithBlockGasLimitOption(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to retrieve head block: %v", err)
 	}
-	if head.GasLimit() != acp176.MinMaxCapacity {
+	if head.GasLimit() != uint64(acp176.MinMaxCapacity) {
 		t.Errorf("head gas limit mismatch: have %v, want %v", head.GasLimit(), acp176.MinMaxCapacity)
 	}
 }

--- a/plugin/evm/header/extra_test.go
+++ b/plugin/evm/header/extra_test.go
@@ -287,7 +287,7 @@ func TestExtraPrefix(t *testing.T) {
 			),
 			want: (&acp176.State{
 				Gas: gas.State{
-					Capacity: acp176.MinMaxPerSecond - 6,
+					Capacity: gas.Gas(acp176.MinMaxPerSecond - 6),
 					Excess:   6,
 				},
 				TargetExcess: 0,
@@ -311,7 +311,7 @@ func TestExtraPrefix(t *testing.T) {
 			desiredTargetExcess: (*gas.Gas)(utils.NewUint64(3)),
 			want: (&acp176.State{
 				Gas: gas.State{
-					Capacity: acp176.MinMaxPerSecond - 3,
+					Capacity: gas.Gas(acp176.MinMaxPerSecond - 3),
 					Excess:   3,
 				},
 				TargetExcess: 3,
@@ -455,7 +455,7 @@ func TestVerifyExtraPrefix(t *testing.T) {
 				GasUsed: 1,
 				Extra: (&acp176.State{
 					Gas: gas.State{
-						Capacity: acp176.MinMaxPerSecond - 1,
+						Capacity: gas.Gas(acp176.MinMaxPerSecond - 1),
 						Excess:   1,
 					},
 					TargetExcess: acp176.MaxTargetExcessDiff + 1, // Too much of a diff
@@ -474,7 +474,7 @@ func TestVerifyExtraPrefix(t *testing.T) {
 				GasUsed: 1,
 				Extra: (&acp176.State{
 					Gas: gas.State{
-						Capacity: acp176.MinMaxPerSecond - 1,
+						Capacity: gas.Gas(acp176.MinMaxPerSecond - 1),
 						Excess:   1,
 					},
 					TargetExcess: acp176.MaxTargetExcessDiff,

--- a/plugin/evm/header/gas_limit_test.go
+++ b/plugin/evm/header/gas_limit_test.go
@@ -44,7 +44,7 @@ func TestGasLimit(t *testing.T) {
 			parent: &types.Header{
 				Number: big.NewInt(0),
 			},
-			want: acp176.MinMaxCapacity,
+			want: uint64(acp176.MinMaxCapacity),
 		},
 		{
 			name:     "cortina",
@@ -131,7 +131,7 @@ func TestVerifyGasUsed(t *testing.T) {
 				// The maximum allowed gas used is:
 				// (header.Time - parent.Time) * [acp176.MinMaxPerSecond]
 				// which is equal to [acp176.MinMaxPerSecond].
-				GasUsed: acp176.MinMaxPerSecond + 1,
+				GasUsed: uint64(acp176.MinMaxPerSecond + 1),
 			},
 			want: errInvalidGasUsed,
 		},
@@ -143,7 +143,7 @@ func TestVerifyGasUsed(t *testing.T) {
 			},
 			header: &types.Header{
 				Time:    1,
-				GasUsed: acp176.MinMaxPerSecond,
+				GasUsed: uint64(acp176.MinMaxPerSecond),
 			},
 			want: nil,
 		},
@@ -199,7 +199,7 @@ func TestVerifyGasLimit(t *testing.T) {
 				Number: big.NewInt(0),
 			},
 			header: &types.Header{
-				GasLimit: acp176.MinMaxCapacity + 1,
+				GasLimit: uint64(acp176.MinMaxCapacity) + 1,
 			},
 			want: errInvalidGasLimit,
 		},
@@ -210,7 +210,7 @@ func TestVerifyGasLimit(t *testing.T) {
 				Number: big.NewInt(0),
 			},
 			header: &types.Header{
-				GasLimit: acp176.MinMaxCapacity,
+				GasLimit: uint64(acp176.MinMaxCapacity),
 			},
 		},
 		{
@@ -327,7 +327,7 @@ func TestGasCapacity(t *testing.T) {
 				Number: big.NewInt(0),
 			},
 			timestamp: 1,
-			want:      acp176.MinMaxPerSecond,
+			want:      uint64(acp176.MinMaxPerSecond),
 		},
 	}
 	for _, test := range tests {
@@ -389,7 +389,7 @@ func TestRemainingAtomicGasCapacity(t *testing.T) {
 				Time:    1,
 				GasUsed: 1,
 			},
-			want: acp176.MinMaxPerSecond - 1,
+			want: uint64(acp176.MinMaxPerSecond - 1),
 		},
 	}
 	for _, test := range tests {

--- a/plugin/evm/upgrade/acp176/acp176.go
+++ b/plugin/evm/upgrade/acp176/acp176.go
@@ -19,8 +19,20 @@ import (
 	"github.com/holiman/uint256"
 )
 
+var (
+	// MinTargetPerSecond is a variable so that it can be changed by external Go code, notably
+	// for load testing in the avalanchego repository. You might want to also update the
+	// following variables value since they depend on MinMaxPerSecond:
+	// - MinTargetPerSecond
+	// - MinMaxPerSecond
+	// - MinMaxCapacity
+	// - eth/gasprice.DefaultMinGasUsed
+	MinTargetPerSecond = gas.Price(1_000_000) // P
+	MinMaxPerSecond    = MinTargetPerSecond * TargetToMax
+	MinMaxCapacity     = MinMaxPerSecond * TimeToFillCapacity
+)
+
 const (
-	MinTargetPerSecond  = 1_000_000                                 // P
 	TargetConversion    = MaxTargetChangeRate * MaxTargetExcessDiff // D
 	MaxTargetExcessDiff = 1 << 15                                   // Q
 	MinGasPrice         = 1                                         // M
@@ -31,8 +43,6 @@ const (
 	MaxTargetChangeRate           = 1024 // Controls the rate that the target can change per block.
 
 	TargetToMaxCapacity = TargetToMax * TimeToFillCapacity
-	MinMaxPerSecond     = MinTargetPerSecond * TargetToMax
-	MinMaxCapacity      = MinMaxPerSecond * TimeToFillCapacity
 
 	StateSize = 3 * wrappers.LongLen
 

--- a/plugin/evm/upgrade/acp176/acp176_test.go
+++ b/plugin/evm/upgrade/acp176/acp176_test.go
@@ -32,8 +32,8 @@ var (
 				},
 				TargetExcess: 0,
 			},
-			target:      MinTargetPerSecond,
-			maxCapacity: MinMaxCapacity,
+			target:      gas.Gas(MinTargetPerSecond),
+			maxCapacity: gas.Gas(MinMaxCapacity),
 			gasPrice:    MinGasPrice,
 		},
 		{
@@ -45,8 +45,8 @@ var (
 				TargetExcess: 33, // Largest excess that doesn't increase the target
 			},
 			skipTestDesiredTargetExcess: true,
-			target:                      MinTargetPerSecond,
-			maxCapacity:                 MinMaxCapacity,
+			target:                      gas.Gas(MinTargetPerSecond),
+			maxCapacity:                 gas.Gas(MinMaxCapacity),
 			gasPrice:                    2 * MinGasPrice,
 		},
 		{
@@ -57,8 +57,8 @@ var (
 				},
 				TargetExcess: 34, // Smallest excess that increases the target
 			},
-			target:      MinTargetPerSecond + 1,
-			maxCapacity: TargetToMaxCapacity * (MinTargetPerSecond + 1),
+			target:      gas.Gas(MinTargetPerSecond + 1),
+			maxCapacity: gas.Gas(TargetToMaxCapacity * (MinTargetPerSecond + 1)),
 			gasPrice:    2 * MinGasPrice,
 		},
 		{
@@ -70,8 +70,8 @@ var (
 				TargetExcess: MaxTargetExcessDiff,
 			},
 			skipTestDesiredTargetExcess: true,
-			target:                      MinTargetPerSecond + 977,
-			maxCapacity:                 TargetToMaxCapacity * (MinTargetPerSecond + 977),
+			target:                      gas.Gas(MinTargetPerSecond + 977),
+			maxCapacity:                 gas.Gas(TargetToMaxCapacity * (MinTargetPerSecond + 977)),
 			gasPrice:                    3 * MinGasPrice,
 		},
 		{


### PR DESCRIPTION
## Why this should be merged

- Needed for load testing on the avalanchego side

## How this works

- Change constant to be a variable
- Add comment with what variables to update upon update of this variable
- Update associated constants to be variables

## How this was tested

## Need to be documented?

## Need to update RELEASES.md?
