### PR TITLE
refactor: re-exec loop check

### DIFF
--- a/core/blockchain.go
+++ b/core/blockchain.go
@@ -1806,8 +1806,14 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 		}
 	}
 
-	for i := 0; i < int(reexec); i++ {
+	for i := 0; i <= int(reexec); i++ {
 		// TODO: handle canceled context
+
+		// Once we have a state, we can reprocess from there.
+		_, err = bc.stateCache.OpenTrie(current.Root())
+		if err == nil {
+			break
+		}
 
 		if current.NumberU64() == 0 {
 			return errors.New("genesis state is missing")
@@ -1817,10 +1823,6 @@ func (bc *BlockChain) reprocessState(current *types.Block, reexec uint64) error 
 			return fmt.Errorf("missing block %s:%d", current.ParentHash().Hex(), current.NumberU64()-1)
 		}
 		current = parent
-		_, err = bc.stateCache.OpenTrie(current.Root())
-		if err == nil {
-			break
-		}
 	}
 	if err != nil {
 		switch err.(type) {

--- a/core/blockchain_ext_test.go
+++ b/core/blockchain_ext_test.go
@@ -96,6 +96,29 @@ var tests = []ChainTest{
 	},
 }
 
+type ReexecTest struct {
+	Name     string
+	testFunc func(
+		t *testing.T,
+		create func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash, commitInterval uint64) (*BlockChain, error),
+	)
+}
+
+var reexecTests = []ReexecTest{
+	{
+		"ReexecBlocks",
+		ReexecBlocksTest,
+	},
+	{
+		"ReexecMaxBlocks",
+		ReexecMaxBlocksTest,
+	},
+	{
+		"ReexecTooManyBlocks",
+		ReexecTooManyBlocksTest,
+	},
+}
+
 func copyMemDB(db ethdb.Database) (ethdb.Database, error) {
 	newDB := rawdb.NewMemoryDatabase()
 	iter := db.NewIterator(nil, nil)
@@ -1453,4 +1476,331 @@ func InsertChainValidBlockFeeTest(t *testing.T, create func(db ethdb.Database, g
 	}
 
 	checkBlockChainState(t, blockchain, gspec, chainDB, create, checkState)
+}
+
+func ReexecBlocksTest(t *testing.T, create func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash, commitInterval uint64) (*BlockChain, error)) {
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB = rawdb.NewMemoryDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	genesisBalance := big.NewInt(1000000)
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+	}
+
+	blockchain, err := create(chainDB, gspec, common.Hash{}, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	// This call generates a chain of 10 blocks.
+	signer := types.HomesteadSigner{}
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 10, 10, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert three blocks into the chain and accept only the first block.
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		t.Fatal(err)
+	}
+
+	foundTxs := []common.Hash{}
+	missingTxs := []common.Hash{}
+	for i, block := range chain {
+		if err := blockchain.Accept(block); err != nil {
+			t.Fatal(err)
+		}
+
+		if i == 3 {
+			// At height 3, kill the async accepted block processor to force an
+			// ungraceful recovery
+			blockchain.stopAcceptor()
+			blockchain.acceptorQueue = nil
+		}
+
+		if i <= 3 {
+			// If <= height 3, all txs should be accessible on lookup
+			for _, tx := range block.Transactions() {
+				foundTxs = append(foundTxs, tx.Hash())
+			}
+		} else {
+			// If > 3, all txs should be accessible on lookup
+			for _, tx := range block.Transactions() {
+				missingTxs = append(missingTxs, tx.Hash())
+			}
+		}
+	}
+
+	// After inserting all blocks, we should confirm that txs added after the
+	// async worker shutdown cannot be found.
+	for _, tx := range foundTxs {
+		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
+		if txLookup == nil {
+			t.Fatalf("missing transaction: %v", tx)
+		}
+	}
+	for _, tx := range missingTxs {
+		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
+		if txLookup != nil {
+			t.Fatalf("transaction should be missing: %v", tx)
+		}
+	}
+
+	// check the state of the last accepted block
+	checkState := func(sdb *state.StateDB) error {
+		nonce := sdb.GetNonce(addr1)
+		if nonce != 10 {
+			return fmt.Errorf("expected nonce addr1: 10, found nonce: %d", nonce)
+		}
+		transferredFunds := uint256.MustFromBig(big.NewInt(100000))
+		balance1 := sdb.GetBalance(addr1)
+		genesisBalance := uint256.MustFromBig(genesisBalance)
+		expectedBalance1 := new(uint256.Int).Sub(genesisBalance, transferredFunds)
+		if balance1.Cmp(expectedBalance1) != 0 {
+			return fmt.Errorf("expected addr1 balance: %d, found balance: %d", expectedBalance1, balance1)
+		}
+
+		balance2 := sdb.GetBalance(addr2)
+		expectedBalance2 := transferredFunds
+		if balance2.Cmp(expectedBalance2) != 0 {
+			return fmt.Errorf("expected addr2 balance: %d, found balance: %d", expectedBalance2, balance2)
+		}
+
+		nonce = sdb.GetNonce(addr2)
+		if nonce != 0 {
+			return fmt.Errorf("expected addr2 nonce: 0, found nonce: %d", nonce)
+		}
+		return nil
+	}
+
+	// wrap the create function to set the commit interval
+	checkCreate := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
+		return create(db, gspec, lastAcceptedHash, blockchain.cacheConfig.CommitInterval)
+	}
+
+	_, newChain, restartedChain := checkBlockChainState(t, blockchain, gspec, chainDB, checkCreate, checkState)
+
+	allTxs := append(foundTxs, missingTxs...)
+	for _, bc := range []*BlockChain{newChain, restartedChain} {
+		// We should confirm that snapshots were properly initialized
+		if bc.snaps == nil {
+			t.Fatal("snapshot initialization failed")
+		}
+
+		// We should confirm all transactions can now be queried
+		for _, tx := range allTxs {
+			txLookup, _, _ := bc.GetTransactionLookup(tx)
+			if txLookup == nil {
+				t.Fatalf("missing transaction: %v", tx)
+			}
+		}
+	}
+}
+
+func ReexecMaxBlocksTest(t *testing.T, create func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash, commitInterval uint64) (*BlockChain, error)) {
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB = rawdb.NewMemoryDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	genesisBalance := big.NewInt(1000000)
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+	}
+
+	blockchain, err := create(chainDB, gspec, common.Hash{}, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	// Check that we are generating enough blocks to test the reexec functionality.
+	genNumBlocks := 20
+	newCommitInterval := 6
+	numAcceptedBlocks := 2*newCommitInterval - 1
+
+	signer := types.HomesteadSigner{}
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, genNumBlocks, 10, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert three blocks into the chain and accept only the first block.
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		t.Fatal(err)
+	}
+
+	foundTxs := []common.Hash{}
+	missingTxs := []common.Hash{}
+	for i, block := range chain {
+		if err := blockchain.Accept(block); err != nil {
+			t.Fatal(err)
+		}
+
+		if i == numAcceptedBlocks {
+			// kill the async accepted block processor to force an
+			// ungraceful recovery
+			blockchain.stopAcceptor()
+			blockchain.acceptorQueue = nil
+		}
+
+		if i <= numAcceptedBlocks {
+			// all txs should be accessible on lookup
+			for _, tx := range block.Transactions() {
+				foundTxs = append(foundTxs, tx.Hash())
+			}
+		} else {
+			// all txs should be accessible on lookup
+			for _, tx := range block.Transactions() {
+				missingTxs = append(missingTxs, tx.Hash())
+			}
+		}
+	}
+
+	// After inserting all blocks, we should confirm that txs added after the
+	// async worker shutdown cannot be found.
+	for _, tx := range foundTxs {
+		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
+		if txLookup == nil {
+			t.Fatalf("missing transaction: %v", tx)
+		}
+	}
+	for _, tx := range missingTxs {
+		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
+		if txLookup != nil {
+			t.Fatalf("transaction should be missing: %v", tx)
+		}
+	}
+
+	// check the state of the last accepted block
+	checkState := func(sdb *state.StateDB) error {
+		nonce := sdb.GetNonce(addr1)
+		if nonce != uint64(genNumBlocks) {
+			return fmt.Errorf("expected nonce addr1: %d, found nonce: %d", genNumBlocks, nonce)
+		}
+		transferredFunds := uint256.MustFromBig(big.NewInt(int64(10000 * genNumBlocks)))
+		balance1 := sdb.GetBalance(addr1)
+		genesisBalance := uint256.MustFromBig(genesisBalance)
+		expectedBalance1 := new(uint256.Int).Sub(genesisBalance, transferredFunds)
+		if balance1.Cmp(expectedBalance1) != 0 {
+			return fmt.Errorf("expected addr1 balance: %d, found balance: %d", expectedBalance1, balance1)
+		}
+
+		balance2 := sdb.GetBalance(addr2)
+		expectedBalance2 := transferredFunds
+		if balance2.Cmp(expectedBalance2) != 0 {
+			return fmt.Errorf("expected addr2 balance: %d, found balance: %d", expectedBalance2, balance2)
+		}
+
+		nonce = sdb.GetNonce(addr2)
+		if nonce != 0 {
+			return fmt.Errorf("expected addr2 nonce: 0, found nonce: %d", nonce)
+		}
+		return nil
+	}
+
+	checkCreate := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
+		return create(db, gspec, lastAcceptedHash, uint64(newCommitInterval))
+	}
+	_, newChain, restartedChain := checkBlockChainState(t, blockchain, gspec, chainDB, checkCreate, checkState)
+
+	allTxs := append(foundTxs, missingTxs...)
+	for _, bc := range []*BlockChain{newChain, restartedChain} {
+		// We should confirm that snapshots were properly initialized
+		if bc.snaps == nil {
+			t.Fatal("snapshot initialization failed")
+		}
+
+		// We should confirm all transactions can now be queried
+		for _, tx := range allTxs {
+			txLookup, _, _ := bc.GetTransactionLookup(tx)
+			if txLookup == nil {
+				t.Fatalf("missing transaction: %v", tx)
+			}
+		}
+	}
+}
+
+func ReexecTooManyBlocksTest(t *testing.T, create func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash, commitInterval uint64) (*BlockChain, error)) {
+	var (
+		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
+		chainDB = rawdb.NewMemoryDatabase()
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	genesisBalance := big.NewInt(1000000)
+	gspec := &Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+	}
+
+	blockchain, err := create(chainDB, gspec, common.Hash{}, 4096)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer blockchain.Stop()
+
+	// Check that we are generating enough blocks to test the reexec functionality.
+	genNumBlocks := 20
+	newCommitInterval := 6
+	numAcceptedBlocks := 2 * newCommitInterval
+
+	signer := types.HomesteadSigner{}
+	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, genNumBlocks, 10, func(i int, gen *BlockGen) {
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Insert three blocks into the chain and accept only the first block.
+	if _, err := blockchain.InsertChain(chain); err != nil {
+		t.Fatal(err)
+	}
+
+	for i, block := range chain {
+		if err := blockchain.Accept(block); err != nil {
+			t.Fatal(err)
+		}
+
+		if i == numAcceptedBlocks {
+			// kill the async accepted block processor to force an
+			// ungraceful recovery
+			blockchain.stopAcceptor()
+			blockchain.acceptorQueue = nil
+		}
+	}
+
+	// Attempt to create chain.
+	copiedDB, err := copyMemDB(chainDB)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = create(copiedDB, gspec, blockchain.lastAccepted.Hash(), uint64(newCommitInterval))
+	if err == nil {
+		t.Fatal("expected error when reprocessing too many blocks, but got none")
+	}
 }

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -35,7 +35,6 @@ import (
 
 	"github.com/ava-labs/avalanchego/upgrade"
 	"github.com/ava-labs/coreth/consensus/dummy"
-	"github.com/ava-labs/coreth/core/state"
 	"github.com/ava-labs/coreth/core/state/pruner"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
@@ -47,7 +46,6 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/eth/tracers/logger"
 	"github.com/ava-labs/libevm/ethdb"
-	"github.com/holiman/uint256"
 )
 
 var (
@@ -423,146 +421,28 @@ func TestRepopulateMissingTries(t *testing.T) {
 }
 
 func TestUngracefulAsyncShutdown(t *testing.T) {
-	var (
-		create = func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash) (*BlockChain, error) {
-			blockchain, err := createBlockChain(db, &CacheConfig{
-				TrieCleanLimit:            256,
-				TrieDirtyLimit:            256,
-				TrieDirtyCommitTarget:     20,
-				TriePrefetcherParallelism: 4,
-				Pruning:                   true,
-				CommitInterval:            4096,
-				StateHistory:              32,
-				SnapshotLimit:             256,
-				SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
-				AcceptorQueueLimit:        1000, // ensure channel doesn't block
-			}, gspec, lastAcceptedHash)
-			if err != nil {
-				return nil, err
-			}
-			return blockchain, nil
+	create := func(db ethdb.Database, gspec *Genesis, lastAcceptedHash common.Hash, commitInterval uint64) (*BlockChain, error) {
+		blockchain, err := createBlockChain(db, &CacheConfig{
+			TrieCleanLimit:            256,
+			TrieDirtyLimit:            256,
+			TrieDirtyCommitTarget:     20,
+			TriePrefetcherParallelism: 4,
+			Pruning:                   true,
+			CommitInterval:            commitInterval,
+			StateHistory:              32,
+			SnapshotLimit:             256,
+			SnapshotNoBuild:           true, // Ensure the test errors if snapshot initialization fails
+			AcceptorQueueLimit:        1000, // ensure channel doesn't block
+		}, gspec, lastAcceptedHash)
+		if err != nil {
+			return nil, err
 		}
-
-		key1, _ = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		key2, _ = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
-		addr1   = crypto.PubkeyToAddress(key1.PublicKey)
-		addr2   = crypto.PubkeyToAddress(key2.PublicKey)
-		chainDB = rawdb.NewMemoryDatabase()
-	)
-
-	// Ensure that key1 has some funds in the genesis block.
-	genesisBalance := big.NewInt(1000000)
-	gspec := &Genesis{
-		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+		return blockchain, nil
 	}
-
-	blockchain, err := create(chainDB, gspec, common.Hash{})
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer blockchain.Stop()
-
-	// This call generates a chain of 10 blocks.
-	signer := types.HomesteadSigner{}
-	_, chain, _, err := GenerateChainWithGenesis(gspec, blockchain.engine, 10, 10, func(i int, gen *BlockGen) {
-		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10000), params.TxGas, nil, nil), signer, key1)
-		gen.AddTx(tx)
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// Insert three blocks into the chain and accept only the first block.
-	if _, err := blockchain.InsertChain(chain); err != nil {
-		t.Fatal(err)
-	}
-
-	foundTxs := []common.Hash{}
-	missingTxs := []common.Hash{}
-	for i, block := range chain {
-		if err := blockchain.Accept(block); err != nil {
-			t.Fatal(err)
-		}
-
-		if i == 3 {
-			// At height 3, kill the async accepted block processor to force an
-			// ungraceful recovery
-			blockchain.stopAcceptor()
-			blockchain.acceptorQueue = nil
-		}
-
-		if i <= 3 {
-			// If <= height 3, all txs should be accessible on lookup
-			for _, tx := range block.Transactions() {
-				foundTxs = append(foundTxs, tx.Hash())
-			}
-		} else {
-			// If > 3, all txs should be accessible on lookup
-			for _, tx := range block.Transactions() {
-				missingTxs = append(missingTxs, tx.Hash())
-			}
-		}
-	}
-
-	// After inserting all blocks, we should confirm that txs added after the
-	// async worker shutdown cannot be found.
-	for _, tx := range foundTxs {
-		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
-		if txLookup == nil {
-			t.Fatalf("missing transaction: %v", tx)
-		}
-	}
-	for _, tx := range missingTxs {
-		txLookup, _, _ := blockchain.GetTransactionLookup(tx)
-		if txLookup != nil {
-			t.Fatalf("transaction should be missing: %v", tx)
-		}
-	}
-
-	// check the state of the last accepted block
-	checkState := func(sdb *state.StateDB) error {
-		nonce := sdb.GetNonce(addr1)
-		if nonce != 10 {
-			return fmt.Errorf("expected nonce addr1: 10, found nonce: %d", nonce)
-		}
-		transferredFunds := uint256.MustFromBig(big.NewInt(100000))
-		balance1 := sdb.GetBalance(addr1)
-		genesisBalance := uint256.MustFromBig(genesisBalance)
-		expectedBalance1 := new(uint256.Int).Sub(genesisBalance, transferredFunds)
-		if balance1.Cmp(expectedBalance1) != 0 {
-			return fmt.Errorf("expected addr1 balance: %d, found balance: %d", expectedBalance1, balance1)
-		}
-
-		balance2 := sdb.GetBalance(addr2)
-		expectedBalance2 := transferredFunds
-		if balance2.Cmp(expectedBalance2) != 0 {
-			return fmt.Errorf("expected addr2 balance: %d, found balance: %d", expectedBalance2, balance2)
-		}
-
-		nonce = sdb.GetNonce(addr2)
-		if nonce != 0 {
-			return fmt.Errorf("expected addr2 nonce: 0, found nonce: %d", nonce)
-		}
-		return nil
-	}
-
-	_, newChain, restartedChain := checkBlockChainState(t, blockchain, gspec, chainDB, create, checkState)
-
-	allTxs := append(foundTxs, missingTxs...)
-	for _, bc := range []*BlockChain{newChain, restartedChain} {
-		// We should confirm that snapshots were properly initialized
-		if bc.snaps == nil {
-			t.Fatal("snapshot initialization failed")
-		}
-
-		// We should confirm all transactions can now be queried
-		for _, tx := range allTxs {
-			txLookup, _, _ := bc.GetTransactionLookup(tx)
-			if txLookup == nil {
-				t.Fatalf("missing transaction: %v", tx)
-			}
-		}
+	for _, tt := range reexecTests {
+		t.Run(tt.Name, func(t *testing.T) {
+			tt.testFunc(t, create)
+		})
 	}
 }
 


### PR DESCRIPTION
## Why this should be merged

`reprocessState` unnecessarily re-executes up to `bc.commitInterval` blocks in some cases, when the most recent commit occurs at the acceptor tip.

## How this works

Instead of immediately decrementing the block number to check, the current block is checked first.

## How this was tested

Additional unit tests were created to ensure equivalent functionality

## Need to be documented?

No.

## Need to update RELEASES.md?

No?
