### PR TITLE
fix AvalancheGo version and nil configs for Granite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run e2e tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@09d98fa253ccc7c734946a42686d8b036c8598ac
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@3d137f0aa84eb0b5a756a0e22c1ad6bc7f884ac2
         with:
           run: ./scripts/tests.e2e.sh
           prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}

--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
-	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523133031-09d98fa253cc
+	github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523173028-3d137f0aa84e
 	github.com/ava-labs/libevm v1.13.14-0.2.0.release
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
@@ -62,6 +62,7 @@ require (
 	github.com/dlclark/regexp2 v1.7.0 // indirect
 	github.com/dop251/goja v0.0.0-20230806174421-c933cf95e127 // indirect
 	github.com/ethereum/c-kzg-4844 v0.4.0 // indirect
+	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/garslo/gogen v0.0.0-20170306192744-1d203ffc1f61 // indirect
 	github.com/gballet/go-libpcsclite v0.0.0-20191108122812-4678299bea08 // indirect

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,6 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523133031-09d98fa253cc h1:A0i7xfLpo/5ElFFSr8UMDkVwYP+9/fPYYUUJmsOcpds=
-github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523133031-09d98fa253cc/go.mod h1:v3HQTO2dQik82QCSIdKVmHH6ajXn8oGrfgf1ncSEdjY=
 github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523173028-3d137f0aa84e h1:mc5Ch72o2wf0u/j204anxgKBR8DBnmKZMnr2z85RXUU=
 github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523173028-3d137f0aa84e/go.mod h1:wKSvv+xjWnX9dUXuLfaNJjKGL0I1oxxj/9hhmDFA1Q8=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=
@@ -177,8 +175,6 @@ github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
-github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
-github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fjl/gencodec v0.1.1 h1:DhQY29Q6JLXB/GgMqE86NbOEuvckiYcJCbXFu02toms=
 github.com/fjl/gencodec v0.1.1/go.mod h1:chDHL3wKXuBgauP8x3XNZkl5EIAR5SoCTmmmDTZRzmw=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523133031-09d98fa253cc h1:A0i7xfLpo/5ElFFSr8UMDkVwYP+9/fPYYUUJmsOcpds=
 github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523133031-09d98fa253cc/go.mod h1:v3HQTO2dQik82QCSIdKVmHH6ajXn8oGrfgf1ncSEdjY=
+github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523173028-3d137f0aa84e h1:mc5Ch72o2wf0u/j204anxgKBR8DBnmKZMnr2z85RXUU=
+github.com/ava-labs/avalanchego v1.13.1-rc.2.0.20250523173028-3d137f0aa84e/go.mod h1:wKSvv+xjWnX9dUXuLfaNJjKGL0I1oxxj/9hhmDFA1Q8=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
@@ -175,6 +177,8 @@ github.com/ethereum/c-kzg-4844 v0.4.0 h1:3MS1s4JtA868KpJxroZoepdV0ZKBp3u/O5HcZ7R
 github.com/ethereum/c-kzg-4844 v0.4.0/go.mod h1:VewdlzQmpT5QSrVhbBuGoCdFJkpaJlO1aQputP83wc0=
 github.com/fasthttp-contrib/websocket v0.0.0-20160511215533-1f3b11f56072/go.mod h1:duJ4Jxv5lDcvg4QuQr0oowTf7dz4/CR8NtyCooz9HL8=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
+github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
+github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
 github.com/fjl/gencodec v0.1.1 h1:DhQY29Q6JLXB/GgMqE86NbOEuvckiYcJCbXFu02toms=
 github.com/fjl/gencodec v0.1.1/go.mod h1:chDHL3wKXuBgauP8x3XNZkl5EIAR5SoCTmmmDTZRzmw=
 github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -24,7 +24,6 @@ import (
 	commonEng "github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/enginetest"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
-	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
 	"github.com/ava-labs/avalanchego/utils/crypto/secp256k1"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/utils/units"
@@ -144,7 +143,7 @@ func TestStateSyncToggleEnabledToDisabled(t *testing.T) {
 	// Reset metrics to allow re-initialization
 	vmSetup.syncerVM.ctx.Metrics = metrics.NewPrefixGatherer()
 	stateSyncDisabledConfigJSON := `{"state-sync-enabled":false}`
-	genesisJSON := []byte(genesisJSON(forkToChainConfig[upgradetest.Latest]))
+	genesisJSON := []byte(genesisJSON(forkToChainConfig[latestKnownFork]))
 	if err := syncDisabledVM.Initialize(
 		context.Background(),
 		vmSetup.syncerVM.ctx,

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -123,6 +123,8 @@ var (
 		upgradetest.Fortuna:           params.TestFortunaChainConfig,
 	}
 
+	latestKnownFork = upgradetest.Fortuna
+
 	genesisJSONCancun = genesisJSON(activateCancun(params.TestChainConfig))
 
 	apricotRulesPhase0 = *params.GetRulesExtra(params.TestLaunchConfig.Rules(common.Big0, params.IsMergeTODO, 0))
@@ -183,7 +185,7 @@ type testVM struct {
 
 func newVM(t *testing.T, config testVMConfig) *testVM {
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	fork := upgradetest.Latest
+	fork := latestKnownFork
 	if config.fork != nil {
 		fork = *config.fork
 	}
@@ -3692,7 +3694,7 @@ func TestSkipChainConfigCheckCompatible(t *testing.T) {
 	// use the block's timestamp instead of 0 since rewind to genesis
 	// is hardcoded to be allowed in core/genesis.go.
 	newCTX := snowtest.Context(t, tvm.vm.ctx.ChainID)
-	upgradetest.SetTimesTo(&newCTX.NetworkUpgrades, upgradetest.Latest, upgrade.UnscheduledActivationTime)
+	upgradetest.SetTimesTo(&newCTX.NetworkUpgrades, latestKnownFork, upgrade.UnscheduledActivationTime)
 	upgradetest.SetTimesTo(&newCTX.NetworkUpgrades, fork+1, blk.Timestamp())
 	upgradetest.SetTimesTo(&newCTX.NetworkUpgrades, fork, upgrade.InitiallyActiveTime)
 	genesis := []byte(genesisJSON(forkToChainConfig[fork]))

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -851,7 +851,7 @@ func TestBlockSignatureRequestsToVM(t *testing.T) {
 }
 
 func TestClearWarpDB(t *testing.T) {
-	ctx, db, genesisBytes, issuer, _ := setupGenesis(t, upgradetest.Latest)
+	ctx, db, genesisBytes, issuer, _ := setupGenesis(t, latestKnownFork)
 	vm := &VM{}
 	require.NoError(t, vm.Initialize(
 		context.Background(),
@@ -884,7 +884,7 @@ func TestClearWarpDB(t *testing.T) {
 	// Restart VM with the same database default should not prune the warp db
 	vm = &VM{}
 	// we need new context since the previous one has registered metrics.
-	ctx, _, _, _, _ = setupGenesis(t, upgradetest.Latest)
+	ctx, _, _, _, _ = setupGenesis(t, latestKnownFork)
 	require.NoError(t, vm.Initialize(
 		context.Background(),
 		ctx,
@@ -908,7 +908,7 @@ func TestClearWarpDB(t *testing.T) {
 	// restart the VM with pruning enabled
 	vm = &VM{}
 	config := `{"prune-warp-db-enabled": true}`
-	ctx, _, _, _, _ = setupGenesis(t, upgradetest.Latest)
+	ctx, _, _, _, _ = setupGenesis(t, latestKnownFork)
 	require.NoError(t, vm.Initialize(
 		context.Background(),
 		ctx,


### PR DESCRIPTION
## Why this should be merged

Fixes e2e tests that failing because the dependent commit does not exist anymore on avalanchego repo.

## How this works

bumps avalanchego to commit in https://github.com/ava-labs/avalanchego/pull/3977

## How this was tested

e2e

## Need to be documented?

no

## Need to update RELEASES.md?

no
