### PR TITLE
fix(core/txpool): demote error log to warn

### DIFF
--- a/core/txpool/legacypool/legacypool.go
+++ b/core/txpool/legacypool/legacypool.go
@@ -1761,7 +1761,7 @@ func (pool *LegacyPool) demoteUnexecutables() {
 			gapped := list.Cap(0)
 			for _, tx := range gapped {
 				hash := tx.Hash()
-				log.Error("Demoting invalidated transaction", "hash", hash)
+				log.Warn("Demoting invalidated transaction", "hash", hash)
 
 				// Internal shuffle shouldn't touch the lookup set.
 				pool.enqueueTx(hash, tx, false, false)


### PR DESCRIPTION
## Why this should be merged

Extraneous error log causing unnecessary pages. Cherry-picks ethereum/go-ethereum#31332

## How this works

This error log in `legacypool.go` isn't necessary, since even though the behavior is unexpected, it is handled correctly. A discussion on issue ethereum/go-ethereum#22301 concluded that this should instead be a warning log.

## How this was tested

N/A

## Need to be documented?

No

## Need to update RELEASES.md?

Yes
