### PR TITLE
feat: add initial target excess

### DIFF
--- a/plugin/evm/config/config.go
+++ b/plugin/evm/config/config.go
@@ -97,6 +97,8 @@ type Config struct {
 	// default to use the parent block's target gas per second.
 	GasTarget *gas.Gas `json:"gas-target,omitempty"`
 
+	InitialTargetExcess *gas.Gas `json:"initial-target-excess,omitempty"`
+
 	// Coreth APIs
 	AdminAPIEnabled       bool   `json:"admin-api-enabled"`
 	AdminAPIDir           string `json:"admin-api-dir"`

--- a/plugin/evm/config/config.md
+++ b/plugin/evm/config/config.md
@@ -14,6 +14,13 @@ _Integer_
 
 The target gas per second that this node will attempt to use when creating blocks. If this config is not specified, the node will default to use the parent block's target gas per second. Defaults to using the parent block's target.
 
+### `initial-target-excess`
+
+_Integer_
+
+The initial target excess that this node will start the chain with. If this
+config is not specified, the initial target excess defaults to `0`.
+
 ## State Sync
 
 ### `state-sync-enabled`

--- a/plugin/evm/header/dynamic_fee_state.go
+++ b/plugin/evm/header/dynamic_fee_state.go
@@ -14,6 +14,8 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 )
 
+var InitialTargetExcess gas.Gas
+
 // feeStateBeforeBlock takes the previous header and the timestamp of its child
 // block and calculates the fee state before the child block is executed.
 func feeStateBeforeBlock(
@@ -29,7 +31,7 @@ func feeStateBeforeBlock(
 		)
 	}
 
-	var state acp176.State
+	var state acp176.State = acp176.State{TargetExcess: InitialTargetExcess}
 	if config.IsFortuna(parent.Time) && parent.Number.Cmp(common.Big0) != 0 {
 		// If the parent block was running with ACP-176, we start with the
 		// resulting fee state from the parent block. It is assumed that the

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ava-labs/coreth/network"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
 	"github.com/ava-labs/coreth/plugin/evm/gossip"
+	"github.com/ava-labs/coreth/plugin/evm/header"
 	"github.com/ava-labs/coreth/plugin/evm/vmerrors"
 	"github.com/prometheus/client_golang/prometheus"
 
@@ -529,6 +530,10 @@ func (vm *VM) initializeChain(lastAcceptedHash common.Hash) error {
 	if vm.config.GasTarget != nil {
 		desiredTargetExcess = new(gas.Gas)
 		*desiredTargetExcess = acp176.DesiredTargetExcess(*vm.config.GasTarget)
+	}
+
+	if vm.config.InitialTargetExcess != nil {
+		header.InitialTargetExcess = *vm.config.InitialTargetExcess
 	}
 
 	vm.eth, err = eth.New(


### PR DESCRIPTION
## Why this should be merged

For load-testing the C-Chain, we modify the chain's gas-per-second via the `GasTarget` config field. However, going from `MinTargetPerSecond` to `GasTarget` requires a non-negligible ramp-up period, which isn't ideal if we're running load tests on expensive hardware. This ramp-up period is a result of the target gas excess going from `0` to the desired target excess, which is regulated by `MaxTargetExcessDiff`. 

## How this works

This PR extends the Coreth config by adding a `InitialTargetExcess` field. This field is applied to the first block and allows clients to reduce the ramp-up period by having the target gas excess start from `InitialTargetExcess` instead of `0`.

## How this was tested

Ran load test with `InitialTargetExcess` and `GasTarget` set to desired values.

## Need to be documented?

Yes

## Need to update RELEASES.md?
 
Yes
