### PR TITLE
feat: enable blockchain ops and tests

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,7 @@
 - Moves atomic operations from plugin/evm to plugin/evm/atomic and wraps the plugin/evm/VM in `atomicvm` to separate the atomic operations from the EVM execution.
 - Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior.
 - Removed the `snowman-api-enabled` flag and the corresponding API implementation.
+- Enable expermiental `state-scheme` flag to specify Firewood as a state database.
 
 ## [v0.15.1](https://github.com/ava-labs/coreth/releases/tag/v0.15.1)
 
@@ -37,6 +38,7 @@
 - Refactored trie_prefetcher.go to be structurally similar to [upstream](https://github.com/ethereum/go-ethereum/tree/v1.13.14).
 
 ## [v0.14.0](https://github.com/ava-labs/coreth/releases/tag/v0.14.0)
+
 - Minor version update to correspond to avalanchego v1.12.0 / Etna.
 - Remove unused historical opcodes CALLEX, BALANCEMC
 - Remove unused pre-AP2 handling of genesis contract
@@ -45,6 +47,7 @@
 - Update go version to 1.22
 
 ## [v0.13.8](https://github.com/ava-labs/coreth/releases/tag/v0.13.8)
+
 - Update geth dependency to v1.13.14
 - eupgrade: lowering the base fee to 1 nAVAX
 - eupgrade/cancun: verify no blobs in header
@@ -53,6 +56,7 @@
 - Remove cross-chain handlers
 
 ## [v0.13.7](https://github.com/ava-labs/coreth/releases/tag/v0.13.7)
+
 - Add EUpgrade base definitions
 - Remove Block Status
 - Fix and improve "GetBlockIDAtHeight"
@@ -60,11 +64,13 @@
 - Bump AvalancheGo to v1.11.10-prerelease
 
 ## [v0.13.6](https://github.com/ava-labs/coreth/releases/tag/v0.13.6)
+
 - rpc: truncate call error data logs
 - logging: remove path prefix (up to coreth@version/) from logged file names.
 - cleanup: removes pre-Durango scripts
 
 ## [v0.13.5](https://github.com/ava-labs/coreth/releases/tag/v0.13.5)
+
 - Bump AvalancheGo to v1.11.7
 - Bump golang version requirement to 1.21.12
 - Switches timestamp log back to "timestamp" (as was before v0.13.4)
@@ -73,6 +79,7 @@
 - Fix state sync crash bug
 
 ## [v0.13.4](https://github.com/ava-labs/coreth/releases/tag/v0.13.4)
+
 - Fixes snapshot use when state sync was explicitly enabled
 - Fixes v0.13.3 locking regression in async snapshot generation
 - Update go-ethereum to v1.13.8
@@ -81,6 +88,7 @@
 - "timestamp" in logs is changed to "t"
 
 ## [v0.13.3](https://github.com/ava-labs/coreth/releases/tag/v0.13.3)
+
 - Update go-ethereum to v1.13.2
 - Bump AvalancheGo to v1.11.5
 - Bump golang version requirement to 1.21.9
@@ -89,6 +97,7 @@
 - Testing improvements
 
 ## [v0.13.2](https://github.com/ava-labs/coreth/releases/tag/v0.13.2)
+
 - Integrate stake weighted gossip selection
 - Update go-ethereum to v1.12.2
 - Force precompile modules registration in ethclient

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -223,6 +223,10 @@ func (c *CacheConfig) triedbConfig() *triedb.Config {
 		}.BackendConstructor
 	}
 	if c.StateScheme == customrawdb.FirewoodScheme {
+		// ChainDataDir may not be set during some tests, where this path won't be called.
+		if c.ChainDataDir == "" {
+			log.Crit("Chain data directory must be specified for Firewood")
+		}
 		config.DBOverride = firewood.Config{
 			FilePath:             filepath.Join(c.ChainDataDir, "firewood_state"),
 			CleanCacheSize:       c.TrieCleanLimit * 1024 * 1024,

--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -175,6 +175,9 @@ const (
 	// trieCleanCacheStatsNamespace is the namespace to surface stats from the trie
 	// clean cache's underlying fastcache.
 	trieCleanCacheStatsNamespace = "hashdb/memcache/clean/fastcache"
+
+	// firewoodPath fixes the name of the firewood database file.
+	firewoodPath = "firewood_state"
 )
 
 // CacheConfig contains the configuration values for the trie database
@@ -228,7 +231,7 @@ func (c *CacheConfig) triedbConfig() *triedb.Config {
 			log.Crit("Chain data directory must be specified for Firewood")
 		}
 		config.DBOverride = firewood.Config{
-			FilePath:             filepath.Join(c.ChainDataDir, "firewood_state"),
+			FilePath:             filepath.Join(c.ChainDataDir, firewoodPath),
 			CleanCacheSize:       c.TrieCleanLimit * 1024 * 1024,
 			FreeListCacheEntries: firewood.Defaults.FreeListCacheEntries,
 			Revisions:            uint(c.StateHistory), // must be at least 2

--- a/core/blockchain_ext_test.go
+++ b/core/blockchain_ext_test.go
@@ -160,6 +160,7 @@ func checkBlockChainState(
 		t.Fatalf("Check state failed for original blockchain due to: %s", err)
 	}
 
+	// Firewood needs a new directory to force the creation of a new database.
 	extraCfg := params.GetExtra(gspec.Config)
 	oldPath := extraCfg.SnowCtx.ChainDataDir
 	newPath := t.TempDir()

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -506,8 +507,10 @@ func testLongReorgedDeepRepair(t *testing.T, snapshots bool) {
 }
 
 func testRepair(t *testing.T, tt *rewindTest, snapshots bool) {
-	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme} {
-		testRepairWithScheme(t, tt, snapshots, scheme)
+	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme, customrawdb.FirewoodScheme} {
+		t.Run(scheme, func(t *testing.T) {
+			testRepairWithScheme(t, tt, snapshots, scheme)
+		})
 	}
 }
 
@@ -515,6 +518,10 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	// It's hard to follow the test case, visualize the input
 	//log.Root().SetHandler(log.LvlFilterHandler(log.LvlTrace, log.StreamHandler(os.Stderr, log.TerminalFormat(true))))
 	// fmt.Println(tt.dump(true))
+
+	if scheme == customrawdb.FirewoodScheme && snapshots {
+		t.Skip("Firewood scheme does not support snapshots")
+	}
 
 	// Create a temporary persistent database
 	datadir := t.TempDir()
@@ -547,6 +554,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 			SnapshotLimit:             0, // Disable snapshot by default
 			StateHistory:              32,
 			StateScheme:               scheme,
+			ChainDataDir:              datadir,
 		}
 	)
 	defer engine.Close()
@@ -620,6 +628,7 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	}
 	defer db.Close()
 
+	// Note this uses the same config, so it will find the same firewood instance if necessary
 	newChain, err := NewBlockChain(db, config, gspec, engine, vm.Config{}, lastAcceptedHash, false)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)

--- a/core/blockchain_repair_test.go
+++ b/core/blockchain_repair_test.go
@@ -628,7 +628,6 @@ func testRepairWithScheme(t *testing.T, tt *rewindTest, snapshots bool, scheme s
 	}
 	defer db.Close()
 
