### PR TITLE
Refactor AP1 `ExtData` Checks

### DIFF
--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -91,12 +91,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 	headerExtra := customtypes.GetHeaderExtra(ethHeader)
 
 	extData := customtypes.BlockExtData(ethBlock)
-	if rules.IsApricotPhase1 {
-		extDataHash := customtypes.CalcExtDataHash(extData)
-		if headerExtra.ExtDataHash != extDataHash {
-			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, extDataHash)
-		}
-	} else {
+	if !rules.IsApricotPhase1 {
 		// Prior to AP1, the extra data hash was not properly initialized.
 		if headerExtra.ExtDataHash != (common.Hash{}) {
 			return fmt.Errorf("expected ExtDataHash to be empty but got %x", headerExtra.ExtDataHash)
@@ -119,6 +114,11 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 			}
 		} else if len(extData) != 0 {
 			return fmt.Errorf("unexpectedly provided extra data in block (%s, %d)", blockHash, b.Height())
+		}
+	} else {
+		extDataHash := customtypes.CalcExtDataHash(extData)
+		if headerExtra.ExtDataHash != extDataHash {
+			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, extDataHash)
 		}
 	}
 

--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -90,7 +90,8 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 	blockHash := ethBlock.Hash()
 	headerExtra := customtypes.GetHeaderExtra(ethHeader)
 
-	if extData := customtypes.BlockExtData(ethBlock); rules.IsApricotPhase1 {
+	extData := customtypes.BlockExtData(ethBlock)
+	if rules.IsApricotPhase1 {
 		extDataHash := customtypes.CalcExtDataHash(extData)
 		if headerExtra.ExtDataHash != extDataHash {
 			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, extDataHash)

--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -107,7 +107,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 		// manually verify that the extra data is correct for each block.
 		extData := customtypes.BlockExtData(ethBlock)
 
-		// If extra data hashes map includes the block hash, we must enforce
+		// If the extra data hashes map includes the block hash, we must enforce
 		// that the extra data provided in the block bytes matches the expected
 		// hash.
 		//

--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -116,6 +116,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 			return fmt.Errorf("unexpectedly provided extra data in block (%s, %d)", blockHash, b.Height())
 		}
 	} else {
+		// After AP1, the extra data hash must be properly initialized.
 		extDataHash := customtypes.CalcExtDataHash(extData)
 		if headerExtra.ExtDataHash != extDataHash {
 			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, extDataHash)

--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -90,11 +90,10 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 	blockHash := ethBlock.Hash()
 	headerExtra := customtypes.GetHeaderExtra(ethHeader)
 
-	if rules.IsApricotPhase1 {
-		extraData := customtypes.BlockExtData(ethBlock)
-		hash := customtypes.CalcExtDataHash(extraData)
-		if headerExtra.ExtDataHash != hash {
-			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, hash)
+	if extData := customtypes.BlockExtData(ethBlock); rules.IsApricotPhase1 {
+		extDataHash := customtypes.CalcExtDataHash(extData)
+		if headerExtra.ExtDataHash != extDataHash {
+			return fmt.Errorf("extra data hash mismatch: have %x, want %x", headerExtra.ExtDataHash, extDataHash)
 		}
 	} else {
 		// Prior to AP1, the extra data hash was not properly initialized.
@@ -105,8 +104,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 		// Because the extra data hash was not included, the extra data prior to
 		// AP1 is not committed to based on the block hash. Therefore, we must
 		// manually verify that the extra data is correct for each block.
-		extData := customtypes.BlockExtData(ethBlock)
-
+		//
 		// If the extra data hashes map includes the block hash, we must enforce
 		// that the extra data provided in the block bytes matches the expected
 		// hash.

--- a/plugin/evm/atomic_block_extension.go
+++ b/plugin/evm/atomic_block_extension.go
@@ -97,8 +97,8 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 			return fmt.Errorf("expected ExtDataHash to be empty but got %x", headerExtra.ExtDataHash)
 		}
 
-		// Because the extra data hash was not included, the extra data prior to
-		// AP1 is not committed to based on the block hash. Therefore, we must
+		// Because the extra data hash was not initialized, the extra data prior
+		// to AP1 is not committed to with the block hash. Therefore, we must
 		// manually verify that the extra data is correct for each block.
 		//
 		// If the extra data hashes map includes the block hash, we must enforce


### PR DESCRIPTION
## Why this should be merged

Personally, I find the current code hard to reason about.

- The current code has multiple cases where AP1 is checked.
- The pre-AP1 check (which is required even after the chains have advanced past AP1) is only enforced for Fuji and Mainnet, even though all chains really would need this check.
- The pre-AP1 checks have a control flow based on untrusted data (rather than having the control flow based on trusted data).

## How this works

1. Refactors the pre-AP1 checks to perform validation based on the known `extDataHashes` rather than based on the claimed `extData`.
2. Enforces all non-Fuji/Mainnet chains with pre-AP1 blocks to not have any `extData`.
3. Combined both `!rules.IsApricotPhase1` cases into a single block.

## How this was tested

CI / visual inspection.

## Need to be documented?

No.

## Need to update RELEASES.md?

No