### PR TITLE
refactor(core): Use state.Database in Genesis

### DIFF
--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -36,6 +36,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 	"github.com/ava-labs/libevm/common"
@@ -43,7 +44,6 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/crypto"
-	"github.com/ava-labs/libevm/triedb"
 	"github.com/stretchr/testify/require"
 )
 
@@ -564,7 +564,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	var sideblocks types.Blocks
 	if tt.sidechainBlocks > 0 {
 		genDb := rawdb.NewMemoryDatabase()
-		gspec.MustCommit(genDb, triedb.NewDatabase(genDb, nil))
+		gspec.MustCommit(state.NewDatabase(genDb))
 		sideblocks, _, err = GenerateChain(gspec.Config, gspec.ToBlock(), engine, genDb, tt.sidechainBlocks, 10, func(i int, b *BlockGen) {
 			b.SetCoinbase(common.Address{0x01})
 			tx, err := types.SignTx(types.NewTransaction(b.TxNonce(addr1), common.Address{0x01}, big.NewInt(10000), params.TxGas, big.NewInt(ap3.InitialBaseFee), nil), signer, key1)
@@ -577,7 +577,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 		}
 	}
 	genDb := rawdb.NewMemoryDatabase()
-	gspec.MustCommit(genDb, triedb.NewDatabase(genDb, nil))
+	gspec.MustCommit(state.NewDatabase(genDb))
 	canonblocks, _, err := GenerateChain(gspec.Config, gspec.ToBlock(), engine, genDb, tt.canonicalBlocks, 10, func(i int, b *BlockGen) {
 		b.SetCoinbase(common.Address{0x02})
 		b.SetDifficulty(big.NewInt(1000000))

--- a/core/chain_makers.go
+++ b/core/chain_makers.go
@@ -363,7 +363,7 @@ func GenerateChainWithGenesis(genesis *Genesis, engine consensus.Engine, n int, 
 	db := rawdb.NewMemoryDatabase()
 	triedb := triedb.NewDatabase(db, triedb.HashDefaults)
 	defer triedb.Close()
-	_, err := genesis.Commit(db, triedb)
+	_, err := genesis.Commit(state.NewDatabaseWithNodeDB(db, triedb))
 	if err != nil {
 		return nil, nil, nil, err
 	}

--- a/core/chain_makers_test.go
+++ b/core/chain_makers_test.go
@@ -32,6 +32,7 @@ import (
 	"math/big"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -58,7 +59,7 @@ func ExampleGenerateChain() {
 		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
 		Alloc:  types.GenesisAlloc{addr1: {Balance: big.NewInt(1000000)}},
 	}
-	genesis := gspec.MustCommit(genDb, triedb.NewDatabase(genDb, triedb.HashDefaults))
+	genesis := gspec.MustCommit(state.NewDatabaseWithConfig(genDb, triedb.HashDefaults))
 
 	// This call generates a chain of 3 blocks. The function runs for
 	// each block and adds different features to gen based on the

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -125,7 +125,7 @@ func (e *GenesisMismatchError) Error() string {
 // specify a fork block below the local head block). In case of a conflict, the
 // error is a *params.ConfigCompatError and the new, unwritten config is returned.
 func SetupGenesisBlock(
-	db ethdb.Database, triedb *triedb.Database, genesis *Genesis, lastAcceptedHash common.Hash, skipChainConfigCheckCompatible bool,
+	db ethdb.Database, coredb state.Database, genesis *Genesis, lastAcceptedHash common.Hash, skipChainConfigCheckCompatible bool,
 ) (*params.ChainConfig, common.Hash, error) {
 	if genesis == nil {
 		return nil, common.Hash{}, ErrNoGenesis
@@ -137,7 +137,7 @@ func SetupGenesisBlock(
 	stored := rawdb.ReadCanonicalHash(db, 0)
 	if (stored == common.Hash{}) {
 		log.Info("Writing genesis to database")
-		block, err := genesis.Commit(db, triedb)
+		block, err := genesis.Commit(coredb)
 		if err != nil {
 			return genesis.Config, common.Hash{}, err
 		}
@@ -148,13 +148,13 @@ func SetupGenesisBlock(
 	// is initialized with an external ancient store. Commit genesis state
 	// in this case.
 	header := rawdb.ReadHeader(db, stored, 0)
-	if header.Root != types.EmptyRootHash && !triedb.Initialized(header.Root) {
+	if header.Root != types.EmptyRootHash && !coredb.TrieDB().Initialized(header.Root) {
 		// Ensure the stored genesis matches with the given one.
 		hash := genesis.ToBlock().Hash()
 		if hash != stored {
 			return genesis.Config, common.Hash{}, &GenesisMismatchError{stored, hash}
 		}
-		_, err := genesis.Commit(db, triedb)
+		_, err := genesis.Commit(coredb)
 		return genesis.Config, common.Hash{}, err
 	}
 	// Check whether the genesis block is already written.
@@ -215,7 +215,7 @@ func (g *Genesis) IsVerkle() bool {
 // ToBlock returns the genesis block according to genesis specification.
 func (g *Genesis) ToBlock() *types.Block {
 	db := rawdb.NewMemoryDatabase()
-	return g.toBlock(db, triedb.NewDatabase(db, g.trieConfig()))
+	return g.toBlock(state.NewDatabaseWithConfig(db, g.trieConfig()))
 }
 
 func (g *Genesis) trieConfig() *triedb.Config {
@@ -229,8 +229,8 @@ func (g *Genesis) trieConfig() *triedb.Config {
 }
 
 // TODO: migrate this function to "flush" for more similarity with upstream.
-func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Block {
-	statedb, err := state.New(types.EmptyRootHash, state.NewDatabaseWithNodeDB(db, triedb), nil)
+func (g *Genesis) toBlock(coredb state.Database) *types.Block {
+	statedb, err := state.New(types.EmptyRootHash, coredb, nil)
 	if err != nil {
 		panic(err)
 	}
@@ -304,7 +304,7 @@ func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Blo
 	}
 	// Commit newly generated states into disk if it's not empty.
 	if root != types.EmptyRootHash {
-		if err := triedb.Commit(root, true); err != nil {
+		if err := coredb.TrieDB().Commit(root, true); err != nil {
 			panic(fmt.Sprintf("unable to commit genesis block: %v", err))
 		}
 	}
@@ -313,8 +313,9 @@ func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Blo
 
 // Commit writes the block and state of a genesis specification to the database.
 // The block is committed as the canonical head block.
-func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Block, error) {
-	block := g.toBlock(db, triedb)
+func (g *Genesis) Commit(coredb state.Database) (*types.Block, error) {
+	db := coredb.DiskDB()
+	block := g.toBlock(coredb)
 	if block.Number().Sign() != 0 {
 		return nil, errors.New("can't commit genesis block with number > 0")
 	}
@@ -336,8 +337,8 @@ func (g *Genesis) Commit(db ethdb.Database, triedb *triedb.Database) (*types.Blo
 
 // MustCommit writes the genesis block and state to db, panicking on error.
 // The block is committed as the canonical head block.
-func (g *Genesis) MustCommit(db ethdb.Database, triedb *triedb.Database) *types.Block {
-	block, err := g.Commit(db, triedb)
+func (g *Genesis) MustCommit(coredb state.Database) *types.Block {
+	block, err := g.Commit(coredb)
 	if err != nil {
 		panic(err)
 	}
@@ -351,7 +352,7 @@ func GenesisBlockForTesting(db ethdb.Database, addr common.Address, balance *big
 		Alloc:   types.GenesisAlloc{addr: {Balance: balance}},
 		BaseFee: big.NewInt(ap3.InitialBaseFee),
 	}
-	return g.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+	return g.MustCommit(state.NewDatabaseWithConfig(db, triedb.HashDefaults))
 }
 
 // ReadBlockByHash reads the block with the given hash from the database.

--- a/core/genesis_extra_test.go
+++ b/core/genesis_extra_test.go
@@ -32,6 +32,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/ava-labs/coreth/utils"
@@ -72,10 +73,10 @@ func TestGenesisEthUpgrades(t *testing.T) {
 		},
 	)
 
-	tdb := triedb.NewDatabase(db, triedb.HashDefaults)
+	coredb := state.NewDatabaseWithConfig(db, triedb.HashDefaults)
 	config := *preEthUpgrades
 	// Set this up once, just to get the genesis hash
-	_, genHash, err := SetupGenesisBlock(db, tdb, &Genesis{Config: &config}, common.Hash{}, false)
+	_, genHash, err := SetupGenesisBlock(db, coredb, &Genesis{Config: &config}, common.Hash{}, false)
 	require.NoError(t, err)
 
 	// Write the configuration back to the db as it would be in prior versions
@@ -96,6 +97,6 @@ func TestGenesisEthUpgrades(t *testing.T) {
 	// We should still be able to re-initialize
 	config = *preEthUpgrades
 	require.NoError(t, params.SetEthUpgrades(&config)) // New versions will set additional fields eg, LondonBlock
-	_, _, err = SetupGenesisBlock(db, tdb, &Genesis{Config: &config}, block.Hash(), false)
+	_, _, err = SetupGenesisBlock(db, coredb, &Genesis{Config: &config}, block.Hash(), false)
 	require.NoError(t, err)
 }

--- a/eth/filters/filter_test.go
+++ b/eth/filters/filter_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ava-labs/coreth/accounts/abi"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/rpc"
@@ -100,7 +101,7 @@ func BenchmarkFilters(b *testing.B) {
 	// The test txs are not properly signed, can't simply create a chain
 	// and then import blocks. TODO(rjl493456442) try to get rid of the
 	// manual database writes.
-	gspec.MustCommit(db, triedb.NewDatabase(db, triedb.HashDefaults))
+	gspec.MustCommit(state.NewDatabaseWithConfig(db, triedb.HashDefaults))
 
 	for i, block := range chain {
 		rawdb.WriteBlock(db, block)
@@ -194,7 +195,7 @@ func TestFilters(t *testing.T) {
 
 	// Hack: GenerateChainWithGenesis creates a new db.
 	// Commit the genesis manually and use GenerateChain.
-	_, err = gspec.Commit(db, triedb.NewDatabase(db, nil))
+	_, err = gspec.Commit(state.NewDatabase(db))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/sync/client/client_test.go
+++ b/sync/client/client_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	clientstats "github.com/ava-labs/coreth/sync/client/stats"
@@ -143,8 +144,8 @@ func TestGetBlocks(t *testing.T) {
 		Config: params.TestChainConfig,
 	}
 	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, nil)
-	genesis := gspec.MustCommit(memdb, tdb)
+	coredb := state.NewDatabase(memdb)
+	genesis := gspec.MustCommit(coredb)
 	engine := dummy.NewETHFaker()
 	numBlocks := 110
 	blocks, _, err := core.GenerateChain(params.TestChainConfig, genesis, engine, memdb, numBlocks, 0, func(i int, b *core.BlockGen) {})

--- a/sync/handlers/block_request_test.go
+++ b/sync/handlers/block_request_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/avalanchego/utils/units"
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	"github.com/ava-labs/coreth/sync/handlers/stats"
@@ -21,7 +22,6 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/rlp"
-	"github.com/ava-labs/libevm/triedb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -107,8 +107,8 @@ func TestBlockRequestHandler(t *testing.T) {
 		Config: params.TestChainConfig,
 	}
 	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, nil)
-	genesis := gspec.MustCommit(memdb, tdb)
+	coredb := state.NewDatabase(memdb)
+	genesis := gspec.MustCommit(coredb)
 	engine := dummy.NewETHFaker()
 	blocks, _, err := core.GenerateChain(params.TestChainConfig, genesis, engine, memdb, 96, 0, func(i int, b *core.BlockGen) {})
 	if err != nil {
@@ -165,8 +165,8 @@ func TestBlockRequestHandlerLargeBlocks(t *testing.T) {
 		signer = types.LatestSigner(gspec.Config)
 	)
 	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, nil)
-	genesis := gspec.MustCommit(memdb, tdb)
+	coredb := state.NewDatabase(memdb)
+	genesis := gspec.MustCommit(coredb)
 	engine := dummy.NewETHFaker()
 	blocks, _, err := core.GenerateChain(gspec.Config, genesis, engine, memdb, 96, 0, func(i int, b *core.BlockGen) {
 		var data []byte
@@ -219,8 +219,8 @@ func TestBlockRequestHandlerCtxExpires(t *testing.T) {
 		Config: params.TestChainConfig,
 	}
 	memdb := rawdb.NewMemoryDatabase()
-	tdb := triedb.NewDatabase(memdb, nil)
-	genesis := gspec.MustCommit(memdb, tdb)
+	coredb := state.NewDatabase(memdb)
+	genesis := gspec.MustCommit(coredb)
 	engine := dummy.NewETHFaker()
 	blocks, _, err := core.GenerateChain(params.TestChainConfig, genesis, engine, memdb, 11, 0, func(i int, b *core.BlockGen) {})
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

Firewood requires a custom implementation of `state.Database`, and the necessary information to create it can not reasonably be supplied to these functions. See #959 

## How this works

Instead of supplying a `TrieDB`, a `state.Database` is provided. This reduces initializations of the `state.Database`, but this only effects the trie caching - low impact on genesis.

## How this was tested

Existing unit tests

## Need to be documented?

No

## Need to update RELEASES.md?

No