-	// Note this uses the same config, so it will find the same firewood instance if necessary
 	newChain, err := NewBlockChain(db, config, gspec, engine, vm.Config{}, lastAcceptedHash, false)
 	if err != nil {
 		t.Fatalf("Failed to recreate chain: %v", err)

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -72,6 +72,9 @@ var (
 		SnapshotLimit:             256,
 		AcceptorQueueLimit:        64,
 	}
+
+	// Note that Firewood should only be included for non-archive, snapshot disabled tests.
+	schemes = []string{rawdb.HashScheme, customrawdb.FirewoodScheme}
 )
 
 func newGwei(n int64) *big.Int {
@@ -144,6 +147,14 @@ func TestPruningBlockChain(t *testing.T) {
 }
 
 func TestPruningBlockChainSnapsDisabled(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testPruningBlockChainSnapsDisabled(t, scheme)
+		})
+	}
+}
+
+func testPruningBlockChainSnapsDisabled(t *testing.T, scheme string) {
 	create := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
 		return createBlockChain(
 			db,
@@ -157,6 +168,8 @@ func TestPruningBlockChainSnapsDisabled(t *testing.T) {
 				StateHistory:              32,
 				SnapshotLimit:             0, // Disable snapshots
 				AcceptorQueueLimit:        64,
+				StateScheme:               scheme,
+				ChainDataDir:              params.GetExtra(gspec.Config).SnowCtx.ChainDataDir,
 			},
 			gspec,
 			lastAcceptedHash,
@@ -195,7 +208,17 @@ func TestPruningBlockChainUngracefulShutdown(t *testing.T) {
 }
 
 func TestPruningBlockChainUngracefulShutdownSnapsDisabled(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testPruningBlockChainUngracefulShutdownSnapsDisabled(t, scheme)
+		})
+	}
+}
+
+func testPruningBlockChainUngracefulShutdownSnapsDisabled(t *testing.T, scheme string) {
 	create := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
+		// If no database path has been persisted, set the path to a temporary test directory.
+		// Otherwise, make sure not to overwrite so that it re-uses any existing database.
 		blockchain, err := createBlockChain(
 			db,
 			&CacheConfig{
@@ -208,6 +231,8 @@ func TestPruningBlockChainUngracefulShutdownSnapsDisabled(t *testing.T) {
 				StateHistory:              32,
 				SnapshotLimit:             0, // Disable snapshots
 				AcceptorQueueLimit:        64,
+				StateScheme:               scheme,
+				ChainDataDir:              params.GetExtra(gspec.Config).SnowCtx.ChainDataDir,
 			},
 			gspec,
 			lastAcceptedHash,
@@ -245,6 +270,7 @@ func TestEnableSnapshots(t *testing.T) {
 				StateHistory:              32,
 				SnapshotLimit:             snapLimit,
 				AcceptorQueueLimit:        64,
+				ChainDataDir:              params.GetExtra(gspec.Config).SnowCtx.ChainDataDir,
 			},
 			gspec,
 			lastAcceptedHash,
@@ -423,20 +449,43 @@ func TestRepopulateMissingTries(t *testing.T) {
 }
 
 func TestUngracefulAsyncShutdown(t *testing.T) {
+	testUngracefulAsyncShutdown(t, rawdb.HashScheme, &CacheConfig{
+		TrieCleanLimit:            256,
+		TrieDirtyLimit:            256,
+		TrieDirtyCommitTarget:     20,
+		TriePrefetcherParallelism: 4,
+		Pruning:                   true,
+		CommitInterval:            4096,
+		SnapshotLimit:             256,
+		SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
+		AcceptorQueueLimit:        1000, // ensure channel doesn't block
+		StateHistory:              32,
+	})
+}
+
+func TestUngracefulAsyncShutdownSnapsDisabled(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testUngracefulAsyncShutdown(t, scheme, &CacheConfig{
+				TrieCleanLimit:        256,
+				TrieDirtyLimit:        256,
+				TrieDirtyCommitTarget: 20,
+				Pruning:               true,
+				CommitInterval:        4096,
+				SnapshotLimit:         0,
+				AcceptorQueueLimit:    1000, // ensure channel doesn't block
+				StateScheme:           scheme,
+				StateHistory:          32,
+			})
+		})
+	}
+}
+
+func testUngracefulAsyncShutdown(t *testing.T, scheme string, cacheConfig *CacheConfig) {
 	var (
 		create = func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
-			blockchain, err := createBlockChain(db, &CacheConfig{
-				TrieCleanLimit:            256,
-				TrieDirtyLimit:            256,
-				TrieDirtyCommitTarget:     20,
-				TriePrefetcherParallelism: 4,
-				Pruning:                   true,
-				CommitInterval:            4096,
-				StateHistory:              32,
-				SnapshotLimit:             256,
-				SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
-				AcceptorQueueLimit:        1000, // ensure channel doesn't block
-			}, gspec, lastAcceptedHash)
+			cacheConfig.ChainDataDir = params.GetExtra(gspec.Config).SnowCtx.ChainDataDir
+			blockchain, err := createBlockChain(db, cacheConfig, gspec, lastAcceptedHash)
 			if err != nil {
 				return nil, err
 			}
@@ -452,8 +501,10 @@ func TestUngracefulAsyncShutdown(t *testing.T) {
 
 	// Ensure that key1 has some funds in the genesis block.
 	genesisBalance := big.NewInt(1000000)
+	config := &params.ChainConfig{HomesteadBlock: new(big.Int)}
+	addDir(config, t.TempDir())
 	gspec := &Genesis{
-		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Config: config,
 		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
 	}
 
@@ -552,7 +603,7 @@ func TestUngracefulAsyncShutdown(t *testing.T) {
 	allTxs := append(foundTxs, missingTxs...)
 	for _, bc := range []*BlockChain{newChain, restartedChain} {
 		// We should confirm that snapshots were properly initialized
-		if bc.snaps == nil {
+		if bc.snaps == nil && bc.cacheConfig.SnapshotLimit > 0 {
 			t.Fatal("snapshot initialization failed")
 		}
 
@@ -566,11 +617,126 @@ func TestUngracefulAsyncShutdown(t *testing.T) {
 	}
 }
 
+// The `TestEmptyBlocks` test ensures that the blockchain can handle eth blocks
+// that are empty, but they still contain atomic txs.
+func TestCompletelyEmptyBlocks(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testCompletelyEmptyBlocks(t, scheme)
+		})
+	}
+}
+
+func testCompletelyEmptyBlocks(t *testing.T, scheme string) {
+	var (
+		create = func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
+			cacheConfig := &CacheConfig{
+				TrieCleanLimit:            256,
+				TrieDirtyLimit:            256,
+				TrieDirtyCommitTarget:     20,
+				TriePrefetcherParallelism: 4,
+				Pruning:                   true,
+				CommitInterval:            4096,
+				SnapshotLimit:             0, // Disable snapshots
+				AcceptorQueueLimit:        64,
+				StateScheme:               scheme,
+				StateHistory:              32,
+				ChainDataDir:              params.GetExtra(gspec.Config).SnowCtx.ChainDataDir,
+			}
+			blockchain, err := NewBlockChain(
+				db,
+				cacheConfig,
+				gspec,
+				dummy.NewFakerWithCallbacks(TestEmptyCallbacks),
+				vm.Config{},
+				lastAcceptedHash,
+				false,
+			)
+			if err != nil {
+				return nil, err
+			}
+			return blockchain, nil
+		}
+
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB = rawdb.NewMemoryDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	genesisBalance := big.NewInt(1000000000)
+	config := &params.ChainConfig{HomesteadBlock: new(big.Int)}
+	addDir(config, t.TempDir())
+	gspec := &Genesis{
+		Config: config,
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+	}
+
+	blockchain, err := create(chainDB, gspec, common.Hash{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 5, 10, func(i int, gen *BlockGen) {
+		if i == 3 {
+			// Generate a transaction to create a unique block
+			tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), types.HomesteadSigner{}, key1)
+			gen.AddTx(tx)
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert three blocks into the chain and accept only the first block.
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		t.Fatal(err)
+	}
+	for _, block := range chain {
+		if err := blockchain.Accept(block); err != nil {
+			t.Fatal(err)
+		}
+	}
+	blockchain.DrainAcceptorQueue()
+
+	// We expect results from block 3
+	checkState := func(sdb *state.StateDB) error {
+		nonce1 := sdb.GetNonce(addr1)
+		if nonce1 != 1 {
+			return fmt.Errorf("expected addr1 nonce: 3, found nonce: %d", nonce1)
+		}
+		balance1 := sdb.GetBalance(addr1)
+		transferredFunds := uint256.NewInt(10000)
+		genesisBalance := uint256.MustFromBig(genesisBalance)
+		expectedBalance := new(uint256.Int).Sub(genesisBalance, transferredFunds)
+		if balance1.Cmp(expectedBalance) != 0 {
+			return fmt.Errorf("expected balance1: %d, found balance: %d", expectedBalance, balance1)
+		}
+		nonce2 := sdb.GetNonce(addr2)
+		if nonce2 != 0 {
+			return fmt.Errorf("expected addr2 nonce: 0, found nonce %d", nonce2)
+		}
+		balance2 := sdb.GetBalance(addr2)
+		if balance2.Cmp(transferredFunds) != 0 {
+			return fmt.Errorf("expected balance2: %d, found %d", transferredFunds, balance2)
+		}
+		return nil
+	}
+
+	checkBlockChainState(t, blockchain, gspec, chainDB, create, checkState)
+}
+
 // TestCanonicalHashMarker tests all the canonical hash markers are updated/deleted
 // correctly in case reorg is called.
 func TestCanonicalHashMarker(t *testing.T) {
-	testCanonicalHashMarker(t, rawdb.HashScheme)
-	testCanonicalHashMarker(t, rawdb.PathScheme)
+	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme, customrawdb.FirewoodScheme} {
+		t.Run(scheme, func(t *testing.T) {
+			testCanonicalHashMarker(t, scheme)
+		})
+	}
 }
 
 func testCanonicalHashMarker(t *testing.T, scheme string) {
@@ -627,7 +793,10 @@ func testCanonicalHashMarker(t *testing.T, scheme string) {
 		}
 
 		// Initialize test chain
-		chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), DefaultCacheConfigWithScheme(scheme), gspec, engine, vm.Config{}, common.Hash{}, false)
+		db := rawdb.NewMemoryDatabase()
+		cacheConfig := DefaultCacheConfigWithScheme(scheme)
+		cacheConfig.ChainDataDir = t.TempDir()
+		chain, err := NewBlockChain(db, cacheConfig, gspec, engine, vm.Config{}, common.Hash{}, false)
 		if err != nil {
 			t.Fatalf("failed to create tester chain: %v", err)
 		}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -73,7 +73,7 @@ var (
 		AcceptorQueueLimit:        64,
 	}
 
-	// Note that Firewood should only be included for non-archive, snapshot disabled tests.
+	// Firewood should only be included for non-archive, snapshot disabled tests.
 	schemes = []string{rawdb.HashScheme, customrawdb.FirewoodScheme}
 )
 
