### PR TITLE
move mempool and gossip handlers to atomic vm

### DIFF
--- a/plugin/evm/api.go
+++ b/plugin/evm/api.go
@@ -182,10 +182,10 @@ func (service *AvaxAPI) IssueTx(r *http.Request, args *api.FormattedTx, response
 	service.vm.ctx.Lock.Lock()
 	defer service.vm.ctx.Lock.Unlock()
 
-	if err := service.vm.mempool.AddLocalTx(tx); err != nil {
+	if err := service.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
 		return err
 	}
-	service.vm.atomicTxPushGossiper.Add(tx)
+	service.vm.atomicVM.AtomicTxPushGossiper.Add(tx)
 	return nil
 }
 

--- a/plugin/evm/api.go
+++ b/plugin/evm/api.go
@@ -182,7 +182,7 @@ func (service *AvaxAPI) IssueTx(r *http.Request, args *api.FormattedTx, response
 	service.vm.ctx.Lock.Lock()
 	defer service.vm.ctx.Lock.Unlock()
 
-	if err := service.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
+	if err := service.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err != nil {
 		return err
 	}
 	service.vm.atomicVM.AtomicTxPushGossiper.Add(tx)

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -137,7 +137,7 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
 	mempool := &Mempool{}
-	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
+	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 1, nil))
 	// create candidate tx (we will drop before validation)
 	tx := atomictest.GenerateTestImportTx()
 
