### PR TITLE
Update interface to the latest version of avalanchego

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Build AvalancheGo and update Coreth dependency
         run: ./scripts/run_task.sh build-avalanchego-with-coreth
       - name: Run e2e tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@507e6bbb5e7d166749fa0b5633e26fd36b753064
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@66ce7a7701db0c4b370f97b339478d5b5ebe919a
         with:
           run: ./scripts/run_task.sh test-e2e
           run_env: AVALANCHEGO_CLONE_PATH=avalanchego
@@ -136,7 +136,7 @@ jobs:
         env:
           AVALANCHEGO_CLONE_PATH: /tmp/e2e/warp/avalanchego
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@507e6bbb5e7d166749fa0b5633e26fd36b753064
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@66ce7a7701db0c4b370f97b339478d5b5ebe919a
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           run_env: AVALANCHEGO_BUILD_PATH=/tmp/e2e/warp/avalanchego/build

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.3-0.20250707201933-507e6bbb5e7d
+	github.com/ava-labs/avalanchego v1.13.3-rc.1
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1
 	github.com/davecgh/go-spew v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -60,8 +60,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.3-0.20250707201933-507e6bbb5e7d h1:+IK0mMgrXj2yOxh23ShACLeJlG+XMb6ZDeXda5IFgb0=
-github.com/ava-labs/avalanchego v1.13.3-0.20250707201933-507e6bbb5e7d/go.mod h1:QmwzzCZtKaam5OY45kuzq3UinsyRXH75LkP85W7713M=
+github.com/ava-labs/avalanchego v1.13.3-rc.1 h1:YhtNjw+MljEohXPdbBqSVGvV74AKjpyknhCunZFFS4E=
+github.com/ava-labs/avalanchego v1.13.3-rc.1/go.mod h1:t5+0qviLU5jwkaBvi9e4KSbuiDIy67OS+VKU7roB38A=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8 h1:f0ZbAiRE1srMiv/0DuXvPQZwgYbLC9OgAWbQUCMebTE=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.8/go.mod h1:j6spQFNSBAfcXKt9g0xbObW/8tMlGP4bFjPIsJmDg/o=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.1 h1:vBMYo+Iazw0rGTr+cwjkBdh5eadLPlv4ywI4lKye3CA=

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1080,7 +1080,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 	return apis, nil
 }
 
-func (vm *VM) CreateHTTP2Handler(context.Context) (http.Handler, error) {
+func (*VM) NewHTTPHandler(context.Context) (http.Handler, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Needed to support header-based routing, see https://github.com/ava-labs/avalanchego/pull/4036

## How this works

See https://github.com/ava-labs/avalanchego/pull/4036

## How this was tested

See https://github.com/ava-labs/avalanchego/pull/4036

## Need to be documented?

No

## Need to update RELEASES.md?

Yes, this is an avalanchego version bump