### PR TITLE
Require min available capacity to build a block

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -60,8 +60,7 @@ import (
 const (
 	// Leaves 256 KBs for other sections of the block (limit is 2MB).
 	// This should suffice for atomic txs, proposervm header, and serialization overhead.
-	targetTxsSize  = 1792 * units.KiB
-	minGasCapacity = 12_800_000 // 12.8M gas is the minimum gas capacity to attempt block building
+	targetTxsSize = 1792 * units.KiB
 )
 
 var ErrInsufficientGasCapacityToBuild = errors.New("insufficient gas capacity to build block")

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -271,8 +271,12 @@ func (w *worker) createCurrentEnvironment(predicateContext *precompileconfig.Pre
 	if err != nil {
 		return nil, fmt.Errorf("calculating gas capacity: %w", err)
 	}
-	if capacity < minGasCapacity {
-		return nil, fmt.Errorf("%w: capacity (%d) < min capacity (%d)", errInsufficientGasCapacity, capacity, minGasCapacity)
+	// If Fortuna has activated, enforce we only build a block when there is a minimum
+	// built up gas capacity.
+	if chainConfigExtra.IsFortuna(header.Time) {
+		if capacity < minGasCapacity {
+			return nil, fmt.Errorf("%w: capacity (%d) < min capacity (%d)", errInsufficientGasCapacity, capacity, minGasCapacity)
+		}
 	}
 	numPrefetchers := w.chain.CacheConfig().TriePrefetcherParallelism
 	currentState.StartPrefetcher("miner", state.WithConcurrentWorkers(numPrefetchers))

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ava-labs/coreth/params"
 	customheader "github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
+	"github.com/ava-labs/coreth/plugin/evm/upgrade/cortina"
 	"github.com/ava-labs/coreth/precompile/precompileconfig"
 	"github.com/ava-labs/coreth/predicate"
 	"github.com/ava-labs/libevm/common"
@@ -285,6 +286,10 @@ func (w *worker) createCurrentEnvironment(predicateContext *precompileconfig.Pre
 		// not allow the bucket to overflow, this would waste potential gas capacity.
 		capacityPerSecond := header.GasLimit / acp176.TimeToFillCapacity
 		minimumBuildableCapacity := header.GasLimit - capacityPerSecond
+
+		// Since the GasLimit is configurable, only wait up to the GasLimit as of the Cortina upgrade.
+		// There is no need to continue scaling up beyond the GasLimit guaranteed prior to ACP-176 activation.
+		minimumBuildableCapacity = min(minimumBuildableCapacity, cortina.GasLimit)
 		if capacity < minimumBuildableCapacity {
 			return nil, fmt.Errorf("%w: %d waiting for %d", ErrInsufficientGasCapacityToBuild, capacity, minimumBuildableCapacity)
 		}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3989,7 +3989,7 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 	require.NoError(blk1.Accept(ctx))
 
 	newHead := <-newTxPoolHeadChan
-	require.Equal(newHead.Head.Hash(), common.Hash(blk1.ID()))
+	require.Equal(common.Hash(blk1.ID()), newHead.Head.Hash())
 
 	// Build a block consuming all of the available gas
 	var (

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3903,23 +3903,6 @@ func TestBuildBlockWithInsufficientCapacity(t *testing.T) {
 	newTxPoolHeadChan := make(chan core.NewTxPoolReorgEvent, 1)
 	tvm.vm.txPool.SubscribeNewReorgEvent(newTxPoolHeadChan)
 
-	importTx, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
-	require.NoError(err)
-
-	require.NoError(tvm.vm.mempool.AddLocalTx(importTx))
-
-	<-tvm.toEngine
-
-	blk1, err := tvm.vm.BuildBlock(ctx)
-	require.NoError(err)
-
-	require.NoError(blk1.Verify(ctx))
-	require.NoError(tvm.vm.SetPreference(ctx, blk1.ID()))
-	require.NoError(blk1.Accept(ctx))
-
-	newHead := <-newTxPoolHeadChan
-	require.Equal(newHead.Head.Hash(), common.Hash(blk1.ID()))
-
 	// Build a block consuming all of the available gas
 	txs := make([]*types.Transaction, 0, 2)
 	for i := uint64(0); i < 2; i++ {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3904,18 +3904,20 @@ func TestBuildBlockWithInsufficientCapacity(t *testing.T) {
 	tvm.vm.txPool.SubscribeNewReorgEvent(newTxPoolHeadChan)
 
 	// Build a block consuming all of the available gas
-	txs := make([]*types.Transaction, 0, 2)
+	var (
+		txs = make([]*types.Transaction, 2)
+		err error
+	)
 	for i := uint64(0); i < 2; i++ {
 		tx := types.NewContractCreation(
 			i,
 			big.NewInt(0),
-			8_000_000, // 8M gas is max guaranteed capacity with default gas target of 10M
+			acp176.MinMaxCapacity,
 			big.NewInt(ap0.MinGasPrice),
 			[]byte{0xfe}, // invalid opcode consumes all gas
 		)
-		signedTx, err := types.SignTx(tx, types.NewEIP155Signer(tvm.vm.chainID), testKeys[0].ToECDSA())
+		txs[i], err = types.SignTx(tx, types.NewEIP155Signer(tvm.vm.chainID), testKeys[0].ToECDSA())
 		require.NoError(err)
-		txs = append(txs, signedTx)
 	}
 
 	errs := tvm.vm.txPool.AddRemotesSync([]*types.Transaction{txs[0]})
@@ -3979,7 +3981,6 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 	require.NoError(tvm.vm.mempool.AddLocalTx(importTx2))
 
 	<-tvm.toEngine
-
 	blk1, err := tvm.vm.BuildBlock(ctx)
 	require.NoError(err)
 
@@ -3988,24 +3989,27 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 	require.NoError(blk1.Accept(ctx))
 
 	newHead := <-newTxPoolHeadChan
-	if newHead.Head.Hash() != common.Hash(blk1.ID()) {
-		t.Fatalf("Expected new block to match")
-	}
-	gasAmount := uint64(8_000_000) // 8M gas
+	require.Equal(newHead.Head.Hash(), common.Hash(blk1.ID()))
 
 	// Build a block consuming all of the available gas
-	maxSizeTxs := make([]*types.Transaction, 0, 2)
+	var (
+		highGasPrice = big.NewInt(2 * ap0.MinGasPrice)
+		lowGasPrice  = big.NewInt(ap0.MinGasPrice)
+	)
+
+	// Refill capacity after distributing funds with import transactions
+	tvm.vm.clock.Set(tvm.vm.clock.Time().Add(acp176.TimeToFillCapacity * time.Second))
+	maxSizeTxs := make([]*types.Transaction, 2)
 	for i := uint64(0); i < 2; i++ {
 		tx := types.NewContractCreation(
 			i,
 			big.NewInt(0),
-			gasAmount,
-			big.NewInt(2*ap0.MinGasPrice), // higher price than smaller tx
-			[]byte{0xfe},                  // invalid opcode consumes all gas
+			acp176.MinMaxCapacity,
+			highGasPrice,
+			[]byte{0xfe}, // invalid opcode consumes all gas
 		)
-		signedTx, err := types.SignTx(tx, types.NewEIP155Signer(tvm.vm.chainID), testKeys[0].ToECDSA())
+		maxSizeTxs[i], err = types.SignTx(tx, types.NewEIP155Signer(tvm.vm.chainID), testKeys[0].ToECDSA())
 		require.NoError(err)
-		maxSizeTxs = append(maxSizeTxs, signedTx)
 	}
 
 	errs := tvm.vm.txPool.AddRemotesSync([]*types.Transaction{maxSizeTxs[0]})
@@ -4026,7 +4030,7 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 
 	// Build a smaller transaction that consumes less gas at a lower price. Block building should
 	// fail and enforce waiting for more capacity to avoid starving the larger transaction.
-	tx := types.NewContractCreation(0, big.NewInt(0), 2_000_000, big.NewInt(ap0.MinGasPrice), []byte{0xfe})
+	tx := types.NewContractCreation(0, big.NewInt(0), 2_000_000, lowGasPrice, []byte{0xfe})
 	signedTx, err := types.SignTx(tx, types.NewEIP155Signer(tvm.vm.chainID), testKeys[1].ToECDSA())
 	require.NoError(err)
 	errs = tvm.vm.txPool.AddRemotesSync([]*types.Transaction{signedTx})
@@ -4042,6 +4046,10 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 	<-tvm.toEngine
 	blk4, err := tvm.vm.BuildBlock(ctx)
 	require.NoError(err)
+	ethBlk4 := blk4.(*chain.BlockWrapper).Block.(*Block).ethBlock
+	actualTxs := ethBlk4.Transactions()
+	require.Len(actualTxs, 1)
+	require.Equal(maxSizeTxs[1].Hash(), actualTxs[0].Hash())
 
 	require.NoError(blk4.Verify(ctx))
 	require.NoError(blk4.Accept(ctx))

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -3918,9 +3918,7 @@ func TestBuildBlockWithInsufficientCapacity(t *testing.T) {
 	require.NoError(blk1.Accept(ctx))
 
 	newHead := <-newTxPoolHeadChan
-	if newHead.Head.Hash() != common.Hash(blk1.ID()) {
-		t.Fatalf("Expected new block to match")
-	}
+	require.Equal(newHead.Head.Hash(), common.Hash(blk1.ID()))
 
 	// Build a block consuming all of the available gas
 	txs := make([]*types.Transaction, 0, 2)
@@ -3959,7 +3957,7 @@ func TestBuildBlockWithInsufficientCapacity(t *testing.T) {
 	require.ErrorIs(err, miner.ErrInsufficientGasCapacityToBuild)
 
 	// Wait to fill block capacity and retry block builiding
-	time.Sleep(acp176.TimeToFillCapacity * time.Second)
+	tvm.vm.clock.Set(tvm.vm.clock.Time().Add(acp176.TimeToFillCapacity * time.Second))
 
 	<-tvm.toEngine
 	blk3, err := tvm.vm.BuildBlock(ctx)
@@ -4057,7 +4055,7 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 	require.ErrorIs(err, miner.ErrInsufficientGasCapacityToBuild)
 
 	// Wait to fill block capacity and retry block building
-	time.Sleep(acp176.TimeToFillCapacity * time.Second)
+	tvm.vm.clock.Set(tvm.vm.clock.Time().Add(acp176.TimeToFillCapacity * time.Second))
 	<-tvm.toEngine
 	blk4, err := tvm.vm.BuildBlock(ctx)
 	require.NoError(err)


### PR DESCRIPTION
## Why this should be merged

This PR updates the block building logic to return an error if the available gas capacity would be < min(80% of GasLimit, 15m).

This ensures that when the chain is quickly increasing fees due to all gas being consumed, block building will pause to allow the capacity to refill until it can guarantee that there is space for a transaction with a gas limit of at least 80% of the gas limit (currently configured on mainnet to 16m implying transactions of size 12.8M gas can be included).

The original heuristic was to ONLY check that at least 80% of the gas limit is available, but as the gas target scales up this would trade off delaying block production to guarantee greater than 15m gas is available. This check is added to ensure that transactions that could be included prior to ACP-176 can properly bid to be included, so there's no need to scale up as the gas limit increases further.

## How this works

After calculating the gas capacity, return an error if there's insufficient capacity. Block building will retry when capacity has refilled.

## How this was tested

Adds two unit tests:
- test block building fails with the expected error when there's insufficient capacity
- test when there's a large and small transaction to include, block building fails rather than include the small tx and starve the larger tx

## Need to be documented?

TODO: add a reference to https://github.com/avalanche-foundation/ACPs/tree/main/ACPs/176-dynamic-evm-gas-limit-and-price-discovery-updates

## Need to update RELEASES.md?
