### PR TITLE
chore: Update libevm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run e2e tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@86c0b96e8e07347f66d008faac50af1b2d3cecc9
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@049b5859a039f3d8a76b8b6fff9e7b3e9506ac99
         with:
           run: ./scripts/tests.e2e.sh
           prometheus_username: ${{ secrets.PROMETHEUS_ID || '' }}

--- a/go.mod
+++ b/go.mod
@@ -4,8 +4,8 @@ go 1.23.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.1-rc.3
-	github.com/ava-labs/libevm v1.13.14-0.2.0.release
+	github.com/ava-labs/avalanchego v1.13.0
+	github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/fjl/gencodec v0.1.1

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.0
+	github.com/ava-labs/avalanchego v1.13.2-0.20250610153956-049b5859a039
 	github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,6 @@ github.com/ava-labs/avalanchego v1.13.2-0.20250610153956-049b5859a039 h1:Wc4uMMi
 github.com/ava-labs/avalanchego v1.13.2-0.20250610153956-049b5859a039/go.mod h1:7BHKKN46mOeRNXpt5idSEJmTz903vDZFa1PXONNmSc4=
 github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc h1:cSXaUY4hdmoJ2FJOgOzn+WiovN/ZB/zkNRgnZhE50OA=
 github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
-github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=
-github.com/ava-labs/libevm v1.13.14-0.2.0.release/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -58,8 +58,11 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
+github.com/ava-labs/avalanchego v1.13.0/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
 github.com/ava-labs/avalanchego v1.13.1-rc.3 h1:txl2n86enk7QbnqZC88vSettLllHQKZ6YwKVA6O/hYs=
 github.com/ava-labs/avalanchego v1.13.1-rc.3/go.mod h1:wKSvv+xjWnX9dUXuLfaNJjKGL0I1oxxj/9hhmDFA1Q8=
+github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc h1:cSXaUY4hdmoJ2FJOgOzn+WiovN/ZB/zkNRgnZhE50OA=
+github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/go.sum
+++ b/go.sum
@@ -58,9 +58,8 @@ github.com/ajg/form v1.5.1/go.mod h1:uL1WgH+h2mgNtvBq0339dVnzXdBETtL2LeUXaIv25UY
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
 github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
-github.com/ava-labs/avalanchego v1.13.0/go.mod h1:fpV/GmbfIB3P53gkq6zFpyeQtyAsJIuZCCKnm7TJ4sQ=
-github.com/ava-labs/avalanchego v1.13.1-rc.3 h1:txl2n86enk7QbnqZC88vSettLllHQKZ6YwKVA6O/hYs=
-github.com/ava-labs/avalanchego v1.13.1-rc.3/go.mod h1:wKSvv+xjWnX9dUXuLfaNJjKGL0I1oxxj/9hhmDFA1Q8=
+github.com/ava-labs/avalanchego v1.13.2-0.20250610153956-049b5859a039 h1:Wc4uMMiPRtnQOgrdEBbNFOXV5rXr6xtPA7GbNYgCqgM=
+github.com/ava-labs/avalanchego v1.13.2-0.20250610153956-049b5859a039/go.mod h1:7BHKKN46mOeRNXpt5idSEJmTz903vDZFa1PXONNmSc4=
 github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc h1:cSXaUY4hdmoJ2FJOgOzn+WiovN/ZB/zkNRgnZhE50OA=
 github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/ava-labs/libevm v1.13.14-0.2.0.release h1:uKGCc5/ceeBbfAPRVtBUxbQt50WzB2pEDb8Uy93ePgQ=


### PR DESCRIPTION
## Why this should be merged

Firewood PR #959 requires an updated libevm branch to build.

## How this works

Since ava-labs/libevm#187, libevm's main branch can be used in `go.mod` files with the cherry-picked commits. Uses ava-labs/avalanchego#4006

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No?
