### PR TITLE
build: Update `libevm` to `v1.13.14-0.3.0.rc.1`

### DIFF
--- a/core/state/snapshot/snapshot.go
+++ b/core/state/snapshot/snapshot.go
@@ -321,7 +321,7 @@ type blockHashes struct {
 }
 
 func WithBlockHashes(blockHash, parentBlockHash common.Hash) stateconf.SnapshotUpdateOption {
-	return stateconf.WithUpdatePayload(blockHashes{blockHash, parentBlockHash})
+	return stateconf.WithSnapshotUpdatePayload(blockHashes{blockHash, parentBlockHash})
 }
 
 // Update adds a new snapshot into the tree, if that can be linked to an existing
@@ -338,7 +338,7 @@ func (t *Tree) Update(
 		return fmt.Errorf("missing block hashes")
 	}
 
-	payload := stateconf.ExtractUpdatePayload(opts[0])
+	payload := stateconf.ExtractSnapshotUpdatePayload(opts[0])
 	p, ok := payload.(blockHashes)
 	if !ok {
 		return fmt.Errorf("invalid block hashes payload type: %T", payload)

--- a/core/state/statedb_multicoin_test.go
+++ b/core/state/statedb_multicoin_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/holiman/uint256"
 	"github.com/stretchr/testify/require"
 )