@@ -617,7 +617,9 @@ func testUngracefulAsyncShutdown(t *testing.T, scheme string, cacheConfig *Cache
 	}
 }
 
-// The `TestEmptyBlocks` test ensures that the blockchain can handle eth blocks
+// TestCompletelyEmptyBlocks tests that the blockchain correctly handles successive
+// duplicate state roots with no txs.
+// The other `TestEmptyBlocks` test ensures that the blockchain can handle eth blocks
 // that are empty, but they still contain atomic txs.
 func TestCompletelyEmptyBlocks(t *testing.T) {
 	for _, scheme := range schemes {

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/libevm/stateconf"
 	"github.com/ava-labs/libevm/log"
 	"github.com/ava-labs/libevm/trie"
 	"github.com/ava-labs/libevm/triedb"
@@ -299,7 +300,11 @@ func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Blo
 		}
 	}
 
-	if _, err := statedb.Commit(0, false); err != nil {
+	// Create the genesis block to use the block hash
+	block := types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil))
+	triedbOpt := stateconf.WithTrieDBUpdatePayload(common.Hash{}, block.Hash())
+
+	if _, err := statedb.Commit(0, false, stateconf.WithTrieDBUpdateOpts(triedbOpt)); err != nil {
 		panic(fmt.Sprintf("unable to commit genesis block to statedb: %v", err))
 	}
 	// Commit newly generated states into disk if it's not empty.
@@ -308,7 +313,7 @@ func (g *Genesis) toBlock(db ethdb.Database, triedb *triedb.Database) *types.Blo
 			panic(fmt.Sprintf("unable to commit genesis block: %v", err))
 		}
 	}
-	return types.NewBlock(head, nil, nil, nil, trie.NewStackTrie(nil))
+	return block
 }
 
 // Commit writes the block and state of a genesis specification to the database.

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -30,15 +30,19 @@ package core
 import (
 	"bytes"
 	_ "embed"
+	"fmt"
 	"math/big"
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/params/extras"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 	"github.com/ava-labs/coreth/precompile/contracts/warp"
+	"github.com/ava-labs/coreth/triedb/firewood"
 	"github.com/ava-labs/coreth/triedb/pathdb"
 	"github.com/ava-labs/coreth/utils"
 	"github.com/ava-labs/libevm/common"
@@ -66,8 +70,11 @@ func TestGenesisBlockForTesting(t *testing.T) {
 }
 
 func TestSetupGenesis(t *testing.T) {
-	testSetupGenesis(t, rawdb.HashScheme)
-	testSetupGenesis(t, rawdb.PathScheme)
+	for _, scheme := range []string{rawdb.HashScheme, rawdb.PathScheme, customrawdb.FirewoodScheme} {
+		t.Run(scheme, func(t *testing.T) {
+			testSetupGenesis(t, scheme)
+		})
+	}
 }
 
 func testSetupGenesis(t *testing.T, scheme string) {
@@ -97,7 +104,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "genesis without ChainConfig",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(scheme)), new(Genesis), common.Hash{})
+				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, db, scheme)), new(Genesis), common.Hash{})
 			},
 			wantErr:    errGenesisNoConfig,
 			wantConfig: nil,
@@ -105,7 +112,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "no block in DB, genesis == nil",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(scheme)), nil, common.Hash{})
+				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, db, scheme)), nil, common.Hash{})
 			},
 			wantErr:    ErrNoGenesis,
 			wantConfig: nil,
@@ -113,7 +120,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "custom block in DB, genesis == nil",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				tdb := triedb.NewDatabase(db, newDbConfig(scheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, db, scheme))
 				customg.Commit(db, tdb)
 				return setupGenesisBlock(db, tdb, nil, common.Hash{})
 			},
@@ -123,7 +130,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "compatible config in DB",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				tdb := triedb.NewDatabase(db, newDbConfig(scheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, db, scheme))
 				oldcustomg.Commit(db, tdb)
 				return setupGenesisBlock(db, tdb, &customg, customghash)
 			},
@@ -135,13 +142,19 @@ func testSetupGenesis(t *testing.T, scheme string) {
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
 				// Commit the 'old' genesis block with ApricotPhase1 transition at 90.
 				// Advance to block #4, past the ApricotPhase1 transition block of customg.
-				tdb := triedb.NewDatabase(db, newDbConfig(scheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, db, rawdb.HashScheme))
 				genesis, err := oldcustomg.Commit(db, tdb)
 				if err != nil {
 					t.Fatal(err)
 				}
+				tdb.Close()
 
-				bc, _ := NewBlockChain(db, DefaultCacheConfigWithScheme(scheme), &oldcustomg, dummy.NewFullFaker(), vm.Config{}, genesis.Hash(), false)
+				cacheConfig := DefaultCacheConfigWithScheme(scheme)
+				cacheConfig.ChainDataDir = t.TempDir()
+				bc, err := NewBlockChain(db, cacheConfig, &oldcustomg, dummy.NewFullFaker(), vm.Config{}, genesis.Hash(), false)
+				if err != nil {
+					t.Fatal(err)
+				}
 				defer bc.Stop()
 
 				_, blocks, _, err := GenerateChainWithGenesis(&oldcustomg, dummy.NewFullFaker(), 4, 25, nil)
@@ -157,7 +170,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 				}
 
 				// This should return a compatibility error.
