### PR TITLE
fix spelling issues

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -223,7 +223,7 @@ type blockTraceTask struct {
 	results []*txTraceResult // Trace results procudes by the task
 }
 
-// blockTraceResult represets the results of tracing a single block when an entire
+// blockTraceResult represents the results of tracing a single block when an entire
 // chain is being traced.
 type blockTraceResult struct {
 	Block  hexutil.Uint64   `json:"block"`  // Block number corresponding to this trace

--- a/nativeasset/contract.go
+++ b/nativeasset/contract.go
@@ -43,7 +43,7 @@ func PackNativeAssetBalanceInput(address common.Address, assetID common.Hash) []
 // UnpackNativeAssetBalanceInput attempts to unpack [input] into the arguments to the native asset balance precompile
 func UnpackNativeAssetBalanceInput(input []byte) (common.Address, common.Hash, error) {
 	if len(input) != 52 {
-		return common.Address{}, common.Hash{}, fmt.Errorf("native asset balance input had unexpcted length %d", len(input))
+		return common.Address{}, common.Hash{}, fmt.Errorf("native asset balance input had unexpected length %d", len(input))
 	}
 	address := common.BytesToAddress(input[:20])
 	assetID := common.Hash{}

--- a/sync/statesync/code_syncer.go
+++ b/sync/statesync/code_syncer.go
@@ -40,7 +40,7 @@ type CodeSyncerConfig struct {
 	DB ethdb.Database
 }
 
-// codeSyncer syncs code bytes from the network in a seprate thread.
+// codeSyncer syncs code bytes from the network in a separate thread.
 // Tracks outstanding requests in the DB, so that it will still fulfill them if interrupted.
 type codeSyncer struct {
 	lock sync.Mutex


### PR DESCRIPTION

_eth/tracers/api.go_
represets - represents

_nativeasset/contract.go_
unexpcted - unexpected

_sync/statesync/code_syncer.go_
seprate - separate