@@ -161,7 +161,7 @@ func TestMempoolPriorityDrop(t *testing.T) {
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
 	mempool := &Mempool{}
-	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
+	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 1, nil))
 
 	tx1 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
 	require.NoError(mempool.AddRemoteTx(tx1))

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -16,9 +16,9 @@ import (
 
 func TestMempoolAddTx(t *testing.T) {
 	require := require.New(t)
+	m := &Mempool{}
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	m, err := NewMempool(ctx, prometheus.NewRegistry(), 5_000, nil)
-	require.NoError(err)
+	require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
 
 	txs := make([]*atomic.Tx, 0)
 	for i := 0; i < 3_000; i++ {
@@ -40,9 +40,9 @@ func TestMempoolAddTx(t *testing.T) {
 // Add should return an error if a tx is already known
 func TestMempoolAdd(t *testing.T) {
 	require := require.New(t)
+	m := &Mempool{}
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	m, err := NewMempool(ctx, prometheus.NewRegistry(), 5_000, nil)
-	require.NoError(err)
+	require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
 
 	tx := &atomic.Tx{
 		UnsignedAtomicTx: &atomictest.TestUnsignedTx{
@@ -51,7 +51,7 @@ func TestMempoolAdd(t *testing.T) {
 	}
 
 	require.NoError(m.Add(tx))
-	err = m.Add(tx)
+	err := m.Add(tx)
 	require.ErrorIs(err, errTxAlreadyKnown)
 }
 
@@ -105,8 +105,8 @@ func TestAtomicMempoolIterate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
 			ctx := snowtest.Context(t, snowtest.CChainID)
-			m, err := NewMempool(ctx, prometheus.NewRegistry(), 10, nil)
-			require.NoError(err)
+			m := &Mempool{}
+			require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 10, nil))
 
 			for _, add := range tt.add {
 				require.NoError(m.Add(add))
@@ -136,8 +136,8 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 	require := require.New(t)
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	mempool, err := NewMempool(ctx, prometheus.NewRegistry(), 1, nil)
-	require.NoError(err)
+	mempool := &Mempool{}
+	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
 	// create candidate tx (we will drop before validation)
 	tx := atomictest.GenerateTestImportTx()
 
@@ -150,7 +150,7 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 
 	// try to add one more tx
 	tx2 := atomictest.GenerateTestImportTx()
-	err = mempool.AddRemoteTx(tx2)
+	err := mempool.AddRemoteTx(tx2)
 	require.ErrorIs(err, ErrTooManyAtomicTx)
 	require.False(mempool.Has(tx2.ID()))
 }
@@ -160,15 +160,15 @@ func TestMempoolPriorityDrop(t *testing.T) {
 	require := require.New(t)
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	mempool, err := NewMempool(ctx, prometheus.NewRegistry(), 1, nil)
-	require.NoError(err)
+	mempool := &Mempool{}
+	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
 
 	tx1 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
 	require.NoError(mempool.AddRemoteTx(tx1))
 	require.True(mempool.Has(tx1.ID()))
 
 	tx2 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
-	err = mempool.AddRemoteTx(tx2)
+	err := mempool.AddRemoteTx(tx2)
 	require.ErrorIs(err, ErrInsufficientAtomicTxFee)
 	require.True(mempool.Has(tx1.ID()))
 	require.False(mempool.Has(tx2.ID()))

--- a/plugin/evm/atomic/vm/block_extension.go
+++ b/plugin/evm/atomic/vm/block_extension.go
@@ -171,7 +171,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 // block manager's SemanticVerify method.
 func (be *blockExtension) SemanticVerify() error {
 	vm := be.blockExtender.vm
-	if vm.IsBootstrapped() {
+	if vm.InnerVM.IsBootstrapped() {
 		// Verify that the UTXOs named in import txs are present in shared
 		// memory.
 		//

--- a/plugin/evm/atomic/vm/block_extension.go
+++ b/plugin/evm/atomic/vm/block_extension.go
@@ -171,7 +171,7 @@ func (be *blockExtension) SyntacticVerify(rules extras.Rules) error {
 // block manager's SemanticVerify method.
 func (be *blockExtension) SemanticVerify() error {
 	vm := be.blockExtender.vm
-	if vm.InnerVM.IsBootstrapped() {
+	if vm.bootstrapped.Get() {
 		// Verify that the UTXOs named in import txs are present in shared
 		// memory.
 		//
@@ -194,7 +194,7 @@ func (be *blockExtension) Accept(acceptedBatch database.Batch) error {
 	vm := be.blockExtender.vm
 	for _, tx := range be.atomicTxs {
 		// Remove the accepted transaction from the mempool
-		vm.Mempool.RemoveTx(tx)
+		vm.AtomicMempool.RemoveTx(tx)
 	}
 
 	// Update VM state for atomic txs in this block. This includes updating the
@@ -214,8 +214,8 @@ func (be *blockExtension) Reject() error {
 	vm := be.blockExtender.vm
 	for _, tx := range be.atomicTxs {
 		// Re-issue the transaction in the mempool, continue even if it fails
-		vm.Mempool.RemoveTx(tx)
-		if err := vm.Mempool.AddRemoteTx(tx); err != nil {
+		vm.AtomicMempool.RemoveTx(tx)
+		if err := vm.AtomicMempool.AddRemoteTx(tx); err != nil {
 			log.Debug("Failed to re-issue transaction in rejected block", "txID", tx.ID(), "err", err)
 		}
 	}

--- a/plugin/evm/atomic/vm/block_extension.go
+++ b/plugin/evm/atomic/vm/block_extension.go
@@ -194,7 +194,7 @@ func (be *blockExtension) Accept(acceptedBatch database.Batch) error {
 	vm := be.blockExtender.vm
 	for _, tx := range be.atomicTxs {
 		// Remove the accepted transaction from the mempool
-		vm.AtomicMempool().RemoveTx(tx)
+		vm.Mempool.RemoveTx(tx)
 	}
 
 	// Update VM state for atomic txs in this block. This includes updating the
@@ -214,8 +214,8 @@ func (be *blockExtension) Reject() error {
 	vm := be.blockExtender.vm
 	for _, tx := range be.atomicTxs {
 		// Re-issue the transaction in the mempool, continue even if it fails
-		vm.AtomicMempool().RemoveTx(tx)
-		if err := vm.AtomicMempool().AddRemoteTx(tx); err != nil {
+		vm.Mempool.RemoveTx(tx)
+		if err := vm.Mempool.AddRemoteTx(tx); err != nil {
 			log.Debug("Failed to re-issue transaction in rejected block", "txID", tx.ID(), "err", err)
 		}
 	}

--- a/plugin/evm/atomic/vm/vm.go
+++ b/plugin/evm/atomic/vm/vm.go
@@ -257,6 +257,8 @@ func (vm *VM) onBootstrapStarted() error {
 }
 
 func (vm *VM) onNormalOperationsStarted() error {
+	// TODO: consider removing this once atomic VM fully wraps inner VM
+	// as we can capture the bootstrapped state here
 	if vm.InnerVM.IsBootstrapped() {
 		return nil
 	}

--- a/plugin/evm/atomic/vm/vm.go
+++ b/plugin/evm/atomic/vm/vm.go
@@ -5,14 +5,19 @@ package vm
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
+	"sync"
 
 	"github.com/ava-labs/avalanchego/codec"
 	"github.com/ava-labs/avalanchego/codec/linearcodec"
 	avalanchedatabase "github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	avalanchegossip "github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
+	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	avalanchecommon "github.com/ava-labs/avalanchego/snow/engine/common"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
 	"github.com/ava-labs/avalanchego/utils/constants"
@@ -29,12 +34,16 @@ import (
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	atomicstate "github.com/ava-labs/coreth/plugin/evm/atomic/state"
-	"github.com/ava-labs/coreth/plugin/evm/atomic/sync"
+	atomicsync "github.com/ava-labs/coreth/plugin/evm/atomic/sync"
 	"github.com/ava-labs/coreth/plugin/evm/atomic/txpool"
+	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/coreth/plugin/evm/customtypes"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
+	"github.com/ava-labs/coreth/plugin/evm/gossip"
 	customheader "github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/plugin/evm/message"
+	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap5"
+	"github.com/ava-labs/coreth/plugin/evm/vmerrors"
 	"github.com/ava-labs/coreth/utils"
 
 	"github.com/ava-labs/libevm/common"
@@ -49,9 +58,16 @@ var (
 	_ block.StateSyncableVM              = (*VM)(nil)
 )
 
-var (
+const (
 	secpCacheSize       = 1024
+	defaultMempoolSize  = 4096
 	targetAtomicTxsSize = 40 * units.KiB
+	// maxAtomicTxMempoolGas is the maximum amount of gas that is allowed to be
+	// used by an atomic transaction in the mempool. It is allowed to build
+	// blocks with larger atomic transactions, but they will not be accepted
+	// into the mempool.
+	maxAtomicTxMempoolGas   = ap5.AtomicGasLimit
+	atomicTxGossipNamespace = "atomic_tx_gossip"
 )
 
 // TODO: remove this
@@ -63,9 +79,6 @@ type InnerVM interface {
 	block.ChainVM
 	block.BuildBlockWithContextChainVM
 	block.StateSyncableVM
-
-	// TODO: remove these
-	AtomicMempool() *txpool.Mempool
 }
 
 type VM struct {
@@ -76,6 +89,7 @@ type VM struct {
 	SecpCache *secp256k1.RecoverCache
 	Fx        secp256k1fx.Fx
 	baseCodec codec.Registry
+	Mempool   *txpool.Mempool
 
 	// [atomicTxRepository] maintains two indexes on accepted atomic txs.
 	// - txID to accepted atomic tx
@@ -84,6 +98,14 @@ type VM struct {
 	AtomicTxRepository *atomicstate.AtomicRepository
 	// [atomicBackend] abstracts verification and processing of atomic transactions
 	AtomicBackend *atomicstate.AtomicBackend
+
+	atomicTxGossipHandler p2p.Handler
+	AtomicTxPushGossiper  *avalanchegossip.PushGossiper[*atomic.Tx]
+	AtomicTxPullGossiper  avalanchegossip.Gossiper
+
+	// [cancel] may be nil until [snow.NormalOp] starts
+	cancel     context.CancelFunc
+	shutdownWg sync.WaitGroup
 
 	clock mockable.Clock
 }
@@ -121,24 +143,26 @@ func (vm *VM) Initialize(
 	// Create the atomic extension structs
 	// some of them need to be initialized after the inner VM is initialized
 	blockExtender := newBlockExtender(extDataHashes, vm)
-	syncExtender := &sync.Extender{}
-	syncProvider := &sync.SummaryProvider{}
+	syncExtender := &atomicsync.Extender{}
+	syncProvider := &atomicsync.SummaryProvider{}
 	// Create and pass the leaf handler to the atomic extension
 	// it will be initialized after the inner VM is initialized
-	leafHandler := sync.NewLeafHandler()
+	leafHandler := atomicsync.NewLeafHandler()
 	atomicLeafTypeConfig := &extension.LeafRequestConfig{
-		LeafType:   sync.TrieNode,
+		LeafType:   atomicsync.TrieNode,
 		MetricName: "sync_atomic_trie_leaves",
 		Handler:    leafHandler,
 	}
+	vm.Mempool = &txpool.Mempool{}
 
 	extensionConfig := &extension.Config{
 		ConsensusCallbacks:         vm.createConsensusCallbacks(),
 		BlockExtender:              blockExtender,
-		SyncableParser:             sync.NewSummaryParser(),
+		SyncableParser:             atomicsync.NewSummaryParser(),
 		SyncExtender:               syncExtender,
 		SyncSummaryProvider:        syncProvider,
 		ExtraSyncLeafHandlerConfig: atomicLeafTypeConfig,
+		ExtraMempool:               vm.Mempool,
 		Clock:                      &vm.clock,
 	}
 	if err := vm.InnerVM.SetExtensionConfig(extensionConfig); err != nil {
@@ -158,6 +182,12 @@ func (vm *VM) Initialize(
 		appSender,
 	); err != nil {
 		return fmt.Errorf("failed to initialize inner VM: %w", err)
+	}
+
+	// Now we can initialize the mempool and so
+	err := vm.Mempool.Initialize(chainCtx, vm.MetricRegistry(), defaultMempoolSize, vm.verifyTxAtTip)
+	if err != nil {
+		return fmt.Errorf("failed to initialize mempool: %w", err)
 	}
 
 	// initialize bonus blocks on mainnet
@@ -230,16 +260,149 @@ func (vm *VM) onNormalOperationsStarted() error {
 	if vm.IsBootstrapped() {
 		return nil
 	}
-	return vm.Fx.Bootstrapped()
+	if err := vm.Fx.Bootstrapped(); err != nil {
+		return err
+	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	vm.cancel = cancel
+	atomicTxGossipMarshaller := atomic.TxMarshaller{}
+	atomicTxGossipClient := vm.NewClient(p2p.AtomicTxGossipHandlerID, p2p.WithValidatorSampling(vm.P2PValidators()))
+	atomicTxGossipMetrics, err := avalanchegossip.NewMetrics(vm.MetricRegistry(), atomicTxGossipNamespace)
+	if err != nil {
+		return fmt.Errorf("failed to initialize atomic tx gossip metrics: %w", err)
+	}
+
+	pushGossipParams := avalanchegossip.BranchingFactor{
+		StakePercentage: vm.Config().PushGossipPercentStake,
+		Validators:      vm.Config().PushGossipNumValidators,
+		Peers:           vm.Config().PushGossipNumPeers,
+	}
+	pushRegossipParams := avalanchegossip.BranchingFactor{
+		Validators: vm.Config().PushRegossipNumValidators,
+		Peers:      vm.Config().PushRegossipNumPeers,
+	}
+
+	vm.AtomicTxPushGossiper, err = avalanchegossip.NewPushGossiper[*atomic.Tx](
+		&atomicTxGossipMarshaller,
+		vm.Mempool,
+		vm.P2PValidators(),
+		atomicTxGossipClient,
+		atomicTxGossipMetrics,
+		pushGossipParams,
+		pushRegossipParams,
+		config.PushGossipDiscardedElements,
+		config.TxGossipTargetMessageSize,
+		vm.Config().RegossipFrequency.Duration,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize atomic tx push gossiper: %w", err)
+	}
+
+	vm.atomicTxGossipHandler = gossip.NewTxGossipHandler[*atomic.Tx](
+		vm.ctx.Log,
+		&atomicTxGossipMarshaller,
+		vm.Mempool,
+		atomicTxGossipMetrics,
+		config.TxGossipTargetMessageSize,
+		config.TxGossipThrottlingPeriod,
+		config.TxGossipThrottlingLimit,
+		vm.P2PValidators(),
+	)
+
+	if err := vm.AddHandler(p2p.AtomicTxGossipHandlerID, vm.atomicTxGossipHandler); err != nil {
+		return fmt.Errorf("failed to add atomic tx gossip handler: %w", err)
+	}
+
+	atomicTxPullGossiper := avalanchegossip.NewPullGossiper[*atomic.Tx](
+		vm.ctx.Log,
+		&atomicTxGossipMarshaller,
+		vm.Mempool,
+		atomicTxGossipClient,
+		atomicTxGossipMetrics,
+		config.TxGossipPollSize,
+	)
+
+	vm.AtomicTxPullGossiper = &avalanchegossip.ValidatorGossiper{
+		Gossiper:   atomicTxPullGossiper,
+		NodeID:     vm.ctx.NodeID,
+		Validators: vm.P2PValidators(),
+	}
+
+	vm.shutdownWg.Add(1)
+	go func() {
+		avalanchegossip.Every(ctx, vm.ctx.Log, vm.AtomicTxPushGossiper, vm.Config().PushGossipFrequency.Duration)
+		vm.shutdownWg.Done()
+	}()
+
+	vm.shutdownWg.Add(1)
+	go func() {
+		avalanchegossip.Every(ctx, vm.ctx.Log, vm.AtomicTxPullGossiper, vm.Config().PullGossipFrequency.Duration)
+		vm.shutdownWg.Done()
+	}()
+
+	return nil
 }
 
-// VerifyTx verifies that [tx] is valid to be issued into a block with parent block [parentHash]
+func (vm *VM) Shutdown(context.Context) error {
+	if vm.ctx == nil {
+		return nil
+	}
+	if vm.cancel != nil {
+		vm.cancel()
+	}
+	if err := vm.InnerVM.Shutdown(context.Background()); err != nil {
+		log.Error("failed to shutdown inner VM", "err", err)
+	}
+	vm.shutdownWg.Wait()
+	return nil
+}
+
+// verifyTxAtTip verifies that [tx] is valid to be issued on top of the currently preferred block
+func (vm *VM) verifyTxAtTip(tx *atomic.Tx) error {
+	if txByteLen := len(tx.SignedBytes()); txByteLen > targetAtomicTxsSize {
+		return fmt.Errorf("tx size (%d) exceeds total atomic txs size target (%d)", txByteLen, targetAtomicTxsSize)
+	}
+	gasUsed, err := tx.GasUsed(true)
+	if err != nil {
+		return err
+	}
+	if gasUsed > maxAtomicTxMempoolGas {
+		return fmt.Errorf("tx gas usage (%d) exceeds maximum allowed mempool gas usage (%d)", gasUsed, maxAtomicTxMempoolGas)
+	}
+	blockchain := vm.Ethereum().BlockChain()
+	// Note: we fetch the current block and then the state at that block instead of the current state directly
+	// since we need the header of the current block below.
+	preferredBlock := blockchain.CurrentBlock()
+	preferredState, err := blockchain.StateAt(preferredBlock.Root)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve block state at tip while verifying atomic tx: %w", err)
+	}
+	extraConfig := params.GetExtra(blockchain.Config())
+	extraRules := params.GetRulesExtra(blockchain.Config().Rules(preferredBlock.Number, params.IsMergeTODO, preferredBlock.Time))
+	parentHeader := preferredBlock
+	var nextBaseFee *big.Int
+	timestamp := uint64(vm.clock.Time().Unix())
+	if extraConfig.IsApricotPhase3(timestamp) {
+		nextBaseFee, err = customheader.EstimateNextBaseFee(extraConfig, parentHeader, timestamp)
+		if err != nil {
+			// Return extremely detailed error since CalcBaseFee should never encounter an issue here
+			return fmt.Errorf("failed to calculate base fee with parent timestamp (%d), parent ExtraData: (0x%x), and current timestamp (%d): %w", parentHeader.Time, parentHeader.Extra, timestamp, err)
+		}
+	}
+
+	// We don’t need to revert the state here in case verifyTx errors, because
+	// [preferredState] is thrown away either way.
+	return vm.verifyTx(tx, parentHeader.Hash(), nextBaseFee, preferredState, *extraRules)
+}
+
+// verifyTx verifies that [tx] is valid to be issued into a block with parent block [parentHash]
 // and validated at [state] using [rules] as the current rule set.
 // Note: VerifyTx may modify [state]. If [state] needs to be properly maintained, the caller is responsible
 // for reverting to the correct snapshot after calling this function. If this function is called with a
 // throwaway state, then this is not necessary.
 // TODO: unexport this function
-func (vm *VM) VerifyTx(tx *atomic.Tx, parentHash common.Hash, baseFee *big.Int, state *state.StateDB, rules extras.Rules) error {
+func (vm *VM) verifyTx(tx *atomic.Tx, parentHash common.Hash, baseFee *big.Int, state *state.StateDB, rules extras.Rules) error {
 	parent, err := vm.InnerVM.GetExtendedBlock(context.TODO(), ids.ID(parentHash))
 	if err != nil {
 		return fmt.Errorf("failed to get parent block: %w", err)
@@ -330,7 +493,7 @@ func (vm *VM) createConsensusCallbacks() dummy.ConsensusCallbacks {
 
 func (vm *VM) preBatchOnFinalizeAndAssemble(header *types.Header, state *state.StateDB, txs []*types.Transaction) ([]byte, *big.Int, *big.Int, error) {
 	for {
-		tx, exists := vm.AtomicMempool().NextTx()
+		tx, exists := vm.Mempool.NextTx()
 		if !exists {
 			break
 		}
@@ -340,10 +503,10 @@ func (vm *VM) preBatchOnFinalizeAndAssemble(header *types.Header, state *state.S
 		// once.
 		snapshot := state.Snapshot()
 		rules := vm.rules(header.Number, header.Time)
-		if err := vm.VerifyTx(tx, header.ParentHash, header.BaseFee, state, rules); err != nil {
+		if err := vm.verifyTx(tx, header.ParentHash, header.BaseFee, state, rules); err != nil {
 			// Discard the transaction from the mempool on failed verification.
 			log.Debug("discarding tx from mempool on failed verification", "txID", tx.ID(), "err", err)
-			vm.AtomicMempool().DiscardCurrentTx(tx.ID())
+			vm.Mempool.DiscardCurrentTx(tx.ID())
 			state.RevertToSnapshot(snapshot)
 			continue
 		}
@@ -353,7 +516,7 @@ func (vm *VM) preBatchOnFinalizeAndAssemble(header *types.Header, state *state.S
 			// Discard the transaction from the mempool and error if the transaction
 			// cannot be marshalled. This should never happen.
 			log.Debug("discarding tx due to unmarshal err", "txID", tx.ID(), "err", err)
-			vm.AtomicMempool().DiscardCurrentTx(tx.ID())
+			vm.Mempool.DiscardCurrentTx(tx.ID())
 			return nil, nil, nil, fmt.Errorf("failed to marshal atomic transaction %s due to %w", tx.ID(), err)
 		}
 		var contribution, gasUsed *big.Int
@@ -396,7 +559,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(
 	}
 
 	for {
-		tx, exists := vm.AtomicMempool().NextTx()
+		tx, exists := vm.Mempool.NextTx()
 		if !exists {
 			break
 		}
@@ -404,7 +567,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(
 		// Ensure that adding [tx] to the block will not exceed the block size soft limit.
 		txSize := len(tx.SignedBytes())
 		if size+txSize > targetAtomicTxsSize {
-			vm.AtomicMempool().CancelCurrentTx(tx.ID())
+			vm.Mempool.CancelCurrentTx(tx.ID())
 			break
 		}
 
@@ -423,7 +586,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(
 		// ensure `gasUsed + batchGasUsed` doesn't exceed `atomicGasLimit`
 		if totalGasUsed := new(big.Int).Add(batchGasUsed, txGasUsed); !utils.BigLessOrEqualUint64(totalGasUsed, atomicGasLimit) {
 			// Send [tx] back to the mempool's tx heap.
-			vm.AtomicMempool().CancelCurrentTx(tx.ID())
+			vm.Mempool.CancelCurrentTx(tx.ID())
 			break
 		}
 
@@ -435,18 +598,18 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(
 			// block will most likely be accepted.
 			// Discard the transaction from the mempool on failed verification.
 			log.Debug("discarding tx due to overlapping input utxos", "txID", tx.ID())
-			vm.AtomicMempool().DiscardCurrentTx(tx.ID())
+			vm.Mempool.DiscardCurrentTx(tx.ID())
 			continue
 		}
 
 		snapshot := state.Snapshot()
-		if err := vm.VerifyTx(tx, header.ParentHash, header.BaseFee, state, rules); err != nil {
+		if err := vm.verifyTx(tx, header.ParentHash, header.BaseFee, state, rules); err != nil {
 			// Discard the transaction from the mempool and reset the state to [snapshot]
 			// if it fails verification here.
 			// Note: prior to this point, we have not modified [state] so there is no need to
 			// revert to a snapshot if we discard the transaction prior to this point.
 			log.Debug("discarding tx from mempool due to failed verification", "txID", tx.ID(), "err", err)
-			vm.AtomicMempool().DiscardCurrentTx(tx.ID())
+			vm.Mempool.DiscardCurrentTx(tx.ID())
 			state.RevertToSnapshot(snapshot)
 			continue
 		}
@@ -467,7 +630,7 @@ func (vm *VM) postBatchOnFinalizeAndAssemble(
 			// If we fail to marshal the batch of atomic transactions for any reason,
 			// discard the entire set of current transactions.
 			log.Debug("discarding txs due to error marshaling atomic transactions", "err", err)
-			vm.AtomicMempool().DiscardCurrentTxs()
+			vm.Mempool.DiscardCurrentTxs()
 			return nil, nil, nil, fmt.Errorf("failed to marshal batch of atomic transactions due to %w", err)
 		}
 		return atomicTxBytes, batchContribution, batchGasUsed, nil
@@ -568,6 +731,29 @@ func (vm *VM) onExtraStateChange(block *types.Block, parent *types.Header, state
 		}
 	}
 	return batchContribution, batchGasUsed, nil
+}
+
+func (vm *VM) BuildBlock(ctx context.Context) (snowman.Block, error) {
+	return vm.BuildBlockWithContext(ctx, nil)
+}
+
+func (vm *VM) BuildBlockWithContext(ctx context.Context, proposerVMBlockCtx *block.Context) (snowman.Block, error) {
+	blk, err := vm.InnerVM.BuildBlockWithContext(ctx, proposerVMBlockCtx)
+
+	// Handle errors and signal the mempool to take appropriate action
+	switch {
+	case err == nil:
+		// Marks the current transactions from the mempool as being successfully issued
+		// into a block.
+		vm.Mempool.IssueCurrentTxs()
+	case errors.Is(err, vmerrors.ErrGenerateBlockFailed), errors.Is(err, vmerrors.ErrBlockVerificationFailed):
+		log.Debug("cancelling txs due to error generating block", "err", err)
+		vm.Mempool.CancelCurrentTxs()
+	case errors.Is(err, vmerrors.ErrWrapBlockFailed):
+		log.Debug("discarding txs due to error making new block", "err", err)
+		vm.Mempool.DiscardCurrentTxs()
+	}
+	return blk, err
 }
 
 func (vm *VM) chainConfigExtra() *extras.ChainConfig {

--- a/plugin/evm/config/constants.go
+++ b/plugin/evm/config/constants.go
@@ -3,9 +3,20 @@
 
 package config
 
+import (
+	"time"
+
+	"github.com/ava-labs/avalanchego/utils/units"
+)
+
 const (
 	TxGossipBloomMinTargetElements       = 8 * 1024
 	TxGossipBloomTargetFalsePositiveRate = 0.01
 	TxGossipBloomResetFalsePositiveRate  = 0.05
 	TxGossipBloomChurnMultiplier         = 3
+	PushGossipDiscardedElements          = 16_384
+	TxGossipTargetMessageSize            = 20 * units.KiB
+	TxGossipThrottlingPeriod             = 10 * time.Second
+	TxGossipThrottlingLimit              = 2
+	TxGossipPollSize                     = 1
 )

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -66,7 +66,7 @@ func createExportTxOptions(t *testing.T, vm *VM, issuer chan engCommon.Message, 
 		t.Fatal(err)
 	}
 
-	if err := vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -385,7 +385,7 @@ func TestExportTxEVMStateTransfer(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.mempool.AddLocalTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1746,7 +1746,7 @@ func TestNewExportTx(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.mempool.AddLocalTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1945,7 +1945,7 @@ func TestNewExportTxMulticoin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.mempool.AddRemoteTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.Mempool.AddRemoteTx(tx); err != nil {
 				t.Fatal(err)
 			}
 

--- a/plugin/evm/export_tx_test.go
+++ b/plugin/evm/export_tx_test.go
@@ -66,7 +66,7 @@ func createExportTxOptions(t *testing.T, vm *VM, issuer chan engCommon.Message, 
 		t.Fatal(err)
 	}
 
-	if err := vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -385,7 +385,7 @@ func TestExportTxEVMStateTransfer(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1746,7 +1746,7 @@ func TestNewExportTx(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1945,7 +1945,7 @@ func TestNewExportTxMulticoin(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.atomicVM.Mempool.AddRemoteTx(tx); err != nil {
+			if err := tvm.vm.atomicVM.AtomicMempool.AddRemoteTx(tx); err != nil {
 				t.Fatal(err)
 			}
 

--- a/plugin/evm/extension/config.go
+++ b/plugin/evm/extension/config.go
@@ -19,7 +19,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
-	"github.com/ava-labs/coreth/eth"
+	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/ava-labs/coreth/plugin/evm/config"
@@ -41,13 +41,10 @@ type ExtensibleVM interface {
 	// SetExtensionConfig sets the configuration for the VM extension
 	// Should be called before any other method and only once
 	SetExtensionConfig(config *Config) error
-
 	// NewClient returns a client to send messages with for the given protocol
 	NewClient(protocol uint64, options ...p2p.ClientOption) *p2p.Client
 	// AddHandler registers a server handler for an application protocol
 	AddHandler(protocol uint64, handler p2p.Handler) error
-	// SetLastAcceptedBlock sets the last accepted block
-	SetLastAcceptedBlock(lastAcceptedBlock snowman.Block) error
 	// GetExtendedBlock returns the VMBlock for the given ID or an error if the block is not found
 	GetExtendedBlock(context.Context, ids.ID) (ExtendedBlock, error)
 	// LastAcceptedExtendedBlock returns the last accepted VM block
@@ -58,8 +55,8 @@ type ExtensibleVM interface {
 	ChainConfig() *params.ChainConfig
 	// P2PValidators returns the validators for the network
 	P2PValidators() *p2p.Validators
-	// Ethereum returns the Ethereum client
-	Ethereum() *eth.Ethereum
+	// Blockchain returns the blockchain client
+	Blockchain() *core.BlockChain
 	// Config returns the configuration for the VM
 	Config() config.Config
 	// MetricRegistry returns the metric registry for the VM

--- a/plugin/evm/extension/config.go
+++ b/plugin/evm/extension/config.go
@@ -49,8 +49,6 @@ type ExtensibleVM interface {
 	GetExtendedBlock(context.Context, ids.ID) (ExtendedBlock, error)
 	// LastAcceptedExtendedBlock returns the last accepted VM block
 	LastAcceptedExtendedBlock() ExtendedBlock
-	// IsBootstrapped returns true if the VM is bootstrapped
-	IsBootstrapped() bool
 	// ChainConfig returns the chain config for the VM
 	ChainConfig() *params.ChainConfig
 	// P2PValidators returns the validators for the network

--- a/plugin/evm/gossip/handler.go
+++ b/plugin/evm/gossip/handler.go
@@ -1,0 +1,67 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package gossip
+
+import (
+	"context"
+	"time"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
+	"github.com/ava-labs/avalanchego/network/p2p/gossip"
+	"github.com/ava-labs/avalanchego/snow/engine/common"
+	"github.com/ava-labs/avalanchego/utils/logging"
+)
+
+var _ p2p.Handler = (*txGossipHandler)(nil)
+
+func NewTxGossipHandler[T gossip.Gossipable](
+	log logging.Logger,
+	marshaller gossip.Marshaller[T],
+	mempool gossip.Set[T],
+	metrics gossip.Metrics,
+	maxMessageSize int,
+	throttlingPeriod time.Duration,
+	throttlingLimit int,
+	validators p2p.ValidatorSet,
+) *txGossipHandler {
+	// push gossip messages can be handled from any peer
+	handler := gossip.NewHandler(
+		log,
+		marshaller,
+		mempool,
+		metrics,
+		maxMessageSize,
+	)
+
+	// pull gossip requests are filtered by validators and are throttled
+	// to prevent spamming
+	validatorHandler := p2p.NewValidatorHandler(
+		p2p.NewThrottlerHandler(
+			handler,
+			p2p.NewSlidingWindowThrottler(throttlingPeriod, throttlingLimit),
+			log,
+		),
+		validators,
+		log,
+	)
+
+	return &txGossipHandler{
+		appGossipHandler:  handler,
+		appRequestHandler: validatorHandler,
+	}
+}
+
+type txGossipHandler struct {
+	appGossipHandler  p2p.Handler
+	appRequestHandler p2p.Handler
+}
+
+func (t *txGossipHandler) AppGossip(ctx context.Context, nodeID ids.NodeID, gossipBytes []byte) {
+	t.appGossipHandler.AppGossip(ctx, nodeID, gossipBytes)
+}
+
+func (t *txGossipHandler) AppRequest(ctx context.Context, nodeID ids.NodeID, deadline time.Time, requestBytes []byte) ([]byte, *common.AppError) {
+	return t.appRequestHandler.AppRequest(ctx, nodeID, deadline, requestBytes)
+}

--- a/plugin/evm/gossiper_atomic_gossiping_test.go
+++ b/plugin/evm/gossiper_atomic_gossiping_test.go
@@ -75,7 +75,7 @@ func TestMempoolAtmTxsAppGossipHandling(t *testing.T) {
 	txGossipedLock.Lock()
 	assert.Equal(0, txGossiped, "tx should not have been gossiped")
 	txGossipedLock.Unlock()
-	assert.True(tvm.vm.atomicVM.Mempool.Has(tx.ID()))
+	assert.True(tvm.vm.atomicVM.AtomicMempool.Has(tx.ID()))
 
 	tvm.vm.ctx.Lock.Unlock()
 
@@ -105,7 +105,7 @@ func TestMempoolAtmTxsAppGossipHandling(t *testing.T) {
 	txGossipedLock.Lock()
 	assert.Equal(0, txGossiped, "tx should not have been gossiped")
 	txGossipedLock.Unlock()
-	assert.False(tvm.vm.atomicVM.Mempool.Has(conflictingTx.ID()), "conflicting tx should not be in the atomic mempool")
+	assert.False(tvm.vm.atomicVM.AtomicMempool.Has(conflictingTx.ID()), "conflicting tx should not be in the atomic mempool")
 }
 
 // show that txs already marked as invalid are not re-requested on gossiping
@@ -116,7 +116,7 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	defer func() {
 		assert.NoError(tvm.vm.Shutdown(context.Background()))
 	}()
-	mempool := tvm.vm.atomicVM.Mempool
+	mempool := tvm.vm.atomicVM.AtomicMempool
 
 	var (
 		txGossiped     int
@@ -175,7 +175,7 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	// Conflicting tx must be submitted over the API to be included in push gossip.
 	// (i.e., txs received via p2p are not included in push gossip)
 	// This test adds it directly to the mempool + gossiper to simulate that.
-	tvm.vm.atomicVM.Mempool.AddRemoteTx(conflictingTx)
+	tvm.vm.atomicVM.AtomicMempool.AddRemoteTx(conflictingTx)
 	tvm.vm.atomicVM.AtomicTxPushGossiper.Add(conflictingTx)
 	time.Sleep(500 * time.Millisecond)
 

--- a/plugin/evm/gossiper_atomic_gossiping_test.go
+++ b/plugin/evm/gossiper_atomic_gossiping_test.go
@@ -75,7 +75,7 @@ func TestMempoolAtmTxsAppGossipHandling(t *testing.T) {
 	txGossipedLock.Lock()
 	assert.Equal(0, txGossiped, "tx should not have been gossiped")
 	txGossipedLock.Unlock()
-	assert.True(tvm.vm.mempool.Has(tx.ID()))
+	assert.True(tvm.vm.atomicVM.Mempool.Has(tx.ID()))
 
 	tvm.vm.ctx.Lock.Unlock()
 
@@ -105,7 +105,7 @@ func TestMempoolAtmTxsAppGossipHandling(t *testing.T) {
 	txGossipedLock.Lock()
 	assert.Equal(0, txGossiped, "tx should not have been gossiped")
 	txGossipedLock.Unlock()
-	assert.False(tvm.vm.mempool.Has(conflictingTx.ID()), "conflicting tx should not be in the atomic mempool")
+	assert.False(tvm.vm.atomicVM.Mempool.Has(conflictingTx.ID()), "conflicting tx should not be in the atomic mempool")
 }
 
 // show that txs already marked as invalid are not re-requested on gossiping
@@ -116,7 +116,7 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	defer func() {
 		assert.NoError(tvm.vm.Shutdown(context.Background()))
 	}()
-	mempool := tvm.vm.mempool
+	mempool := tvm.vm.atomicVM.Mempool
 
 	var (
 		txGossiped     int
@@ -175,8 +175,8 @@ func TestMempoolAtmTxsAppGossipHandlingDiscardedTx(t *testing.T) {
 	// Conflicting tx must be submitted over the API to be included in push gossip.
 	// (i.e., txs received via p2p are not included in push gossip)
 	// This test adds it directly to the mempool + gossiper to simulate that.
-	tvm.vm.mempool.AddRemoteTx(conflictingTx)
-	tvm.vm.atomicTxPushGossiper.Add(conflictingTx)
+	tvm.vm.atomicVM.Mempool.AddRemoteTx(conflictingTx)
+	tvm.vm.atomicVM.AtomicTxPushGossiper.Add(conflictingTx)
 	time.Sleep(500 * time.Millisecond)
 
 	tvm.vm.ctx.Lock.Lock()

--- a/plugin/evm/mempool_atomic_gossiping_test.go
+++ b/plugin/evm/mempool_atomic_gossiping_test.go
@@ -32,7 +32,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 				err := tvm.vm.Shutdown(context.Background())
 				assert.NoError(err)
 			}()
-			mempool := tvm.vm.mempool
+			mempool := tvm.vm.atomicVM.Mempool
 
 			// generate a valid and conflicting tx
 			var (
@@ -49,13 +49,13 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 			conflictingTxID := conflictingTx.ID()
 
 			// add a tx to the mempool
-			err := tvm.vm.mempool.AddLocalTx(tx)
+			err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx)
 			assert.NoError(err)
 			has := mempool.Has(txID)
 			assert.True(has, "valid tx not recorded into mempool")
 
 			// try to add a conflicting tx
-			err = tvm.vm.mempool.AddLocalTx(conflictingTx)
+			err = tvm.vm.atomicVM.Mempool.AddLocalTx(conflictingTx)
 			assert.ErrorIs(err, atomictxpool.ErrConflictingAtomicTx)
 			has = mempool.Has(conflictingTxID)
 			assert.False(has, "conflicting tx in mempool")

--- a/plugin/evm/mempool_atomic_gossiping_test.go
+++ b/plugin/evm/mempool_atomic_gossiping_test.go
@@ -32,7 +32,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 				err := tvm.vm.Shutdown(context.Background())
 				assert.NoError(err)
 			}()
-			mempool := tvm.vm.atomicVM.Mempool
+			mempool := tvm.vm.atomicVM.AtomicMempool
 
 			// generate a valid and conflicting tx
 			var (
@@ -49,13 +49,13 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 			conflictingTxID := conflictingTx.ID()
 
 			// add a tx to the mempool
-			err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx)
+			err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx)
 			assert.NoError(err)
 			has := mempool.Has(txID)
 			assert.True(has, "valid tx not recorded into mempool")
 
 			// try to add a conflicting tx
-			err = tvm.vm.atomicVM.Mempool.AddLocalTx(conflictingTx)
+			err = tvm.vm.atomicVM.AtomicMempool.AddLocalTx(conflictingTx)
 			assert.ErrorIs(err, atomictxpool.ErrConflictingAtomicTx)
 			has = mempool.Has(conflictingTxID)
 			assert.False(has, "conflicting tx in mempool")

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -310,7 +310,7 @@ func createSyncServerAndClientVMs(t *testing.T, test syncTest, numBlocks int) *s
 			// spend the UTXOs from shared memory
 			importTx, err = server.vm.newImportTx(server.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 			require.NoError(err)
-			require.NoError(server.vm.mempool.AddLocalTx(importTx))
+			require.NoError(server.vm.atomicVM.Mempool.AddLocalTx(importTx))
 		case 1:
 			// export some of the imported UTXOs to test exportTx is properly synced
 			exportTx, err = server.vm.newExportTx(
@@ -322,7 +322,7 @@ func createSyncServerAndClientVMs(t *testing.T, test syncTest, numBlocks int) *s
 				[]*secp256k1.PrivateKey{testKeys[0]},
 			)
 			require.NoError(err)
-			require.NoError(server.vm.mempool.AddLocalTx(exportTx))
+			require.NoError(server.vm.atomicVM.Mempool.AddLocalTx(exportTx))
 		default: // Generate simple transfer transactions.
 			pk := testKeys[0].ToECDSA()
 			tx := types.NewTransaction(gen.TxNonce(testEthAddrs[0]), testEthAddrs[1], common.Big1, params.TxGas, initialBaseFee, nil)

--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -310,7 +310,7 @@ func createSyncServerAndClientVMs(t *testing.T, test syncTest, numBlocks int) *s
 			// spend the UTXOs from shared memory
 			importTx, err = server.vm.newImportTx(server.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 			require.NoError(err)
-			require.NoError(server.vm.atomicVM.Mempool.AddLocalTx(importTx))
+			require.NoError(server.vm.atomicVM.AtomicMempool.AddLocalTx(importTx))
 		case 1:
 			// export some of the imported UTXOs to test exportTx is properly synced
 			exportTx, err = server.vm.newExportTx(
@@ -322,7 +322,7 @@ func createSyncServerAndClientVMs(t *testing.T, test syncTest, numBlocks int) *s
 				[]*secp256k1.PrivateKey{testKeys[0]},
 			)
 			require.NoError(err)
-			require.NoError(server.vm.atomicVM.Mempool.AddLocalTx(exportTx))
+			require.NoError(server.vm.atomicVM.AtomicMempool.AddLocalTx(exportTx))
 		default: // Generate simple transfer transactions.
 			pk := testKeys[0].ToECDSA()
 			tx := types.NewTransaction(gen.TxNonce(testEthAddrs[0]), testEthAddrs[1], common.Big1, params.TxGas, initialBaseFee, nil)

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -276,7 +276,7 @@ func TestAtomicTxGossip(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
+	require.NoError(vm.atomicVM.AtomicMempool.AddLocalTx(tx))
 
 	// wait so we aren't throttled by the vm
 	time.Sleep(5 * time.Second)
@@ -472,7 +472,7 @@ func TestAtomicTxPushGossipOutbound(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
+	require.NoError(vm.atomicVM.AtomicMempool.AddLocalTx(tx))
 	vm.atomicVM.AtomicTxPushGossiper.Add(tx)
 
 	gossipedBytes := <-sender.SentAppGossip
@@ -539,7 +539,7 @@ func TestAtomicTxPushGossipInbound(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
+	require.NoError(vm.atomicVM.AtomicMempool.AddLocalTx(tx))
 
 	marshaller := atomic.TxMarshaller{}
 	gossipBytes, err := marshaller.MarshalGossip(tx)
@@ -554,5 +554,5 @@ func TestAtomicTxPushGossipInbound(t *testing.T) {
 	inboundGossipMsg := append(binary.AppendUvarint(nil, p2p.AtomicTxGossipHandlerID), inboundGossipBytes...)
 
 	require.NoError(vm.AppGossip(ctx, ids.EmptyNodeID, inboundGossipMsg))
-	require.True(vm.atomicVM.Mempool.Has(tx.ID()))
+	require.True(vm.atomicVM.AtomicMempool.Has(tx.ID()))
 }

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -58,10 +58,7 @@ func TestEthTxGossip(t *testing.T) {
 	responseSender := &enginetest.SenderStub{
 		SentAppResponse: make(chan []byte, 1),
 	}
-	vm := &VM{
-		atomicTxGossipHandler: &p2p.NoOpHandler{},
-		atomicTxPullGossiper:  &gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	require.NoError(vm.Initialize(
 		ctx,
@@ -191,10 +188,7 @@ func TestAtomicTxGossip(t *testing.T) {
 	responseSender := &enginetest.SenderStub{
 		SentAppResponse: make(chan []byte, 1),
 	}
-	vm := &VM{
-		ethTxGossipHandler: &p2p.NoOpHandler{},
-		ethTxPullGossiper:  &gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	require.NoError(vm.Initialize(
 		ctx,
@@ -282,7 +276,7 @@ func TestAtomicTxGossip(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.mempool.AddLocalTx(tx))
+	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
 
 	// wait so we aren't throttled by the vm
 	time.Sleep(5 * time.Second)
@@ -319,10 +313,7 @@ func TestEthTxPushGossipOutbound(t *testing.T) {
 		SentAppGossip: make(chan []byte, 1),
 	}
 
-	vm := &VM{
-		ethTxPullGossiper:    gossip.NoOpGossiper{},
-		atomicTxPullGossiper: gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	pk, err := secp256k1.NewPrivateKey()
 	require.NoError(err)
@@ -378,10 +369,7 @@ func TestEthTxPushGossipInbound(t *testing.T) {
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 
 	sender := &enginetest.Sender{}
-	vm := &VM{
-		ethTxPullGossiper:    gossip.NoOpGossiper{},
-		atomicTxPullGossiper: gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	pk, err := secp256k1.NewPrivateKey()
 	require.NoError(err)
@@ -452,10 +440,7 @@ func TestAtomicTxPushGossipOutbound(t *testing.T) {
 	sender := &enginetest.SenderStub{
 		SentAppGossip: make(chan []byte, 1),
 	}
-	vm := &VM{
-		ethTxPullGossiper:    gossip.NoOpGossiper{},
-		atomicTxPullGossiper: gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	require.NoError(vm.Initialize(
 		ctx,
@@ -487,8 +472,8 @@ func TestAtomicTxPushGossipOutbound(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.mempool.AddLocalTx(tx))
-	vm.atomicTxPushGossiper.Add(tx)
+	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
+	vm.atomicVM.AtomicTxPushGossiper.Add(tx)
 
 	gossipedBytes := <-sender.SentAppGossip
 	require.Equal(byte(p2p.AtomicTxGossipHandlerID), gossipedBytes[0])
@@ -522,10 +507,7 @@ func TestAtomicTxPushGossipInbound(t *testing.T) {
 	require.NoError(err)
 
 	sender := &enginetest.Sender{}
-	vm := &VM{
-		ethTxPullGossiper:    gossip.NoOpGossiper{},
-		atomicTxPullGossiper: gossip.NoOpGossiper{},
-	}
+	vm := &VM{}
 
 	require.NoError(vm.Initialize(
 		ctx,
@@ -557,7 +539,7 @@ func TestAtomicTxPushGossipInbound(t *testing.T) {
 	require.NoError(err)
 	tx, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, address, initialBaseFee, secp256k1fx.NewKeychain(pk), []*avax.UTXO{utxo})
 	require.NoError(err)
-	require.NoError(vm.mempool.AddLocalTx(tx))
+	require.NoError(vm.atomicVM.Mempool.AddLocalTx(tx))
 
 	marshaller := atomic.TxMarshaller{}
 	gossipBytes, err := marshaller.MarshalGossip(tx)
@@ -572,5 +554,5 @@ func TestAtomicTxPushGossipInbound(t *testing.T) {
 	inboundGossipMsg := append(binary.AppendUvarint(nil, p2p.AtomicTxGossipHandlerID), inboundGossipBytes...)
 
 	require.NoError(vm.AppGossip(ctx, ids.EmptyNodeID, inboundGossipMsg))
-	require.True(vm.mempool.Has(tx.ID()))
+	require.True(vm.atomicVM.Mempool.Has(tx.ID()))
 }

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -168,7 +168,7 @@ func executeTxTest(t *testing.T, test atomicTxTest) {
 		}
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(tx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine

--- a/plugin/evm/tx_test.go
+++ b/plugin/evm/tx_test.go
@@ -168,7 +168,7 @@ func executeTxTest(t *testing.T, test atomicTxTest) {
 		}
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -798,25 +798,22 @@ func (vm *VM) initBlockBuilding() error {
 		Peers:      vm.config.PushRegossipNumPeers,
 	}
 
-	ethTxPushGossiper := vm.ethTxPushGossiper.Get()
-	if ethTxPushGossiper == nil {
-		ethTxPushGossiper, err = avalanchegossip.NewPushGossiper[*GossipEthTx](
-			ethTxGossipMarshaller,
-			ethTxPool,
-			vm.P2PValidators(),
-			ethTxGossipClient,
-			ethTxGossipMetrics,
-			pushGossipParams,
-			pushRegossipParams,
-			config.PushGossipDiscardedElements,
-			config.TxGossipTargetMessageSize,
-			vm.config.RegossipFrequency.Duration,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to initialize eth tx push gossiper: %w", err)
-		}
-		vm.ethTxPushGossiper.Set(ethTxPushGossiper)
+	ethTxPushGossiper, err := avalanchegossip.NewPushGossiper[*GossipEthTx](
+		ethTxGossipMarshaller,
+		ethTxPool,
+		vm.P2PValidators(),
+		ethTxGossipClient,
+		ethTxGossipMetrics,
+		pushGossipParams,
+		pushRegossipParams,
+		config.PushGossipDiscardedElements,
+		config.TxGossipTargetMessageSize,
+		vm.config.RegossipFrequency.Duration,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to initialize eth tx push gossiper: %w", err)
 	}
+	vm.ethTxPushGossiper.Set(ethTxPushGossiper)
 
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
 	vm.builder = vm.NewBlockBuilder(vm.toEngine, vm.extensionConfig.ExtraMempool)
@@ -1134,7 +1131,7 @@ func (vm *VM) getAtomicTx(txID ids.ID) (*atomic.Tx, atomic.Status, uint64, error
 	} else if err != database.ErrNotFound {
 		return nil, atomic.Unknown, 0, err
 	}
-	tx, dropped, found := vm.atomicVM.Mempool.GetTx(txID)
+	tx, dropped, found := vm.atomicVM.AtomicMempool.GetTx(txID)
 	switch {
 	case found && dropped:
 		return tx, atomic.Dropped, 0, nil

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -20,10 +20,11 @@ import (
 	"github.com/ava-labs/avalanchego/cache/metercacher"
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
-	"github.com/ava-labs/avalanchego/network/p2p/gossip"
 	avalanchegoConstants "github.com/ava-labs/avalanchego/utils/constants"
 	"github.com/ava-labs/coreth/network"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
+	"github.com/ava-labs/coreth/plugin/evm/gossip"
+	"github.com/ava-labs/coreth/plugin/evm/vmerrors"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
@@ -38,15 +39,12 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
-	atomictxpool "github.com/ava-labs/coreth/plugin/evm/atomic/txpool"
 	atomicvm "github.com/ava-labs/coreth/plugin/evm/atomic/vm"
 	"github.com/ava-labs/coreth/plugin/evm/config"
-	customheader "github.com/ava-labs/coreth/plugin/evm/header"
 	corethlog "github.com/ava-labs/coreth/plugin/evm/log"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	vmsync "github.com/ava-labs/coreth/plugin/evm/sync"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/acp176"
-	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap5"
 	"github.com/ava-labs/coreth/triedb/hashdb"
 
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -87,6 +85,7 @@ import (
 	"github.com/ava-labs/avalanchego/database"
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
+	avalanchegossip "github.com/ava-labs/avalanchego/network/p2p/gossip"
 	"github.com/ava-labs/avalanchego/snow"
 	"github.com/ava-labs/avalanchego/snow/consensus/snowman"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
@@ -121,7 +120,6 @@ const (
 	// and fail verification
 	maxFutureBlockTime = 10 * time.Second
 	maxUTXOsToFetch    = 1024
-	defaultMempoolSize = 4096
 
 	secpCacheSize          = 1024
 	decidedCacheSize       = 10 * units.MiB
@@ -134,21 +132,6 @@ const (
 	ethMetricsPrefix        = "eth"
 	sdkMetricsPrefix        = "sdk"
 	chainStateMetricsPrefix = "chain_state"
-
-	targetAtomicTxsSize = 40 * units.KiB
-
-	// maxAtomicTxMempoolGas is the maximum amount of gas that is allowed to be
-	// used by an atomic transaction in the mempool. It is allowed to build
-	// blocks with larger atomic transactions, but they will not be accepted
-	// into the mempool.
-	maxAtomicTxMempoolGas = ap5.AtomicGasLimit
-
-	// gossip constants
-	pushGossipDiscardedElements = 16_384
-	txGossipTargetMessageSize   = 20 * units.KiB
-	txGossipThrottlingPeriod    = 10 * time.Second
-	txGossipThrottlingLimit     = 2
-	txGossipPollSize            = 1
 )
 
 // Define the API endpoints for the VM
@@ -258,8 +241,7 @@ type VM struct {
 
 	builder *blockBuilder
 
-	clock   *mockable.Clock
-	mempool *atomictxpool.Mempool
+	clock *mockable.Clock
 
 	shutdownChan chan struct{}
 	shutdownWg   sync.WaitGroup
@@ -286,12 +268,9 @@ type VM struct {
 	warpBackend warp.Backend
 
 	// Initialize only sets these if nil so they can be overridden in tests
-	ethTxGossipHandler    p2p.Handler
-	ethTxPushGossiper     avalancheUtils.Atomic[*gossip.PushGossiper[*GossipEthTx]]
-	ethTxPullGossiper     gossip.Gossiper
-	atomicTxGossipHandler p2p.Handler
-	atomicTxPushGossiper  *gossip.PushGossiper[*atomic.Tx]
-	atomicTxPullGossiper  gossip.Gossiper
+	ethTxGossipHandler p2p.Handler
+	ethTxPushGossiper  avalancheUtils.Atomic[*avalanchegossip.PushGossiper[*GossipEthTx]]
+	ethTxPullGossiper  avalanchegossip.Gossiper
 
 	chainAlias string
 	// RPC handlers (should be stopped before closing chaindb)
@@ -327,6 +306,8 @@ func (vm *VM) Initialize(
 	if err := vm.extensionConfig.Validate(); err != nil {
 		return fmt.Errorf("failed to validate extension config: %w", err)
 	}
+
+	vm.clock = &mockable.Clock{}
 	if vm.extensionConfig.Clock != nil {
 		vm.clock = vm.extensionConfig.Clock
 	}
@@ -403,7 +384,7 @@ func (vm *VM) Initialize(
 	vm.ethConfig = ethconfig.NewDefaultConfig()
 	vm.ethConfig.Genesis = g
 	vm.ethConfig.NetworkId = vm.chainID.Uint64()
-	vm.genesisHash = vm.ethConfig.Genesis.ToBlock().Hash() // must create genesis hash before [vm.readLastAccepted]
+	vm.genesisHash = vm.ethConfig.Genesis.ToBlock().Hash() // must create genesis hash before [vm.ReadLastAccepted]
 	lastAcceptedHash, lastAcceptedHeight, err := vm.ReadLastAccepted()
 	if err != nil {
 		return err
@@ -466,11 +447,7 @@ func (vm *VM) Initialize(
 		}
 	}
 
-	// TODO: read size from settings
-	vm.mempool, err = atomictxpool.NewMempool(chainCtx, vm.sdkMetrics, defaultMempoolSize, vm.verifyTxAtTip)
-	if err != nil {
-		return fmt.Errorf("failed to initialize mempool: %w", err)
-	}
+	vm.chainConfig = g.Config
 
 	vm.networkCodec = message.Codec
 	vm.Network, err = network.NewNetwork(vm.ctx, appSender, vm.networkCodec, vm.config.MaxOutboundActiveRequests, vm.sdkMetrics)
@@ -798,7 +775,7 @@ func (vm *VM) initBlockBuilding() error {
 
 	ethTxGossipMarshaller := GossipEthTxMarshaller{}
 	ethTxGossipClient := vm.Network.NewClient(p2p.TxGossipHandlerID, p2p.WithValidatorSampling(vm.P2PValidators()))
-	ethTxGossipMetrics, err := gossip.NewMetrics(vm.sdkMetrics, ethTxGossipNamespace)
+	ethTxGossipMetrics, err := avalanchegossip.NewMetrics(vm.sdkMetrics, ethTxGossipNamespace)
 	if err != nil {
 		return fmt.Errorf("failed to initialize eth tx gossip metrics: %w", err)
 	}
@@ -811,27 +788,19 @@ func (vm *VM) initBlockBuilding() error {
 		ethTxPool.Subscribe(ctx)
 		vm.shutdownWg.Done()
 	}()
-
-	atomicTxGossipMarshaller := &atomic.TxMarshaller{}
-	atomicTxGossipClient := vm.Network.NewClient(p2p.AtomicTxGossipHandlerID, p2p.WithValidatorSampling(vm.P2PValidators()))
-	atomicTxGossipMetrics, err := gossip.NewMetrics(vm.sdkMetrics, atomicTxGossipNamespace)
-	if err != nil {
-		return fmt.Errorf("failed to initialize atomic tx gossip metrics: %w", err)
-	}
-
-	pushGossipParams := gossip.BranchingFactor{
+	pushGossipParams := avalanchegossip.BranchingFactor{
 		StakePercentage: vm.config.PushGossipPercentStake,
 		Validators:      vm.config.PushGossipNumValidators,
 		Peers:           vm.config.PushGossipNumPeers,
 	}
-	pushRegossipParams := gossip.BranchingFactor{
+	pushRegossipParams := avalanchegossip.BranchingFactor{
 		Validators: vm.config.PushRegossipNumValidators,
 		Peers:      vm.config.PushRegossipNumPeers,
 	}
 
 	ethTxPushGossiper := vm.ethTxPushGossiper.Get()
 	if ethTxPushGossiper == nil {
-		ethTxPushGossiper, err = gossip.NewPushGossiper[*GossipEthTx](
+		ethTxPushGossiper, err = avalanchegossip.NewPushGossiper[*GossipEthTx](
 			ethTxGossipMarshaller,
 			ethTxPool,
 			vm.P2PValidators(),
@@ -839,8 +808,8 @@ func (vm *VM) initBlockBuilding() error {
 			ethTxGossipMetrics,
 			pushGossipParams,
 			pushRegossipParams,
-			pushGossipDiscardedElements,
-			txGossipTargetMessageSize,
+			config.PushGossipDiscardedElements,
+			config.TxGossipTargetMessageSize,
 			vm.config.RegossipFrequency.Duration,
 		)
 		if err != nil {
@@ -849,115 +818,59 @@ func (vm *VM) initBlockBuilding() error {
 		vm.ethTxPushGossiper.Set(ethTxPushGossiper)
 	}
 
-	if vm.atomicTxPushGossiper == nil {
-		vm.atomicTxPushGossiper, err = gossip.NewPushGossiper[*atomic.Tx](
-			atomicTxGossipMarshaller,
-			vm.mempool,
-			vm.P2PValidators(),
-			atomicTxGossipClient,
-			atomicTxGossipMetrics,
-			pushGossipParams,
-			pushRegossipParams,
-			pushGossipDiscardedElements,
-			txGossipTargetMessageSize,
-			vm.config.RegossipFrequency.Duration,
-		)
-		if err != nil {
-			return fmt.Errorf("failed to initialize atomic tx push gossiper: %w", err)
-		}
-	}
-
 	// NOTE: gossip network must be initialized first otherwise ETH tx gossip will not work.
-	vm.builder = vm.NewBlockBuilder(vm.toEngine)
+	vm.builder = vm.NewBlockBuilder(vm.toEngine, vm.extensionConfig.ExtraMempool)
 	vm.builder.awaitSubmittedTxs()
 
-	if vm.ethTxGossipHandler == nil {
-		vm.ethTxGossipHandler = newTxGossipHandler[*GossipEthTx](
-			vm.ctx.Log,
-			ethTxGossipMarshaller,
-			ethTxPool,
-			ethTxGossipMetrics,
-			txGossipTargetMessageSize,
-			txGossipThrottlingPeriod,
-			txGossipThrottlingLimit,
-			vm.P2PValidators(),
-		)
-	}
+	vm.ethTxGossipHandler = gossip.NewTxGossipHandler[*GossipEthTx](
+		vm.ctx.Log,
+		ethTxGossipMarshaller,
+		ethTxPool,
+		ethTxGossipMetrics,
+		config.TxGossipTargetMessageSize,
+		config.TxGossipThrottlingPeriod,
+		config.TxGossipThrottlingLimit,
+		vm.P2PValidators(),
+	)
 
 	if err := vm.Network.AddHandler(p2p.TxGossipHandlerID, vm.ethTxGossipHandler); err != nil {
 		return fmt.Errorf("failed to add eth tx gossip handler: %w", err)
 	}
 
-	if vm.atomicTxGossipHandler == nil {
-		vm.atomicTxGossipHandler = newTxGossipHandler[*atomic.Tx](
-			vm.ctx.Log,
-			atomicTxGossipMarshaller,
-			vm.mempool,
-			atomicTxGossipMetrics,
-			txGossipTargetMessageSize,
-			txGossipThrottlingPeriod,
-			txGossipThrottlingLimit,
-			vm.P2PValidators(),
-		)
-	}
+	ethTxPullGossiper := avalanchegossip.NewPullGossiper[*GossipEthTx](
+		vm.ctx.Log,
+		ethTxGossipMarshaller,
+		ethTxPool,
+		ethTxGossipClient,
+		ethTxGossipMetrics,
+		config.TxGossipPollSize,
+	)
 
-	if err := vm.Network.AddHandler(p2p.AtomicTxGossipHandlerID, vm.atomicTxGossipHandler); err != nil {
-		return fmt.Errorf("failed to add atomic tx gossip handler: %w", err)
-	}
-
-	if vm.ethTxPullGossiper == nil {
-		ethTxPullGossiper := gossip.NewPullGossiper[*GossipEthTx](
-			vm.ctx.Log,
-			ethTxGossipMarshaller,
-			ethTxPool,
-			ethTxGossipClient,
-			ethTxGossipMetrics,
-			txGossipPollSize,
-		)
-
-		vm.ethTxPullGossiper = gossip.ValidatorGossiper{
-			Gossiper:   ethTxPullGossiper,
-			NodeID:     vm.ctx.NodeID,
-			Validators: vm.P2PValidators(),
-		}
+	vm.ethTxPullGossiper = avalanchegossip.ValidatorGossiper{
+		Gossiper:   ethTxPullGossiper,
+		NodeID:     vm.ctx.NodeID,
+		Validators: vm.P2PValidators(),
 	}
 
 	vm.shutdownWg.Add(1)
 	go func() {
-		gossip.Every(ctx, vm.ctx.Log, ethTxPushGossiper, vm.config.PushGossipFrequency.Duration)
+		avalanchegossip.Every(ctx, vm.ctx.Log, ethTxPushGossiper, vm.config.PushGossipFrequency.Duration)
 		vm.shutdownWg.Done()
 	}()
 	vm.shutdownWg.Add(1)
 	go func() {
-		gossip.Every(ctx, vm.ctx.Log, vm.ethTxPullGossiper, vm.config.PullGossipFrequency.Duration)
+		avalanchegossip.Every(ctx, vm.ctx.Log, vm.ethTxPullGossiper, vm.config.PullGossipFrequency.Duration)
 		vm.shutdownWg.Done()
 	}()
 
-	if vm.atomicTxPullGossiper == nil {
-		atomicTxPullGossiper := gossip.NewPullGossiper[*atomic.Tx](
-			vm.ctx.Log,
-			atomicTxGossipMarshaller,
-			vm.mempool,
-			atomicTxGossipClient,
-			atomicTxGossipMetrics,
-			txGossipPollSize,
-		)
-
-		vm.atomicTxPullGossiper = &gossip.ValidatorGossiper{
-			Gossiper:   atomicTxPullGossiper,
-			NodeID:     vm.ctx.NodeID,
-			Validators: vm.P2PValidators(),
-		}
-	}
-
 	vm.shutdownWg.Add(1)
 	go func() {
-		gossip.Every(ctx, vm.ctx.Log, vm.atomicTxPushGossiper, vm.config.PushGossipFrequency.Duration)
+		avalanchegossip.Every(ctx, vm.ctx.Log, ethTxPushGossiper, vm.config.PushGossipFrequency.Duration)
 		vm.shutdownWg.Done()
 	}()
 	vm.shutdownWg.Add(1)
 	go func() {
-		gossip.Every(ctx, vm.ctx.Log, vm.atomicTxPullGossiper, vm.config.PullGossipFrequency.Duration)
+		avalanchegossip.Every(ctx, vm.ctx.Log, vm.ethTxPullGossiper, vm.config.PullGossipFrequency.Duration)
 		vm.shutdownWg.Done()
 	}()
 
@@ -1005,18 +918,14 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	block, err := vm.miner.GenerateBlock(predicateCtx)
 	vm.builder.handleGenerateBlock()
 	if err != nil {
-		vm.mempool.CancelCurrentTxs()
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", vmerrors.ErrGenerateBlockFailed, err)
 	}
 
 	// Note: the status of block is set by ChainState
 	blk, err := wrapBlock(block, vm)
 	if err != nil {
-		log.Debug("discarding txs due to error making new block", "err", err)
-		vm.mempool.DiscardCurrentTxs()
-		return nil, err
+		return nil, fmt.Errorf("%w: %w", vmerrors.ErrWrapBlockFailed, err)
 	}
-
 	// Verify is called on a non-wrapped block here, such that this
 	// does not add [blk] to the processing blocks map in ChainState.
 	//
@@ -1030,16 +939,12 @@ func (vm *VM) buildBlockWithContext(ctx context.Context, proposerVMBlockCtx *blo
 	// to the blk state root in the triedb when we are going to call verify
 	// again from the consensus engine with writes enabled.
 	if err := blk.verify(predicateCtx, false /*=writes*/); err != nil {
-		vm.mempool.CancelCurrentTxs()
-		return nil, fmt.Errorf("block failed verification due to: %w", err)
+		return nil, fmt.Errorf("%w: %w", vmerrors.ErrBlockVerificationFailed, err)
 	}
 
 	log.Debug("built block",
 		"id", blk.ID(),
 	)
-	// Marks the current transactions from the mempool as being successfully issued
-	// into a block.
-	vm.mempool.IssueCurrentTxs()
 	return blk, nil
 }
 
@@ -1229,7 +1134,7 @@ func (vm *VM) getAtomicTx(txID ids.ID) (*atomic.Tx, atomic.Status, uint64, error
 	} else if err != database.ErrNotFound {
 		return nil, atomic.Unknown, 0, err
 	}
-	tx, dropped, found := vm.mempool.GetTx(txID)
+	tx, dropped, found := vm.atomicVM.Mempool.GetTx(txID)
 	switch {
 	case found && dropped:
 		return tx, atomic.Dropped, 0, nil
@@ -1264,43 +1169,6 @@ func (vm *VM) ParseAddress(addrStr string) (ids.ID, ids.ShortID, error) {
 		return ids.ID{}, ids.ShortID{}, err
 	}
 	return chainID, addr, nil
-}
-
-// verifyTxAtTip verifies that [tx] is valid to be issued on top of the currently preferred block
-func (vm *VM) verifyTxAtTip(tx *atomic.Tx) error {
-	if txByteLen := len(tx.SignedBytes()); txByteLen > targetAtomicTxsSize {
-		return fmt.Errorf("tx size (%d) exceeds total atomic txs size target (%d)", txByteLen, targetAtomicTxsSize)
-	}
-	gasUsed, err := tx.GasUsed(true)
-	if err != nil {
-		return err
-	}
-	if gasUsed > maxAtomicTxMempoolGas {
-		return fmt.Errorf("tx gas usage (%d) exceeds maximum allowed mempool gas usage (%d)", gasUsed, maxAtomicTxMempoolGas)
-	}
-
-	// Note: we fetch the current block and then the state at that block instead of the current state directly
-	// since we need the header of the current block below.
-	preferredBlock := vm.blockChain.CurrentBlock()
-	preferredState, err := vm.blockChain.StateAt(preferredBlock.Root)
-	if err != nil {
-		return fmt.Errorf("failed to retrieve block state at tip while verifying atomic tx: %w", err)
-	}
-	rules := vm.currentRules()
-	parentHeader := preferredBlock
-	var nextBaseFee *big.Int
-	timestamp := uint64(vm.clock.Time().Unix())
-	if vm.chainConfigExtra().IsApricotPhase3(timestamp) {
-		nextBaseFee, err = customheader.EstimateNextBaseFee(vm.chainConfigExtra(), parentHeader, timestamp)
-		if err != nil {
-			// Return extremely detailed error since CalcBaseFee should never encounter an issue here
-			return fmt.Errorf("failed to calculate base fee with parent timestamp (%d), parent ExtraData: (0x%x), and current timestamp (%d): %w", parentHeader.Time, parentHeader.Extra, timestamp, err)
-		}
-	}
-
-	// We don’t need to revert the state here in case verifyTx errors, because
-	// [preferredState] is thrown away either way.
-	return vm.atomicVM.VerifyTx(tx, parentHeader.Hash(), nextBaseFee, preferredState, rules)
 }
 
 // GetAtomicUTXOs returns the utxos that at least one of the provided addresses is

--- a/plugin/evm/vm_extensible.go
+++ b/plugin/evm/vm_extensible.go
@@ -58,11 +58,6 @@ func (vm *VM) LastAcceptedExtendedBlock() extension.ExtendedBlock {
 	return lastAcceptedBlock.(*wrappedBlock)
 }
 
-// IsBootstrapped returns true if the VM has finished bootstrapping
-func (vm *VM) IsBootstrapped() bool {
-	return vm.bootstrapped.Get()
-}
-
 func (vm *VM) ChainConfig() *params.ChainConfig {
 	return vm.chainConfig
 }

--- a/plugin/evm/vm_extensible.go
+++ b/plugin/evm/vm_extensible.go
@@ -10,7 +10,7 @@ import (
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p"
-	"github.com/ava-labs/coreth/eth"
+	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
@@ -67,8 +67,8 @@ func (vm *VM) ChainConfig() *params.ChainConfig {
 	return vm.chainConfig
 }
 
-func (vm *VM) Ethereum() *eth.Ethereum {
-	return vm.eth
+func (vm *VM) Blockchain() *core.BlockChain {
+	return vm.blockChain
 }
 
 func (vm *VM) Config() config.Config {

--- a/plugin/evm/vm_extensible.go
+++ b/plugin/evm/vm_extensible.go
@@ -9,11 +9,13 @@ import (
 
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/coreth/eth"
 	"github.com/ava-labs/coreth/params"
-	"github.com/ava-labs/coreth/plugin/evm/atomic/txpool"
 	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
+	vmsync "github.com/ava-labs/coreth/plugin/evm/sync"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
 var _ extension.InnerVM = (*VM)(nil)
@@ -73,10 +75,18 @@ func (vm *VM) Config() config.Config {
 	return vm.config
 }
 
+func (vm *VM) MetricRegistry() *prometheus.Registry {
+	return vm.sdkMetrics
+}
+
+func (vm *VM) Validators() *p2p.Validators {
+	return vm.P2PValidators()
+}
+
 func (vm *VM) VersionDB() *versiondb.Database {
 	return vm.versiondb
 }
 
-func (vm *VM) AtomicMempool() *txpool.Mempool {
-	return vm.mempool
+func (vm *VM) SyncerClient() vmsync.Client {
+	return vm.Client
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -459,7 +459,7 @@ func TestImportMissingUTXOs(t *testing.T) {
 
 	importTx, err := tvm1.vm.newImportTx(tvm1.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(t, err)
-	require.NoError(t, tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx))
+	require.NoError(t, tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx))
 	<-tvm1.toEngine
 	blk, err := tvm1.vm.BuildBlock(context.Background())
 	require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -556,7 +556,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(exportTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -619,7 +619,7 @@ func TestBuildEthTxBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -780,7 +780,7 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 		t.Fatal(err)
 	}
 	for _, tx := range importTxs[:2] {
-		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -810,11 +810,11 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 	// the VM returns an error when it attempts to issue the conflict into the mempool
 	// and when it attempts to build a block with the conflict force added to the mempool.
 	for i, tx := range conflictTxs[:2] {
-		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err == nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err == nil {
 			t.Fatal("Expected issueTx to fail due to conflicting transaction")
 		}
 		// Force issue transaction directly to the mempool
-		if err := tvm.vm.atomicVM.Mempool.ForceAddTx(tx); err != nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.ForceAddTx(tx); err != nil {
 			t.Fatal(err)
 		}
 		<-tvm.toEngine
@@ -832,7 +832,7 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 	// Generate one more valid block so that we can copy the header to create an invalid block
 	// with modified extra data. This new block will be invalid for more than one reason (invalid merkle root)
 	// so we check to make sure that the expected error is returned from block verification.
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTxs[2]); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTxs[2]); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -941,10 +941,10 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := vm.atomicVM.Mempool.AddLocalTx(tx1); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(tx1); err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.atomicVM.Mempool.AddLocalTx(tx2); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(tx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -968,10 +968,10 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := vm.atomicVM.Mempool.AddLocalTx(tx1); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(tx1); err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.atomicVM.Mempool.AddLocalTx(tx2); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(tx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1001,27 +1001,27 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.atomicVM.Mempool.AddLocalTx(importTx1); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(importTx1); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := vm.atomicVM.Mempool.AddLocalTx(importTx2); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(importTx2); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := vm.atomicVM.Mempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
 				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingAtomicTx, err)
 			}
 
-			assert.True(t, vm.atomicVM.Mempool.Has(importTx1.ID()))
-			assert.True(t, vm.atomicVM.Mempool.Has(importTx2.ID()))
-			assert.False(t, vm.atomicVM.Mempool.Has(reissuanceTx1.ID()))
+			assert.True(t, vm.atomicVM.AtomicMempool.Has(importTx1.ID()))
+			assert.True(t, vm.atomicVM.AtomicMempool.Has(importTx2.ID()))
+			assert.False(t, vm.atomicVM.AtomicMempool.Has(reissuanceTx1.ID()))
 
 			reissuanceTx2, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(4), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.atomicVM.Mempool.AddLocalTx(reissuanceTx2); err != nil {
+			if err := vm.atomicVM.AtomicMempool.AddLocalTx(reissuanceTx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1036,12 +1036,12 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 			issuedTxs, evictedTxs := issueTxs(t, tvm.vm, tvm.atomicMemory)
 
 			for i, tx := range issuedTxs {
-				_, issued := tvm.vm.atomicVM.Mempool.GetPendingTx(tx.ID())
+				_, issued := tvm.vm.atomicVM.AtomicMempool.GetPendingTx(tx.ID())
 				assert.True(t, issued, "expected issued tx at index %d to be issued", i)
 			}
 
 			for i, tx := range evictedTxs {
-				_, discarded, _ := tvm.vm.atomicVM.Mempool.GetTx(tx.ID())
+				_, discarded, _ := tvm.vm.atomicVM.AtomicMempool.GetTx(tx.ID())
 				assert.True(t, discarded, "expected discarded tx at index %d to be discarded", i)
 			}
 		})
@@ -1107,7 +1107,7 @@ func TestSetPreferenceRace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1336,7 +1336,7 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx0A); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx0A); err != nil {
 		t.Fatalf("Failed to issue importTx0A: %s", err)
 	}
 
@@ -1394,7 +1394,7 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatalf("Failed to issue importTx1 due to: %s", err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx1); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1413,11 +1413,11 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx0B); err == nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx0B); err == nil {
 		t.Fatalf("Should not have been able to issue import tx with conflict")
 	}
 	// Force issue transaction directly into the mempool
-	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(importTx0B); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.ForceAddTx(importTx0B); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -1475,7 +1475,7 @@ func TestBonusBlocksTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1563,7 +1563,7 @@ func TestReorgProtection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1733,7 +1733,7 @@ func TestNonCanonicalAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1930,7 +1930,7 @@ func TestStickyPreference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2190,7 +2190,7 @@ func TestUncleBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2361,7 +2361,7 @@ func TestEmptyBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2444,7 +2444,7 @@ func TestAcceptReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2631,7 +2631,7 @@ func TestFutureBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2700,7 +2700,7 @@ func TestBuildApricotPhase1Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2807,7 +2807,7 @@ func TestLastAcceptedBlockNumberAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2884,7 +2884,7 @@ func TestReissueAtomicTx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2970,7 +2970,7 @@ func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {
 	exportTxs := createExportTxOptions(t, tvm.vm, tvm.toEngine, tvm.atomicMemory)
 	exportTx1, exportTx2 := exportTxs[0], exportTxs[1]
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx1); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(exportTx1); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -2986,16 +2986,16 @@ func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx2); err == nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(exportTx2); err == nil {
 		t.Fatal("Should have failed to issue due to an invalid export tx")
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddRemoteTx(exportTx2); err == nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddRemoteTx(exportTx2); err == nil {
 		t.Fatal("Should have failed to add because conflicting")
 	}
 
 	// Manually add transaction to mempool to bypass validation
-	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(exportTx2); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.ForceAddTx(exportTx2); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -3051,11 +3051,11 @@ func TestBuildInvalidBlockHead(t *testing.T) {
 
 	// Verify that the transaction fails verification when attempting to issue
 	// it into the atomic mempool.
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err == nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(tx); err == nil {
 		t.Fatal("Should have failed to issue invalid transaction")
 	}
 	// Force issue the transaction directly to the mempool
-	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(tx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.ForceAddTx(tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3127,7 +3127,7 @@ func TestBuildApricotPhase4Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3299,7 +3299,7 @@ func TestBuildApricotPhase5Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3429,7 +3429,7 @@ func TestConsecutiveAtomicTransactionsRevertSnapshot(t *testing.T) {
 	importTxs := createImportTxOptions(t, tvm.vm, tvm.atomicMemory)
 
 	// Issue the first import transaction, build, and accept the block.
-	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTxs[0]); err != nil {
+	if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTxs[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3459,8 +3459,8 @@ func TestConsecutiveAtomicTransactionsRevertSnapshot(t *testing.T) {
 
 	// Add the two conflicting transactions directly to the mempool, so that two consecutive transactions
 	// will fail verification when build block is called.
-	tvm.vm.atomicVM.Mempool.AddRemoteTx(importTxs[1])
-	tvm.vm.atomicVM.Mempool.AddRemoteTx(importTxs[2])
+	tvm.vm.atomicVM.AtomicMempool.AddRemoteTx(importTxs[1])
+	tvm.vm.atomicVM.AtomicMempool.AddRemoteTx(importTxs[2])
 
 	if _, err := tvm.vm.BuildBlock(context.Background()); err == nil {
 		t.Fatal("Expected build block to fail due to empty block")
@@ -3492,7 +3492,7 @@ func TestAtomicTxBuildBlockDropsConflicts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 			t.Fatal(err)
 		}
 		conflictSets[index].Add(importTx.ID())
@@ -3500,11 +3500,11 @@ func TestAtomicTxBuildBlockDropsConflicts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(conflictTx); err == nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(conflictTx); err == nil {
 			t.Fatal("should conflict with the utxoSet in the mempool")
 		}
 		// force add the tx
-		tvm.vm.atomicVM.Mempool.ForceAddTx(conflictTx)
+		tvm.vm.atomicVM.AtomicMempool.ForceAddTx(conflictTx)
 		conflictSets[index].Add(conflictTx.ID())
 	}
 	<-tvm.toEngine
@@ -3563,7 +3563,7 @@ func TestBuildBlockDoesNotExceedAtomicGasLimit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+		if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3627,7 +3627,7 @@ func TestExtraStateChangeAtomicGasLimitExceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tvm1.vm.atomicVM.Mempool.ForceAddTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.AtomicMempool.ForceAddTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3685,7 +3685,7 @@ func TestSkipChainConfigCheckCompatible(t *testing.T) {
 	// accept one block to test the SkipUpgradeCheck functionality.
 	importTx, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(t, err)
-	require.NoError(t, tvm.vm.atomicVM.Mempool.AddLocalTx(importTx))
+	require.NoError(t, tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx))
 	<-tvm.toEngine
 
 	blk, err := tvm.vm.BuildBlock(context.Background())
@@ -3792,7 +3792,7 @@ func TestParentBeaconRootBlock(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
+			if err := tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3977,11 +3977,11 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 
 	importTx1, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(err)
-	require.NoError(tvm.vm.atomicVM.Mempool.AddLocalTx(importTx1))
+	require.NoError(tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx1))
 
 	importTx2, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[1], initialBaseFee, []*secp256k1.PrivateKey{testKeys[1]})
 	require.NoError(err)
-	require.NoError(tvm.vm.atomicVM.Mempool.AddLocalTx(importTx2))
+	require.NoError(tvm.vm.atomicVM.AtomicMempool.AddLocalTx(importTx2))
 
 	<-tvm.toEngine
 	blk1, err := tvm.vm.BuildBlock(ctx)

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -459,7 +459,7 @@ func TestImportMissingUTXOs(t *testing.T) {
 
 	importTx, err := tvm1.vm.newImportTx(tvm1.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(t, err)
-	require.NoError(t, tvm1.vm.mempool.AddLocalTx(importTx))
+	require.NoError(t, tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx))
 	<-tvm1.toEngine
 	blk, err := tvm1.vm.BuildBlock(context.Background())
 	require.NoError(t, err)
@@ -505,7 +505,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -556,7 +556,7 @@ func TestIssueAtomicTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(exportTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -619,7 +619,7 @@ func TestBuildEthTxBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -780,7 +780,7 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 		t.Fatal(err)
 	}
 	for _, tx := range importTxs[:2] {
-		if err := tvm.vm.mempool.AddLocalTx(tx); err != nil {
+		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err != nil {
 			t.Fatal(err)
 		}
 
@@ -810,11 +810,11 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 	// the VM returns an error when it attempts to issue the conflict into the mempool
 	// and when it attempts to build a block with the conflict force added to the mempool.
 	for i, tx := range conflictTxs[:2] {
-		if err := tvm.vm.mempool.AddLocalTx(tx); err == nil {
+		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err == nil {
 			t.Fatal("Expected issueTx to fail due to conflicting transaction")
 		}
 		// Force issue transaction directly to the mempool
-		if err := tvm.vm.mempool.ForceAddTx(tx); err != nil {
+		if err := tvm.vm.atomicVM.Mempool.ForceAddTx(tx); err != nil {
 			t.Fatal(err)
 		}
 		<-tvm.toEngine
@@ -832,7 +832,7 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork) {
 	// Generate one more valid block so that we can copy the header to create an invalid block
 	// with modified extra data. This new block will be invalid for more than one reason (invalid merkle root)
 	// so we check to make sure that the expected error is returned from block verification.
-	if err := tvm.vm.mempool.AddLocalTx(importTxs[2]); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTxs[2]); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -941,10 +941,10 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := vm.mempool.AddLocalTx(tx1); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(tx1); err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.mempool.AddLocalTx(tx2); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(tx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -968,10 +968,10 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := vm.mempool.AddLocalTx(tx1); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(tx1); err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.mempool.AddLocalTx(tx2); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(tx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1001,27 +1001,27 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.mempool.AddLocalTx(importTx1); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(importTx1); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := vm.mempool.AddLocalTx(importTx2); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(importTx2); err != nil {
 				t.Fatal(err)
 			}
 
-			if err := vm.mempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
+			if err := vm.atomicVM.Mempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
 				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingAtomicTx, err)
 			}
 
-			assert.True(t, vm.mempool.Has(importTx1.ID()))
-			assert.True(t, vm.mempool.Has(importTx2.ID()))
-			assert.False(t, vm.mempool.Has(reissuanceTx1.ID()))
+			assert.True(t, vm.atomicVM.Mempool.Has(importTx1.ID()))
+			assert.True(t, vm.atomicVM.Mempool.Has(importTx2.ID()))
+			assert.False(t, vm.atomicVM.Mempool.Has(reissuanceTx1.ID()))
 
 			reissuanceTx2, err := atomic.NewImportTx(vm.ctx, vm.currentRules(), vm.clock.Unix(), vm.ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(4), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
 			if err != nil {
 				t.Fatal(err)
 			}
-			if err := vm.mempool.AddLocalTx(reissuanceTx2); err != nil {
+			if err := vm.atomicVM.Mempool.AddLocalTx(reissuanceTx2); err != nil {
 				t.Fatal(err)
 			}
 
@@ -1036,12 +1036,12 @@ func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
 			issuedTxs, evictedTxs := issueTxs(t, tvm.vm, tvm.atomicMemory)
 
 			for i, tx := range issuedTxs {
-				_, issued := tvm.vm.mempool.GetPendingTx(tx.ID())
+				_, issued := tvm.vm.atomicVM.Mempool.GetPendingTx(tx.ID())
 				assert.True(t, issued, "expected issued tx at index %d to be issued", i)
 			}
 
 			for i, tx := range evictedTxs {
-				_, discarded, _ := tvm.vm.mempool.GetTx(tx.ID())
+				_, discarded, _ := tvm.vm.atomicVM.Mempool.GetTx(tx.ID())
 				assert.True(t, discarded, "expected discarded tx at index %d to be discarded", i)
 			}
 		})
@@ -1107,7 +1107,7 @@ func TestSetPreferenceRace(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1336,7 +1336,7 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx0A); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx0A); err != nil {
 		t.Fatalf("Failed to issue importTx0A: %s", err)
 	}
 
@@ -1394,7 +1394,7 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatalf("Failed to issue importTx1 due to: %s", err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx1); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx1); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1413,11 +1413,11 @@ func TestConflictingTransitiveAncestryWithGap(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx0B); err == nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx0B); err == nil {
 		t.Fatalf("Should not have been able to issue import tx with conflict")
 	}
 	// Force issue transaction directly into the mempool
-	if err := tvm.vm.mempool.ForceAddTx(importTx0B); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(importTx0B); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -1475,7 +1475,7 @@ func TestBonusBlocksTxs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1563,7 +1563,7 @@ func TestReorgProtection(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1733,7 +1733,7 @@ func TestNonCanonicalAccept(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -1930,7 +1930,7 @@ func TestStickyPreference(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2190,7 +2190,7 @@ func TestUncleBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2361,7 +2361,7 @@ func TestEmptyBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2444,7 +2444,7 @@ func TestAcceptReorg(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm1.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2631,7 +2631,7 @@ func TestFutureBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2700,7 +2700,7 @@ func TestBuildApricotPhase1Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2807,7 +2807,7 @@ func TestLastAcceptedBlockNumberAllow(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2884,7 +2884,7 @@ func TestReissueAtomicTx(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -2970,7 +2970,7 @@ func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {
 	exportTxs := createExportTxOptions(t, tvm.vm, tvm.toEngine, tvm.atomicMemory)
 	exportTx1, exportTx2 := exportTxs[0], exportTxs[1]
 
-	if err := tvm.vm.mempool.AddLocalTx(exportTx1); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx1); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -2986,16 +2986,16 @@ func TestAtomicTxFailsEVMStateTransferBuildBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(exportTx2); err == nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(exportTx2); err == nil {
 		t.Fatal("Should have failed to issue due to an invalid export tx")
 	}
 
-	if err := tvm.vm.mempool.AddRemoteTx(exportTx2); err == nil {
+	if err := tvm.vm.atomicVM.Mempool.AddRemoteTx(exportTx2); err == nil {
 		t.Fatal("Should have failed to add because conflicting")
 	}
 
 	// Manually add transaction to mempool to bypass validation
-	if err := tvm.vm.mempool.ForceAddTx(exportTx2); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(exportTx2); err != nil {
 		t.Fatal(err)
 	}
 	<-tvm.toEngine
@@ -3051,11 +3051,11 @@ func TestBuildInvalidBlockHead(t *testing.T) {
 
 	// Verify that the transaction fails verification when attempting to issue
 	// it into the atomic mempool.
-	if err := tvm.vm.mempool.AddLocalTx(tx); err == nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(tx); err == nil {
 		t.Fatal("Should have failed to issue invalid transaction")
 	}
 	// Force issue the transaction directly to the mempool
-	if err := tvm.vm.mempool.ForceAddTx(tx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.ForceAddTx(tx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3127,7 +3127,7 @@ func TestBuildApricotPhase4Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3299,7 +3299,7 @@ func TestBuildApricotPhase5Block(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3429,7 +3429,7 @@ func TestConsecutiveAtomicTransactionsRevertSnapshot(t *testing.T) {
 	importTxs := createImportTxOptions(t, tvm.vm, tvm.atomicMemory)
 
 	// Issue the first import transaction, build, and accept the block.
-	if err := tvm.vm.mempool.AddLocalTx(importTxs[0]); err != nil {
+	if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTxs[0]); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3459,8 +3459,8 @@ func TestConsecutiveAtomicTransactionsRevertSnapshot(t *testing.T) {
 
 	// Add the two conflicting transactions directly to the mempool, so that two consecutive transactions
 	// will fail verification when build block is called.
-	tvm.vm.mempool.AddRemoteTx(importTxs[1])
-	tvm.vm.mempool.AddRemoteTx(importTxs[2])
+	tvm.vm.atomicVM.Mempool.AddRemoteTx(importTxs[1])
+	tvm.vm.atomicVM.Mempool.AddRemoteTx(importTxs[2])
 
 	if _, err := tvm.vm.BuildBlock(context.Background()); err == nil {
 		t.Fatal("Expected build block to fail due to empty block")
@@ -3492,7 +3492,7 @@ func TestAtomicTxBuildBlockDropsConflicts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 			t.Fatal(err)
 		}
 		conflictSets[index].Add(importTx.ID())
@@ -3500,11 +3500,11 @@ func TestAtomicTxBuildBlockDropsConflicts(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.mempool.AddLocalTx(conflictTx); err == nil {
+		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(conflictTx); err == nil {
 			t.Fatal("should conflict with the utxoSet in the mempool")
 		}
 		// force add the tx
-		tvm.vm.mempool.ForceAddTx(conflictTx)
+		tvm.vm.atomicVM.Mempool.ForceAddTx(conflictTx)
 		conflictSets[index].Add(conflictTx.ID())
 	}
 	<-tvm.toEngine
@@ -3563,7 +3563,7 @@ func TestBuildBlockDoesNotExceedAtomicGasLimit(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+		if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -3627,7 +3627,7 @@ func TestExtraStateChangeAtomicGasLimitExceeded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if err := tvm1.vm.mempool.ForceAddTx(importTx); err != nil {
+	if err := tvm1.vm.atomicVM.Mempool.ForceAddTx(importTx); err != nil {
 		t.Fatal(err)
 	}
 
@@ -3685,7 +3685,7 @@ func TestSkipChainConfigCheckCompatible(t *testing.T) {
 	// accept one block to test the SkipUpgradeCheck functionality.
 	importTx, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(t, err)
-	require.NoError(t, tvm.vm.mempool.AddLocalTx(importTx))
+	require.NoError(t, tvm.vm.atomicVM.Mempool.AddLocalTx(importTx))
 	<-tvm.toEngine
 
 	blk, err := tvm.vm.BuildBlock(context.Background())
@@ -3792,7 +3792,7 @@ func TestParentBeaconRootBlock(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if err := tvm.vm.mempool.AddLocalTx(importTx); err != nil {
+			if err := tvm.vm.atomicVM.Mempool.AddLocalTx(importTx); err != nil {
 				t.Fatal(err)
 			}
 
@@ -3977,11 +3977,11 @@ func TestBuildBlockLargeTxStarvation(t *testing.T) {
 
 	importTx1, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[0], initialBaseFee, []*secp256k1.PrivateKey{testKeys[0]})
 	require.NoError(err)
-	require.NoError(tvm.vm.mempool.AddLocalTx(importTx1))
+	require.NoError(tvm.vm.atomicVM.Mempool.AddLocalTx(importTx1))
 
 	importTx2, err := tvm.vm.newImportTx(tvm.vm.ctx.XChainID, testEthAddrs[1], initialBaseFee, []*secp256k1.PrivateKey{testKeys[1]})
 	require.NoError(err)
-	require.NoError(tvm.vm.mempool.AddLocalTx(importTx2))
+	require.NoError(tvm.vm.atomicVM.Mempool.AddLocalTx(importTx2))
 
 	<-tvm.toEngine
 	blk1, err := tvm.vm.BuildBlock(ctx)

--- a/plugin/evm/vmerrors/errors.go
+++ b/plugin/evm/vmerrors/errors.go
@@ -1,0 +1,12 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package vmerrors
+
+import "errors"
+
+var (
+	ErrGenerateBlockFailed     = errors.New("failed to generate block")
+	ErrBlockVerificationFailed = errors.New("failed to verify block")
+	ErrWrapBlockFailed         = errors.New("failed to wrap block")
+)


### PR DESCRIPTION
## Why this should be merged

Moves atomic mempool and gossip handler to atomic vm

## How this works

This pull request introduces significant changes to the `plugin/evm` module, focusing on refactoring the `Mempool` implementation, improving atomic transaction handling, and enhancing gossip protocols for atomic transactions. The most important changes include replacing the `NewMempool` constructor with an `Initialize` method, updating `Mempool` usage across the codebase, introducing gossip handlers for atomic transactions, and restructuring the VM initialization process.

### Mempool Refactoring:
* Replaced the `NewMempool` constructor with an `Initialize` method for better flexibility in instantiation. Updated all instances of `NewMempool` to use the new `Initialize` method. (`plugin/evm/atomic/txpool/mempool.go`, `plugin/evm/atomic/txpool/mempool_test.go`) [[1]](diffhunk://#diff-d615e06b8befc5add8456ee51bc23436353863caeb0e87f79ecae9e002033b22L88-R115) [[2]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6R19-R21) [[3]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6R43-R45) [[4]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L108-R109) [[5]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L139-R140) [[6]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L163-R171)

### VM Enhancements:
* Added a `Mempool` field to the `VM` struct and updated the VM initialization process to initialize the `Mempool` with default settings. (`plugin/evm/atomic/vm/vm.go`) [[1]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449R92) [[2]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L124-R165) [[3]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449R187-R192)
* Replaced the `AtomicMempool` method with direct usage of the new `Mempool` field across the VM implementation. (`plugin/evm/atomic/vm/vm.go`) [[1]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L66-L68) [[2]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L333-R496) [[3]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L343-R509)

### Atomic Transaction Gossip:
* Introduced gossip handlers, including `AtomicTxPushGossiper` and `AtomicTxPullGossiper`, for efficient dissemination of atomic transactions. Added initialization logic for these gossip components in the VM's `onNormalOperationsStarted` method. (`plugin/evm/atomic/vm/vm.go`)

### Code Cleanup:
* Removed redundant methods and fields, such as `AtomicMempool()` from the `InnerVM` interface, and replaced outdated imports with updated ones. (`plugin/evm/atomic/vm/vm.go`) [[1]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L66-L68) [[2]](diffhunk://#diff-26a9954b366b563cb620189ad070df2b73b355692248686a6b86487fba21b449L32-R46)
* Renamed variables and adjusted error handling for consistency across the codebase. (`plugin/evm/atomic/vm/block_extension.go`, `plugin/evm/atomic/vm/vm.go`) [[1]](diffhunk://#diff-0348c8819036dea33c9b8c16c611565b3db549bcb9d99b191970cc5c216a6482L197-R197) [[2]](diffhunk://#diff-0348c8819036dea33c9b8c16c611565b3db549bcb9d99b191970cc5c216a6482L217-R218) [[3]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L54-R54) [[4]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L153-R153) [[5]](diffhunk://#diff-47eccd10420e839a22b6dd7a0e36756f9167f5a51514c8c9658c55cfc0e0b4c6L163-R171)

These changes collectively improve the modularity, scalability, and maintainability of the `plugin/evm` module, particularly in handling atomic transactions and gossip protocols.

## How this was tested

Existing tests

## Need to be documented?

No

## Need to update RELEASES.md?

No