-				return setupGenesisBlock(db, tdb, &customg, bc.lastAccepted.Hash())
+				return setupGenesisBlock(db, bc.TrieDB(), &customg, bc.lastAccepted.Hash())
 			},
 			wantHash:   customghash,
 			wantConfig: customg.Config,
@@ -171,7 +184,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 	}
 
 	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s %s", test.name, scheme), func(t *testing.T) {
 			db := rawdb.NewMemoryDatabase()
 			config, hash, err := test.fn(db)
 			// Check the return values.
@@ -285,11 +298,21 @@ func TestGenesisWriteUpgradesRegression(t *testing.T) {
 	require.NoError(err)
 }
 
-func newDbConfig(scheme string) *triedb.Config {
-	if scheme == rawdb.HashScheme {
+func newDbConfig(t *testing.T, db ethdb.Database, scheme string) *triedb.Config {
+	switch scheme {
+	case rawdb.HashScheme:
 		return triedb.HashDefaults
+	case rawdb.PathScheme:
+		return &triedb.Config{DBOverride: pathdb.Defaults.BackendConstructor}
+	case customrawdb.FirewoodScheme:
+		fwCfg := firewood.Defaults
+		// Create a unique temporary directory for each test
+		fwCfg.FilePath = filepath.Join(t.TempDir(), "firewood_state") // matches blockchain.go
+		return &triedb.Config{DBOverride: fwCfg.BackendConstructor}
+	default:
+		t.Fatalf("unknown scheme %s", scheme)
 	}
-	return &triedb.Config{DBOverride: pathdb.Defaults.BackendConstructor}
+	return nil
 }
 
 func TestVerkleGenesisCommit(t *testing.T) {

--- a/core/genesis_test.go
+++ b/core/genesis_test.go
@@ -104,7 +104,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "genesis without ChainConfig",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, db, scheme)), new(Genesis), common.Hash{})
+				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, scheme)), new(Genesis), common.Hash{})
 			},
 			wantErr:    errGenesisNoConfig,
 			wantConfig: nil,
@@ -112,7 +112,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "no block in DB, genesis == nil",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, db, scheme)), nil, common.Hash{})
+				return setupGenesisBlock(db, triedb.NewDatabase(db, newDbConfig(t, scheme)), nil, common.Hash{})
 			},
 			wantErr:    ErrNoGenesis,
 			wantConfig: nil,
@@ -120,7 +120,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "custom block in DB, genesis == nil",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				tdb := triedb.NewDatabase(db, newDbConfig(t, db, scheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, scheme))
 				customg.Commit(db, tdb)
 				return setupGenesisBlock(db, tdb, nil, common.Hash{})
 			},
@@ -130,7 +130,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 		{
 			name: "compatible config in DB",
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
-				tdb := triedb.NewDatabase(db, newDbConfig(t, db, scheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, scheme))
 				oldcustomg.Commit(db, tdb)
 				return setupGenesisBlock(db, tdb, &customg, customghash)
 			},