@@ -71,7 +72,8 @@ func TestMultiCoinSnapshot(t *testing.T) {
 	assertBalances(10, 0, 0)
 
 	// Commit and get the new root
-	root, err = stateDB.Commit(0, false, snapshot.WithBlockHashes(common.Hash{}, common.Hash{}))
+	snapshotOpt := snapshot.WithBlockHashes(common.Hash{}, common.Hash{})
+	root, err = stateDB.Commit(0, false, stateconf.WithSnapshotUpdateOpts(snapshotOpt))
 	require.NoError(t, err, "committing statedb")
 	assertBalances(10, 0, 0)
 
@@ -80,7 +82,8 @@ func TestMultiCoinSnapshot(t *testing.T) {
 	stateDB, err = New(root, sdb, snapTree)
 	require.NoError(t, err, "creating statedb")
 	stateDB.AddBalanceMultiCoin(addr, assetID1, big.NewInt(10))
-	root, err = stateDB.Commit(0, false, snapshot.WithBlockHashes(common.Hash{}, common.Hash{}))
+	snapshotOpt = snapshot.WithBlockHashes(common.Hash{}, common.Hash{})
+	root, err = stateDB.Commit(0, false, stateconf.WithSnapshotUpdateOpts(snapshotOpt))
 	require.NoError(t, err, "committing statedb")
 	assertBalances(10, 10, 0)
 
@@ -90,7 +93,8 @@ func TestMultiCoinSnapshot(t *testing.T) {
 		require.NoErrorf(t, err, "creating statedb %d", i)
 		stateDB.AddBalanceMultiCoin(addr, assetID1, big.NewInt(1))
 		stateDB.AddBalanceMultiCoin(addr, assetID2, big.NewInt(2))
-		root, err = stateDB.Commit(0, false, snapshot.WithBlockHashes(common.Hash{}, common.Hash{}))
+		snapshotOpt = snapshot.WithBlockHashes(common.Hash{}, common.Hash{})
+		root, err = stateDB.Commit(0, false, stateconf.WithSnapshotUpdateOpts(snapshotOpt))
 		require.NoErrorf(t, err, "committing statedb %d", i)
 	}
 	assertBalances(10, 266, 512)
@@ -101,7 +105,8 @@ func TestMultiCoinSnapshot(t *testing.T) {
 	require.NoError(t, err, "creating statedb")
 	stateDB.AddBalance(addr, uint256.NewInt(1))
 	stateDB.AddBalanceMultiCoin(addr, assetID1, big.NewInt(1))
-	root, err = stateDB.Commit(0, false, snapshot.WithBlockHashes(common.Hash{}, common.Hash{}))
+	snapshotOpt = snapshot.WithBlockHashes(common.Hash{}, common.Hash{})
+	root, err = stateDB.Commit(0, false, stateconf.WithSnapshotUpdateOpts(snapshotOpt))
 	require.NoError(t, err, "committing statedb")
 
 	stateDB, err = New(root, sdb, snapTree)

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.9
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.13.2-0.20250611151756-1a40195dc447
-	github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc
+	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/fjl/gencodec v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/ava-labs/avalanchego v1.13.2-0.20250611151756-1a40195dc447 h1:ZMuCKMeb47pQujFVgCJNgbYxqvml7nLC0CHJ4mQPXvY=
 github.com/ava-labs/avalanchego v1.13.2-0.20250611151756-1a40195dc447/go.mod h1:mTa01sHk2kpDh73GP7v06vhJ9+udQ6vw4ffdlX9khUM=
-github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc h1:cSXaUY4hdmoJ2FJOgOzn+WiovN/ZB/zkNRgnZhE50OA=
-github.com/ava-labs/libevm v0.0.0-20250610142802-2672fbd7cdfc/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
+github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1 h1:vBMYo+Iazw0rGTr+cwjkBdh5eadLPlv4ywI4lKye3CA=
+github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1/go.mod h1:+Iol+sVQ1KyoBsHf3veyrBmHCXr3xXRWq6ZXkgVfNLU=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ava-labs/libevm/core/vm"
 	"github.com/ava-labs/libevm/libevm"
 	"github.com/ava-labs/libevm/libevm/legacy"
+	ethparams "github.com/ava-labs/libevm/params"
 )
 
 type RulesExtra extras.Rules
@@ -35,6 +36,11 @@ func (r RulesExtra) CanCreateContract(ac *libevm.AddressContext, gas uint64, sta
 
 func (r RulesExtra) CanExecuteTransaction(_ common.Address, _ *common.Address, _ libevm.StateReader) error {
 	return nil
+}
+
+// MinimumGasConsumption is a no-op.
+func (r RulesExtra) MinimumGasConsumption(x uint64) uint64 {
+	return (ethparams.NOOPHooks{}).MinimumGasConsumption(x)
 }
 
 var PrecompiledContractsApricotPhase2 = map[common.Address]contract.StatefulPrecompiledContract{

--- a/triedb/hashdb/database.go
+++ b/triedb/hashdb/database.go
@@ -39,6 +39,7 @@ import (
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/metrics"
 	"github.com/ava-labs/libevm/rlp"
@@ -650,7 +651,7 @@ func (db *Database) Initialized(genesisRoot common.Hash) bool {
 // account trie with multiple storage tries if necessary.
 // If ReferenceRootAtomicallyOnUpdate was enabled in the config, it will also add a reference from
 // the root to the metaroot while holding the db's lock.
-func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set) error {
+func (db *Database) Update(root common.Hash, parent common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, _ ...stateconf.TrieDBUpdateOption) error {
 	// Ensure the parent state is present and signal a warning if not.
 	if parent != types.EmptyRootHash {
 		if blob, _ := db.node(parent); len(blob) == 0 {

--- a/triedb/pathdb/database.go
+++ b/triedb/pathdb/database.go
@@ -38,6 +38,7 @@ import (
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/trie/trienode"
 	"github.com/ava-labs/libevm/trie/triestate"
@@ -242,7 +243,7 @@ func (db *Database) Reader(root common.Hash) (database.Reader, error) {
 //
 // The passed in maps(nodes, states) will be retained to avoid copying everything.
 // Therefore, these maps must not be changed afterwards.
-func (db *Database) Update(root common.Hash, parentRoot common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set) error {
+func (db *Database) Update(root common.Hash, parentRoot common.Hash, block uint64, nodes *trienode.MergedNodeSet, states *triestate.Set, _ ...stateconf.TrieDBUpdateOption) error {
 	// Hold the lock to prevent concurrent mutations.
 	db.lock.Lock()
 	defer db.lock.Unlock()


### PR DESCRIPTION
## Why this should be merged

Uses the most recent `libevm` update.

## How this works

There were two additional changes required to update hooks and options correctly.

## How this was tested

Unit tests

## Need to be documented?

No

## Need to update RELEASES.md?

No
