### PR TITLE
use explicity structs and innervm calls

### DIFF
--- a/plugin/evm/atomic/sync/extender.go
+++ b/plugin/evm/atomic/sync/extender.go
@@ -16,26 +16,24 @@ import (
 	"github.com/ava-labs/libevm/log"
 )
 
-var _ sync.Extender = (*extender)(nil)
+var _ sync.Extender = (*Extender)(nil)
 
-type extender struct {
+// Extender is the sync extender for the atomic VM.
+type Extender struct {
 	backend     *state.AtomicBackend
 	trie        *state.AtomicTrie
 	requestSize uint16 // maximum number of leaves to sync in a single request
 }
 
-// Initialize initializes the sync extender with the backend and trie.
-func NewExtender() *extender {
-	return &extender{}
-}
-
-func (a *extender) Initialize(backend *state.AtomicBackend, trie *state.AtomicTrie, requestSize uint16) {
+// Initialize initializes the sync extender with the backend and trie and request size.
+func (a *Extender) Initialize(backend *state.AtomicBackend, trie *state.AtomicTrie, requestSize uint16) {
 	a.backend = backend
 	a.trie = trie
 	a.requestSize = requestSize
 }
 
-func (a *extender) Sync(ctx context.Context, client syncclient.LeafClient, verDB *versiondb.Database, summary message.Syncable) error {
+// Sync syncs the atomic summary with the given client and verDB.
+func (a *Extender) Sync(ctx context.Context, client syncclient.LeafClient, verDB *versiondb.Database, summary message.Syncable) error {
 	atomicSummary, ok := summary.(*Summary)
 	if !ok {
 		return fmt.Errorf("expected *Summary, got %T", summary)
@@ -60,7 +58,8 @@ func (a *extender) Sync(ctx context.Context, client syncclient.LeafClient, verDB
 	return err
 }
 
-func (a *extender) OnFinishBeforeCommit(lastAcceptedHeight uint64, Summary message.Syncable) error {
+// OnFinishBeforeCommit implements the sync.Extender interface by marking the previously last accepted block for the shared memory cursor.
+func (a *Extender) OnFinishBeforeCommit(lastAcceptedHeight uint64, Summary message.Syncable) error {
 	// Mark the previously last accepted block for the shared memory cursor, so that we will execute shared
 	// memory operations from the previously last accepted block when ApplyToSharedMemory
 	// is called.
@@ -71,7 +70,8 @@ func (a *extender) OnFinishBeforeCommit(lastAcceptedHeight uint64, Summary messa
 	return nil
 }
 
-func (a *extender) OnFinishAfterCommit(summaryHeight uint64) error {
+// OnFinishAfterCommit implements the sync.Extender interface by applying the atomic trie to the shared memory.
+func (a *Extender) OnFinishAfterCommit(summaryHeight uint64) error {
 	// the chain state is already restored, and, from this point on,
 	// the block synced to is the accepted block. The last operation
 	// is updating shared memory with the atomic trie.

--- a/plugin/evm/atomic/sync/leaf_handler.go
+++ b/plugin/evm/atomic/sync/leaf_handler.go
@@ -34,7 +34,7 @@ type leafHandler struct {
 	handlers.LeafRequestHandler
 }
 
-// NewAtomicLeafHandler returns a new uninitialzied atomicLeafHandler that can be later initialized
+// NewAtomicLeafHandler returns a new uninitialized leafHandler that can be later initialized
 func NewLeafHandler() *leafHandler {
 	return &leafHandler{
 		LeafRequestHandler: &uninitializedHandler{},

--- a/plugin/evm/atomic/sync/summary_provider.go
+++ b/plugin/evm/atomic/sync/summary_provider.go
@@ -14,22 +14,20 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 )
 
-var _ sync.SummaryProvider = (*summaryProvider)(nil)
+var _ sync.SummaryProvider = (*SummaryProvider)(nil)
 
-type summaryProvider struct {
+// SummaryProvider is the summary provider that provides the state summary for the atomic trie.
+type SummaryProvider struct {
 	trie *state.AtomicTrie
 }
 
-func NewSummaryProvider() *summaryProvider {
-	return &summaryProvider{}
-}
-
-func (a *summaryProvider) Initialize(trie *state.AtomicTrie) {
+// Initialize initializes the summary provider with the atomic trie.
+func (a *SummaryProvider) Initialize(trie *state.AtomicTrie) {
 	a.trie = trie
 }
 
 // StateSummaryAtBlock returns the block state summary at [blk] if valid.
-func (a *summaryProvider) StateSummaryAtBlock(blk *types.Block) (block.StateSummary, error) {
+func (a *SummaryProvider) StateSummaryAtBlock(blk *types.Block) (block.StateSummary, error) {
 	height := blk.NumberU64()
 	atomicRoot, err := a.trie.Root(height)
 	if err != nil {


### PR DESCRIPTION
## Why this should be merged

There were few reviews in https://github.com/ava-labs/coreth/pull/1009 after it was merged. This PR intends to responde those.

## How this works

This pull request refactors the atomic sync components in the EVM plugin to improve clarity and maintainability. Key changes include renaming internal types to exported ones, enhancing comments for better documentation, and updating initialization logic to align with the new architecture.

### Refactoring of sync components:

* [`plugin/evm/atomic/sync/extender.go`](diffhunk://#diff-aebac339a2d897f6e91947de63526b1fee94fbf080a087cc70d0b83ed8336677L19-R36): Renamed `extender` to `Extender` and updated comments to clarify its role as the sync extender for the atomic VM. Updated methods to align with the new exported type. [[1]](diffhunk://#diff-aebac339a2d897f6e91947de63526b1fee94fbf080a087cc70d0b83ed8336677L19-R36) [[2]](diffhunk://#diff-aebac339a2d897f6e91947de63526b1fee94fbf080a087cc70d0b83ed8336677L63-R62) [[3]](diffhunk://#diff-aebac339a2d897f6e91947de63526b1fee94fbf080a087cc70d0b83ed8336677L74-R74)

* [`plugin/evm/atomic/sync/summary_provider.go`](diffhunk://#diff-24b33426e51d56beb1f83e13193dbeeb49c879916a3ab95e4a36a96c9a5f8d32L17-R30): Renamed `summaryProvider` to `SummaryProvider` and updated comments to describe its role in providing state summaries for the atomic trie. Adjusted initialization logic to match the new exported type.

### Updates to VM initialization logic:

* [`plugin/evm/atomic/vm/vm.go`](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L89-R90): Updated initialization of `sync.Extender` and `sync.SummaryProvider` to use exported types. Adjusted initialization of dependent components (`atomicBackend`, `atomicTrie`, and `leafHandler`) to improve clarity and consistency. [[1]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L89-R90) [[2]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L128-R138)

### Minor corrections:

* [`plugin/evm/atomic/sync/leaf_handler.go`](diffhunk://#diff-2107b10115fd4b1352cc0e093b352317360c7a378911bc1fd54b3b6e78d7fe2fL37-R37): Fixed a typo in the comment for `NewLeafHandler` ("uninitialzied" → "uninitialized").

* [`plugin/evm/atomic/vm/vm.go`](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L108-R108): Corrected the method call to set the extension configuration from `vm.SetExtensionConfig` to `vm.InnerVM.SetExtensionConfig` for proper delegation.

## How this was tested

Existing tests

## Need to be documented?

No

## Need to update RELEASES.md?

No