@@ -142,7 +142,7 @@ func testSetupGenesis(t *testing.T, scheme string) {
 			fn: func(db ethdb.Database) (*params.ChainConfig, common.Hash, error) {
 				// Commit the 'old' genesis block with ApricotPhase1 transition at 90.
 				// Advance to block #4, past the ApricotPhase1 transition block of customg.
-				tdb := triedb.NewDatabase(db, newDbConfig(t, db, rawdb.HashScheme))
+				tdb := triedb.NewDatabase(db, newDbConfig(t, rawdb.HashScheme))
 				genesis, err := oldcustomg.Commit(db, tdb)
 				if err != nil {
 					t.Fatal(err)
@@ -298,7 +298,7 @@ func TestGenesisWriteUpgradesRegression(t *testing.T) {
 	require.NoError(err)
 }
 
-func newDbConfig(t *testing.T, db ethdb.Database, scheme string) *triedb.Config {
+func newDbConfig(t *testing.T, scheme string) *triedb.Config {
 	switch scheme {
 	case rawdb.HashScheme:
 		return triedb.HashDefaults

--- a/core/state_manager.go
+++ b/core/state_manager.go
@@ -65,7 +65,7 @@ type TrieDB interface {
 }
 
 func NewTrieWriter(db TrieDB, config *CacheConfig) TrieWriter {
-	// Firewood doesn't require explicit pruning.
+	// Firewood should only be used in pruning mode, but we shouldn't explicitly manage this.
 	if config.Pruning && config.StateScheme != customrawdb.FirewoodScheme {
 		cm := &cappedMemoryTrieWriter{
 			TrieDB:           db,

--- a/core/state_manager.go
+++ b/core/state_manager.go
@@ -32,6 +32,7 @@ import (
 	"math/rand"
 	"time"
 
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
@@ -64,7 +65,8 @@ type TrieDB interface {
 }
 
 func NewTrieWriter(db TrieDB, config *CacheConfig) TrieWriter {
-	if config.Pruning {
+	// Firewood doesn't require explicit pruning.
+	if config.Pruning && config.StateScheme != customrawdb.FirewoodScheme {
 		cm := &cappedMemoryTrieWriter{
 			TrieDB:           db,
 			memoryCap:        common.StorageSize(config.TrieDirtyLimit) * 1024 * 1024,

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -202,6 +202,13 @@ func New(
 			rawdb.WriteDatabaseVersion(chainDb, core.BlockChainVersion)
 		}
 	}
+
+	// If the context is not set, avoid a panic. Only necessary during firewood use.
+	chainDataDir := ""
+	if ctx := params.GetExtra(config.Genesis.Config).SnowCtx; ctx != nil {
+		chainDataDir = ctx.ChainDataDir
+	}
+
 	var (
 		vmConfig = vm.Config{
 			EnablePreimageRecording: config.EnablePreimageRecording,
@@ -228,7 +235,7 @@ func New(
 			SkipTxIndexing:                  config.SkipTxIndexing,
 			StateHistory:                    config.StateHistory,
 			StateScheme:                     scheme,
-			ChainDataDir:                    params.GetExtra(config.Genesis.Config).SnowCtx.ChainDataDir,
+			ChainDataDir:                    chainDataDir,
 		}
 	)
 

--- a/eth/backend.go
+++ b/eth/backend.go
@@ -151,7 +151,7 @@ func New(
 		"snapshot clean", common.StorageSize(config.SnapshotCache)*1024*1024,
 	)
 
-	scheme, err := rawdb.ParseStateScheme(config.StateScheme, chainDb)
+	scheme, err := customrawdb.ParseStateSchemeExt(config.StateScheme, chainDb)
 	if err != nil {
 		return nil, err
 	}
@@ -228,6 +228,7 @@ func New(
 			SkipTxIndexing:                  config.SkipTxIndexing,
 			StateHistory:                    config.StateHistory,
 			StateScheme:                     scheme,
+			ChainDataDir:                    params.GetExtra(config.Genesis.Config).SnowCtx.ChainDataDir,
 		}
 	)
 

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -226,9 +226,10 @@ func (eth *Ethereum) pathState(block *types.Block) (*state.StateDB, func(), erro
 //     on disk.
 func (eth *Ethereum) stateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (statedb *state.StateDB, release tracers.StateReleaseFunc, err error) {
 	// Check if we're using firewood backend by typecasting
+	// firewoodDB.Scheme() == rawdb.HashScheme, so typecasting is necessary
 	_, isFirewood := eth.blockchain.TrieDB().Backend().(*firewood.Database)
 
-	// Use `hashState` if the state can be recomptued from the live database.
+	// Use `hashState` if the state can be recomputed from the live database.
 	if eth.blockchain.TrieDB().Scheme() == rawdb.HashScheme && !isFirewood {
 		return eth.hashState(ctx, block, reexec, base, readOnly, preferDisk)
 	}

--- a/eth/state_accessor.go
+++ b/eth/state_accessor.go
@@ -36,7 +36,7 @@ import (
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/eth/tracers"
-	"github.com/ava-labs/coreth/triedb/firewood"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
@@ -227,7 +227,7 @@ func (eth *Ethereum) pathState(block *types.Block) (*state.StateDB, func(), erro
 func (eth *Ethereum) stateAtBlock(ctx context.Context, block *types.Block, reexec uint64, base *state.StateDB, readOnly bool, preferDisk bool) (statedb *state.StateDB, release tracers.StateReleaseFunc, err error) {
 	// Check if we're using firewood backend by typecasting
 	// firewoodDB.Scheme() == rawdb.HashScheme, so typecasting is necessary
-	_, isFirewood := eth.blockchain.TrieDB().Backend().(*firewood.Database)
+	isFirewood := eth.blockchain.CacheConfig().StateScheme == customrawdb.FirewoodScheme
 
 	// Use `hashState` if the state can be recomputed from the live database.
 	if eth.blockchain.TrieDB().Scheme() == rawdb.HashScheme && !isFirewood {

--- a/eth/tracers/tracers_test.go
+++ b/eth/tracers/tracers_test.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/tests"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -42,7 +43,15 @@ import (
 	"github.com/ava-labs/libevm/eth/tracers/logger"
 )
 
-func BenchmarkTransactionTrace(b *testing.B) {
+func BenchmarkPrestateTracer(b *testing.B) {
+	for _, scheme := range []string{rawdb.HashScheme, customrawdb.FirewoodScheme} {
+		b.Run(scheme, func(b *testing.B) {
+			benchmarkTransactionTrace(b, scheme)
+		})
+	}
+}
+
+func benchmarkTransactionTrace(b *testing.B, scheme string) {
 	key, _ := crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
 	from := crypto.PubkeyToAddress(key.PublicKey)
 	gas := uint64(1000000) // 1M gas
@@ -90,7 +99,7 @@ func BenchmarkTransactionTrace(b *testing.B) {
 		Code:    []byte{},
 		Balance: big.NewInt(500000000000000),
 	}
-	state := tests.MakePreState(rawdb.NewMemoryDatabase(), alloc, false, rawdb.HashScheme)
+	state := tests.MakePreState(rawdb.NewMemoryDatabase(), alloc, false, scheme)
 	defer state.Close()
 
 	// Create the tracer, the EVM environment and run it

--- a/plugin/evm/config/config.go
+++ b/plugin/evm/config/config.go
@@ -244,6 +244,9 @@ type Config struct {
 
 	// RPC settings
 	HttpBodyLimit uint64 `json:"http-body-limit"`
+
+	// Database Scheme
+	StateScheme string `json:"state-scheme"`
 }
 
 // TxPoolConfig contains the transaction pool config to be passed

--- a/plugin/evm/config/config.md
+++ b/plugin/evm/config/config.md
@@ -113,7 +113,6 @@ The names used in this configuration flag have been updated in Coreth `v0.8.14`.
 
 The mapping of deprecated values and their updated equivalent follows:
 
-
 |Deprecated                      |Use instead         |
 |--------------------------------|--------------------|
 |public-eth                      |eth                 |
@@ -129,6 +128,7 @@ The mapping of deprecated values and their updated equivalent follows:
 |internal-private-debug          |internal-debug      |
 |internal-public-account         |internal-account    |
 |internal-private-personal       |internal-personal   |
+
 </Callout>
 
 <Callout title="Note">
@@ -589,6 +589,14 @@ If `true`, allow users to unlock accounts in unsafe HTTP environment. Defaults t
 
 ## Database
 
+### `state-scheme`
+
+_String_
+
+Can be one of `hash` or `firewood`. Defaults to `hash`.
+
+__WARNING__: `firewood` scheme is untested in production.
+
 ### `trie-clean-cache`
 
 _Integer_
@@ -618,8 +626,6 @@ Max concurrent disk reads trie pre-fetcher should perform at once. Defaults to `
 _Integer_
 
 Size of the snapshot disk layer clean cache (in MBs). Should be a multiple of `64`. Defaults to `256`.
-
-
 
 ### `acceptor-queue-limit`
 
@@ -681,7 +687,7 @@ If `true`, clears the warp database on startup. Defaults to `false`.
 
 _Boolean_
 
-If `true`, offline pruning will run on startup and block until it completes (approximately one hour on Mainnet). This will reduce the size of the database by deleting old trie nodes. **While performing offline pruning, your node will not be able to process blocks and will be considered offline.** While ongoing, the pruning process consumes a small amount of additional disk space (for deletion markers and the bloom filter). For more information see [here.](https://build.avax.network/docs/nodes/maintain/reduce-disk-usage#disk-space-considerations)
+If `true`, offline pruning will run on startup and block until it completes (approximately one hour on Mainnet). This will reduce the size of the database by deleting old trie nodes. __While performing offline pruning, your node will not be able to process blocks and will be considered offline.__ While ongoing, the pruning process consumes a small amount of additional disk space (for deletion markers and the bloom filter). For more information see [here.](https://build.avax.network/docs/nodes/maintain/reduce-disk-usage#disk-space-considerations)
 
 Since offline pruning deletes old state data, this should not be run on nodes that need to support archival API requests.
 

--- a/plugin/evm/config/config.md
+++ b/plugin/evm/config/config.md
@@ -128,7 +128,6 @@ The mapping of deprecated values and their updated equivalent follows:
 |internal-private-debug          |internal-debug      |
 |internal-public-account         |internal-account    |
 |internal-private-personal       |internal-personal   |
-
 </Callout>
 
 <Callout title="Note">
@@ -627,6 +626,8 @@ _Integer_
 
 Size of the snapshot disk layer clean cache (in MBs). Should be a multiple of `64`. Defaults to `256`.
 
+
+
 ### `acceptor-queue-limit`
 
 _Integer_
@@ -687,7 +688,7 @@ If `true`, clears the warp database on startup. Defaults to `false`.
 
 _Boolean_
 
-If `true`, offline pruning will run on startup and block until it completes (approximately one hour on Mainnet). This will reduce the size of the database by deleting old trie nodes. __While performing offline pruning, your node will not be able to process blocks and will be considered offline.__ While ongoing, the pruning process consumes a small amount of additional disk space (for deletion markers and the bloom filter). For more information see [here.](https://build.avax.network/docs/nodes/maintain/reduce-disk-usage#disk-space-considerations)
+If `true`, offline pruning will run on startup and block until it completes (approximately one hour on Mainnet). This will reduce the size of the database by deleting old trie nodes. **While performing offline pruning, your node will not be able to process blocks and will be considered offline.** While ongoing, the pruning process consumes a small amount of additional disk space (for deletion markers and the bloom filter). For more information see [here.](https://build.avax.network/docs/nodes/maintain/reduce-disk-usage#disk-space-considerations)
 
 Since offline pruning deletes old state data, this should not be run on nodes that need to support archival API requests.
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ava-labs/avalanchego/network/p2p"
 	"github.com/ava-labs/avalanchego/network/p2p/acp118"
 	"github.com/ava-labs/coreth/network"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
 	"github.com/ava-labs/coreth/plugin/evm/gossip"
 	"github.com/ava-labs/coreth/plugin/evm/vmerrors"
@@ -409,6 +410,26 @@ func (vm *VM) Initialize(
 	vm.ethConfig.StateHistory = vm.config.StateHistory
 	vm.ethConfig.TransactionHistory = vm.config.TransactionHistory
 	vm.ethConfig.SkipTxIndexing = vm.config.SkipTxIndexing
+	vm.ethConfig.StateScheme = vm.config.StateScheme
+
+	if vm.ethConfig.StateScheme == customrawdb.FirewoodScheme {
+		log.Warn("Firewood state scheme is enabled")
+		log.Warn("This is untested in production, use at your own risk")
+		// Firewood only supports pruning for now.
+		if !vm.config.Pruning {
+			return errors.New("Pruning must be enabled for Firewood")
+		}
+		// Firewood does not support iterators, so the snapshot cannot be constructed
+		if vm.config.SnapshotCache > 0 {
+			return errors.New("Snapshot cache must be disabled for Firewood")
+		}
+		if vm.config.OfflinePruning {
+			return errors.New("Offline pruning is not supported for Firewood")
+		}
+		if vm.config.StateSyncEnabled == nil || *vm.config.StateSyncEnabled {
+			return errors.New("State sync is not yet supported for Firewood")
+		}
+	}
 
 	// Create directory for offline pruning
 	if len(vm.ethConfig.OfflinePruningDataDirectory) != 0 {
@@ -570,14 +591,18 @@ func (vm *VM) initializeStateSync(lastAcceptedHeight uint64) error {
 	// Create standalone EVM TrieDB (read only) for serving leafs requests.
 	// We create a standalone TrieDB here, so that it has a standalone cache from the one
 	// used by the node when processing blocks.
-	evmTrieDB := triedb.NewDatabase(
-		vm.chaindb,
-		&triedb.Config{
-			DBOverride: hashdb.Config{
-				CleanCacheSize: vm.config.StateSyncServerTrieCache * units.MiB,
-			}.BackendConstructor,
-		},
-	)
+	// However, Firewood does not support multiple TrieDBs, so we use the same one.
+	evmTrieDB := vm.eth.BlockChain().TrieDB()
+	if vm.ethConfig.StateScheme != customrawdb.FirewoodScheme {
+		evmTrieDB = triedb.NewDatabase(
+			vm.chaindb,
+			&triedb.Config{
+				DBOverride: hashdb.Config{
+					CleanCacheSize: vm.config.StateSyncServerTrieCache * units.MiB,
+				}.BackendConstructor,
+			},
+		)
+	}
 	leafHandlers := make(LeafHandlers)
 	leafMetricsNames := make(map[message.NodeType]string)
 	// register default leaf request handler for state trie

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -430,6 +430,10 @@ func (vm *VM) Initialize(
 			return errors.New("State sync is not yet supported for Firewood")
 		}
 	}
+	if vm.ethConfig.StateScheme == rawdb.PathScheme {
+		log.Error("Path state scheme is not supported. Please use HashDB or Firewood state schemes instead")
+		return errors.New("Path state scheme is not supported")
+	}
 
 	// Create directory for offline pruning
 	if len(vm.ethConfig.OfflinePruningDataDirectory) != 0 {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -394,6 +394,14 @@ func TestVMContinuousProfiler(t *testing.T) {
 }
 
 func TestVMUpgrades(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testVMUpgrades(t, scheme)
+		})
+	}
+}
+
+func testVMUpgrades(t *testing.T, scheme string) {
 	genesisTests := []struct {
 		fork             upgradetest.Fork
 		expectedGasPrice *big.Int
@@ -436,36 +444,31 @@ func TestVMUpgrades(t *testing.T) {
 		},
 	}
 
-	schemes := schemes
 	for _, test := range genesisTests {
 		t.Run(test.fork.String(), func(t *testing.T) {
-			for _, scheme := range schemes {
-				t.Run(scheme, func(t *testing.T) {
-					require := require.New(t)
+			require := require.New(t)
 
-					vm := newVM(t, testVMConfig{
-						fork:       &test.fork,
-						configJSON: getConfig(scheme, ""),
-					}).vm
-					defer func() {
-						require.NoError(vm.Shutdown(context.Background()))
-					}()
+			vm := newVM(t, testVMConfig{
+				fork:       &test.fork,
+				configJSON: getConfig(scheme, ""),
+			}).vm
+			defer func() {
+				require.NoError(vm.Shutdown(context.Background()))
+			}()
 
-					require.Equal(test.expectedGasPrice, vm.txPool.GasTip())
+			require.Equal(test.expectedGasPrice, vm.txPool.GasTip())
 
-					// Verify that the genesis is correctly managed.
-					lastAcceptedID, err := vm.LastAccepted(context.Background())
-					require.NoError(err)
-					require.Equal(ids.ID(vm.genesisHash), lastAcceptedID)
+			// Verify that the genesis is correctly managed.
+			lastAcceptedID, err := vm.LastAccepted(context.Background())
+			require.NoError(err)
+			require.Equal(ids.ID(vm.genesisHash), lastAcceptedID)
 
-					genesisBlk, err := vm.GetBlock(context.Background(), lastAcceptedID)
-					require.NoError(err)
-					require.Zero(genesisBlk.Height())
+			genesisBlk, err := vm.GetBlock(context.Background(), lastAcceptedID)
+			require.NoError(err)
+			require.Zero(genesisBlk.Height())
 
-					_, err = vm.ParseBlock(context.Background(), genesisBlk.Bytes())
-					require.NoError(err)
-				})
-			}
+			_, err = vm.ParseBlock(context.Background(), genesisBlk.Bytes())
+			require.NoError(err)
 		})
 	}
 }
@@ -979,130 +982,134 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork, scheme string
 }
 
 func TestReissueAtomicTxHigherGasPrice(t *testing.T) {
-	kc := secp256k1fx.NewKeychain(testKeys...)
-
 	for _, scheme := range schemes {
 		t.Run(scheme, func(t *testing.T) {
-			for name, issueTxs := range map[string]func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, discarded []*atomic.Tx){
-				"single UTXO override": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
-					utxo, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
-					if err != nil {
-						t.Fatal(err)
-					}
-					tx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo})
-					if err != nil {
-						t.Fatal(err)
-					}
-					tx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(common.Big2, initialBaseFee), kc, []*avax.UTXO{utxo})
-					if err != nil {
-						t.Fatal(err)
-					}
+			testReissueAtomicTxHigherGasPrice(t, scheme)
+		})
+	}
+}
 
-					if err := vm.AtomicMempool.AddLocalTx(tx1); err != nil {
-						t.Fatal(err)
-					}
-					if err := vm.AtomicMempool.AddLocalTx(tx2); err != nil {
-						t.Fatal(err)
-					}
+func testReissueAtomicTxHigherGasPrice(t *testing.T, scheme string) {
+	kc := secp256k1fx.NewKeychain(testKeys...)
+	tests := map[string]func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, discarded []*atomic.Tx){
+		"single UTXO override": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
+			utxo, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(common.Big2, initialBaseFee), kc, []*avax.UTXO{utxo})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					return []*atomic.Tx{tx2}, []*atomic.Tx{tx1}
-				},
-				"one of two UTXOs overrides": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
-					utxo1, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
-					if err != nil {
-						t.Fatal(err)
-					}
-					utxo2, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
-					if err != nil {
-						t.Fatal(err)
-					}
-					tx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo1, utxo2})
-					if err != nil {
-						t.Fatal(err)
-					}
-					tx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(common.Big2, initialBaseFee), kc, []*avax.UTXO{utxo1})
-					if err != nil {
-						t.Fatal(err)
-					}
+			if err := vm.AtomicMempool.AddLocalTx(tx1); err != nil {
+				t.Fatal(err)
+			}
+			if err := vm.AtomicMempool.AddLocalTx(tx2); err != nil {
+				t.Fatal(err)
+			}
 
-					if err := vm.AtomicMempool.AddLocalTx(tx1); err != nil {
-						t.Fatal(err)
-					}
-					if err := vm.AtomicMempool.AddLocalTx(tx2); err != nil {
-						t.Fatal(err)
-					}
+			return []*atomic.Tx{tx2}, []*atomic.Tx{tx1}
+		},
+		"one of two UTXOs overrides": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
+			utxo1, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			utxo2, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo1, utxo2})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(common.Big2, initialBaseFee), kc, []*avax.UTXO{utxo1})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					return []*atomic.Tx{tx2}, []*atomic.Tx{tx1}
-				},
-				"hola": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
-					utxo1, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
-					if err != nil {
-						t.Fatal(err)
-					}
-					utxo2, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
-					if err != nil {
-						t.Fatal(err)
-					}
+			if err := vm.AtomicMempool.AddLocalTx(tx1); err != nil {
+				t.Fatal(err)
+			}
+			if err := vm.AtomicMempool.AddLocalTx(tx2); err != nil {
+				t.Fatal(err)
+			}
 
-					importTx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo1})
-					if err != nil {
-						t.Fatal(err)
-					}
+			return []*atomic.Tx{tx2}, []*atomic.Tx{tx1}
+		},
+		"hola": func(t *testing.T, vm *atomicvm.VM, sharedMemory *avalancheatomic.Memory) (issued []*atomic.Tx, evicted []*atomic.Tx) {
+			utxo1, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
+			utxo2, err := addUTXO(sharedMemory, vm.Ctx, ids.GenerateTestID(), 0, vm.Ctx.AVAXAssetID, units.Avax, testShortIDAddrs[0])
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					importTx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(3), initialBaseFee), kc, []*avax.UTXO{utxo2})
-					if err != nil {
-						t.Fatal(err)
-					}
+			importTx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], initialBaseFee, kc, []*avax.UTXO{utxo1})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					reissuanceTx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(2), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if err := vm.AtomicMempool.AddLocalTx(importTx1); err != nil {
-						t.Fatal(err)
-					}
+			importTx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(3), initialBaseFee), kc, []*avax.UTXO{utxo2})
+			if err != nil {
+				t.Fatal(err)
+			}
 
-					if err := vm.AtomicMempool.AddLocalTx(importTx2); err != nil {
-						t.Fatal(err)
-					}
+			reissuanceTx1, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(2), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := vm.AtomicMempool.AddLocalTx(importTx1); err != nil {
+				t.Fatal(err)
+			}
 
-					if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
-						t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingAtomicTx, err)
-					}
+			if err := vm.AtomicMempool.AddLocalTx(importTx2); err != nil {
+				t.Fatal(err)
+			}
 
-					assert.True(t, vm.AtomicMempool.Has(importTx1.ID()))
-					assert.True(t, vm.AtomicMempool.Has(importTx2.ID()))
-					assert.False(t, vm.AtomicMempool.Has(reissuanceTx1.ID()))
+			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
+				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingAtomicTx, err)
+			}
 
-					reissuanceTx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(4), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
-					if err != nil {
-						t.Fatal(err)
-					}
-					if err := vm.AtomicMempool.AddLocalTx(reissuanceTx2); err != nil {
-						t.Fatal(err)
-					}
+			assert.True(t, vm.AtomicMempool.Has(importTx1.ID()))
+			assert.True(t, vm.AtomicMempool.Has(importTx2.ID()))
+			assert.False(t, vm.AtomicMempool.Has(reissuanceTx1.ID()))
 
-					return []*atomic.Tx{reissuanceTx2}, []*atomic.Tx{importTx1, importTx2}
-				},
-			} {
-				t.Run(name, func(t *testing.T) {
-					fork := upgradetest.ApricotPhase5
-					tvm := newVM(t, testVMConfig{
-						fork:       &fork,
-						configJSON: getConfig(scheme, `"pruning-enabled":true`),
-					})
-					issuedTxs, evictedTxs := issueTxs(t, tvm.atomicVM, tvm.atomicMemory)
+			reissuanceTx2, err := atomic.NewImportTx(vm.Ctx, vm.CurrentRules(), vm.Clock().Unix(), vm.Ctx.XChainID, testEthAddrs[0], new(big.Int).Mul(big.NewInt(4), initialBaseFee), kc, []*avax.UTXO{utxo1, utxo2})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx2); err != nil {
+				t.Fatal(err)
+			}
 
-					for i, tx := range issuedTxs {
-						_, issued := tvm.atomicVM.AtomicMempool.GetPendingTx(tx.ID())
-						assert.True(t, issued, "expected issued tx at index %d to be issued", i)
-					}
+			return []*atomic.Tx{reissuanceTx2}, []*atomic.Tx{importTx1, importTx2}
+		},
+	}
+	for name, issueTxs := range tests {
+		t.Run(name, func(t *testing.T) {
+			fork := upgradetest.ApricotPhase5
+			tvm := newVM(t, testVMConfig{
+				fork:       &fork,
+				configJSON: getConfig(scheme, `"pruning-enabled":true`),
+			})
+			issuedTxs, evictedTxs := issueTxs(t, tvm.atomicVM, tvm.atomicMemory)
 
-					for i, tx := range evictedTxs {
-						_, discarded, _ := tvm.atomicVM.AtomicMempool.GetTx(tx.ID())
-						assert.True(t, discarded, "expected discarded tx at index %d to be discarded", i)
-					}
-				})
+			for i, tx := range issuedTxs {
+				_, issued := tvm.atomicVM.AtomicMempool.GetPendingTx(tx.ID())
+				assert.True(t, issued, "expected issued tx at index %d to be issued", i)
+			}
+
+			for i, tx := range evictedTxs {
+				_, discarded, _ := tvm.atomicVM.AtomicMempool.GetTx(tx.ID())
+				assert.True(t, discarded, "expected discarded tx at index %d to be discarded", i)
 			}
 		})
 	}

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -263,7 +263,7 @@ func getConfig(scheme, otherConfig string) string {
 		if len(innerConfig) > 0 {
 			innerConfig += ", "
 		}
-		innerConfig += fmt.Sprintf(`"state-scheme": "%s", "snapshot-cache": 0, "pruning-enabled": true`, customrawdb.FirewoodScheme)
+		innerConfig += fmt.Sprintf(`"state-scheme": "%s", "snapshot-cache": 0, "pruning-enabled": true, "state-sync-enabled": false`, customrawdb.FirewoodScheme)
 	}
 
 	return fmt.Sprintf(`{%s}`, innerConfig)

--- a/plugin/evm/vm_warp_test.go
+++ b/plugin/evm/vm_warp_test.go
@@ -74,10 +74,19 @@ const (
 )
 
 func TestSendWarpMessage(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testSendWarpMessage(t, scheme)
+		})
+	}
+}
+
+func testSendWarpMessage(t *testing.T, scheme string) {
 	require := require.New(t)
 	fork := upgradetest.Durango
 	tvm := newVM(t, testVMConfig{
-		fork: &fork,
+		fork:       &fork,
+		configJSON: getConfig(scheme, ""),
 	})
 	defer func() {
 		require.NoError(tvm.vm.Shutdown(context.Background()))
@@ -178,6 +187,14 @@ func TestSendWarpMessage(t *testing.T) {
 }
 
 func TestValidateWarpMessage(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testValidateWarpMessage(t, scheme)
+		})
+	}
+}
+
+func testValidateWarpMessage(t *testing.T, scheme string) {
 	require := require.New(t)
 	sourceChainID := ids.GenerateTestID()
 	sourceAddress := common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2")
@@ -200,10 +217,18 @@ func TestValidateWarpMessage(t *testing.T) {
 	)
 	require.NoError(err)
 
-	testWarpVMTransaction(t, unsignedMessage, true, exampleWarpPayload)
+	testWarpVMTransaction(t, scheme, unsignedMessage, true, exampleWarpPayload)
 }
 
 func TestValidateInvalidWarpMessage(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testValidateInvalidWarpMessage(t, scheme)
+		})
+	}
+}
+
+func testValidateInvalidWarpMessage(t *testing.T, scheme string) {
 	require := require.New(t)
 	sourceChainID := ids.GenerateTestID()
 	sourceAddress := common.HexToAddress("0x376c47978271565f56DEB45495afa69E59c16Ab2")
@@ -223,10 +248,18 @@ func TestValidateInvalidWarpMessage(t *testing.T) {
 	)
 	require.NoError(err)
 
-	testWarpVMTransaction(t, unsignedMessage, false, exampleWarpPayload)
+	testWarpVMTransaction(t, scheme, unsignedMessage, false, exampleWarpPayload)
 }
 
 func TestValidateWarpBlockHash(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testValidateWarpBlockHash(t, scheme)
+		})
+	}
+}
+
+func testValidateWarpBlockHash(t *testing.T, scheme string) {
 	require := require.New(t)
 	sourceChainID := ids.GenerateTestID()
 	blockHash := ids.GenerateTestID()
@@ -244,10 +277,18 @@ func TestValidateWarpBlockHash(t *testing.T) {
 	)
 	require.NoError(err)
 
-	testWarpVMTransaction(t, unsignedMessage, true, exampleWarpPayload)
+	testWarpVMTransaction(t, scheme, unsignedMessage, true, exampleWarpPayload)
 }
 
 func TestValidateInvalidWarpBlockHash(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testValidateInvalidWarpBlockHash(t, scheme)
+		})
+	}
+}
+
+func testValidateInvalidWarpBlockHash(t *testing.T, scheme string) {
 	require := require.New(t)
 	sourceChainID := ids.GenerateTestID()
 	blockHash := ids.GenerateTestID()
@@ -263,14 +304,15 @@ func TestValidateInvalidWarpBlockHash(t *testing.T) {
 	)
 	require.NoError(err)
 
-	testWarpVMTransaction(t, unsignedMessage, false, exampleWarpPayload)
+	testWarpVMTransaction(t, scheme, unsignedMessage, false, exampleWarpPayload)
 }
 
-func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.UnsignedMessage, validSignature bool, txPayload []byte) {
+func testWarpVMTransaction(t *testing.T, scheme string, unsignedMessage *avalancheWarp.UnsignedMessage, validSignature bool, txPayload []byte) {
 	require := require.New(t)
 	fork := upgradetest.Durango
 	tvm := newVM(t, testVMConfig{
-		fork: &fork,
+		fork:       &fork,
+		configJSON: getConfig(scheme, ""),
 	})
 	defer func() {
 		require.NoError(tvm.vm.Shutdown(context.Background()))
@@ -420,10 +462,19 @@ func testWarpVMTransaction(t *testing.T, unsignedMessage *avalancheWarp.Unsigned
 }
 
 func TestReceiveWarpMessage(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testReceiveWarpMessageWithScheme(t, scheme)
+		})
+	}
+}
+
+func testReceiveWarpMessageWithScheme(t *testing.T, scheme string) {
 	require := require.New(t)
 	fork := upgradetest.Durango
 	tvm := newVM(t, testVMConfig{
-		fork: &fork,
+		fork:       &fork,
+		configJSON: getConfig(scheme, ""),
 	})
 	defer func() {
 		require.NoError(tvm.vm.Shutdown(context.Background()))
@@ -740,9 +791,18 @@ func testReceiveWarpMessage(
 }
 
 func TestSignatureRequestsToVM(t *testing.T) {
+	for _, scheme := range schemes {
+		t.Run(scheme, func(t *testing.T) {
+			testSignatureRequestsToVM(t, scheme)
+		})
+	}
+}
+
+func testSignatureRequestsToVM(t *testing.T, scheme string) {
 	fork := upgradetest.Durango
 	tvm := newVM(t, testVMConfig{
-		fork: &fork,
+		fork:       &fork,
+		configJSON: getConfig(scheme, ""),
 	})
 	defer func() {
 		require.NoError(t, tvm.vm.Shutdown(context.Background()))

--- a/tests/state_test_util.go
+++ b/tests/state_test_util.go
@@ -28,8 +28,13 @@
 package tests
 
 import (
+	"os"
+	"path/filepath"
+
 	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/state/snapshot"
+	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
+	"github.com/ava-labs/coreth/triedb/firewood"
 	"github.com/ava-labs/coreth/triedb/hashdb"
 	"github.com/ava-labs/coreth/triedb/pathdb"
 	"github.com/ava-labs/libevm/common"
@@ -45,16 +50,31 @@ type StateTestState struct {
 	StateDB   *state.StateDB
 	TrieDB    *triedb.Database
 	Snapshots *snapshot.Tree
+	TempDir   string
 }
 
 // MakePreState creates a state containing the given allocation.
 func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bool, scheme string) StateTestState {
-	tconf := &triedb.Config{Preimages: true}
-	if scheme == rawdb.HashScheme {
-		tconf.DBOverride = hashdb.Defaults.BackendConstructor
-	} else {
-		tconf.DBOverride = pathdb.Defaults.BackendConstructor
+	// Set database path
+	tempdir, err := os.MkdirTemp("", "coreth-state-test-*")
+	if err != nil {
+		panic("failed to create temporary directory: " + err.Error())
 	}
+
+	tconf := &triedb.Config{Preimages: true}
+	switch scheme {
+	case rawdb.HashScheme:
+		tconf.DBOverride = hashdb.Defaults.BackendConstructor
+	case rawdb.PathScheme:
+		tconf.DBOverride = pathdb.Defaults.BackendConstructor
+	case customrawdb.FirewoodScheme:
+		cfg := firewood.Defaults
+		cfg.FilePath = filepath.Join(tempdir, "firewood")
+		tconf.DBOverride = cfg.BackendConstructor
+	default:
+		panic("unknown trie database scheme" + scheme)
+	}
+
 	triedb := triedb.NewDatabase(db, tconf)
 	sdb := state.NewDatabaseWithNodeDB(db, triedb)
 	statedb, _ := state.New(types.EmptyRootHash, sdb, nil)
@@ -67,7 +87,10 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 		}
 	}
 	// Commit and re-open to start with a clean state.
-	root, _ := statedb.Commit(0, false)
+	root, err := statedb.Commit(0, false)
+	if err != nil {
+		panic("failed to commit state: " + err.Error())
+	}
 
 	// If snapshot is requested, initialize the snapshotter and use it in state.
 	var snaps *snapshot.Tree
@@ -81,7 +104,7 @@ func MakePreState(db ethdb.Database, accounts types.GenesisAlloc, snapshotter bo
 		snaps, _ = snapshot.New(snapconfig, db, triedb, common.Hash{}, root)
 	}
 	statedb, _ = state.New(root, sdb, snaps)
-	return StateTestState{statedb, triedb, snaps}
+	return StateTestState{statedb, triedb, snaps, tempdir}
 }
 
 // Close should be called when the state is no longer needed, ie. after running the test.
@@ -95,5 +118,12 @@ func (st *StateTestState) Close() {
 		st.Snapshots.AbortGeneration()
 		st.Snapshots.Release()
 		st.Snapshots = nil
+	}
+
+	if st.TempDir != "" {
+		if err := os.RemoveAll(st.TempDir); err != nil {
+			panic("failed to remove temporary directory: " + err.Error())
+		}
+		st.TempDir = ""
 	}
 }


### PR DESCRIPTION
## Why this should be merged

This is the final step to completely enable Firewood to bootstrap in the EVM.

### Next steps for integration
- Debug APIS and Snapshot (requires an iterator)
- Integrating firewood metrics/logging - [see this comment](https://github.com/ava-labs/coreth/pull/959#discussion_r2143268672)
- E2E testing
- State Sync
- Performance testing to find optimizations/weak points

## How this works

This hooks into existing libevm functionality as necessary.

## How this was tested

Unit tests, bootstrap mainnet.

## Need to be documented?

Yes.

## Need to update RELEASES.md?
Yes.