### PR TITLE
fix: Ensure Firewood does not return data on unimplemented APIs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
 - Removed the `snowman-api-enabled` flag and the corresponding API implementation.
 - Enable expermiental `state-scheme` flag to specify Firewood as a state database.
 - Added prometheus metrics for Firewood if it is enabled and expensive metrics are being used.
+- Disable incompatible APIs for Firewood.
 
 ## [v0.15.1](https://github.com/ava-labs/coreth/releases/tag/v0.15.1)
 

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -180,7 +180,6 @@ func (api *DebugAPI) StorageRangeAt(ctx context.Context, blockNrOrHash rpc.Block
 		return StorageRangeResult{}, errFirewoodNotSupported
 	}
 
-	var block *types.Block
 	block, err := api.eth.APIBackend.BlockByNumberOrHash(ctx, blockNrOrHash)
 	if err != nil {
 		return StorageRangeResult{}, err

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -176,7 +176,7 @@ type storageEntry struct {
 
 // StorageRangeAt returns the storage at the given block height and transaction index.
 func (api *DebugAPI) StorageRangeAt(ctx context.Context, blockNrOrHash rpc.BlockNumberOrHash, txIndex int, contractAddress common.Address, keyStart hexutil.Bytes, maxResult int) (StorageRangeResult, error) {
-	if api.eth.blockchain.CacheConfig().StateScheme == customrawdb.FirewoodScheme {
+	if api.isFirewood() {
 		return StorageRangeResult{}, errFirewoodNotSupported
 	}
 
@@ -238,7 +238,7 @@ func storageRangeAt(statedb *state.StateDB, root common.Hash, address common.Add
 //
 // With one parameter, returns the list of accounts modified in the specified block.
 func (api *DebugAPI) GetModifiedAccountsByNumber(startNum uint64, endNum *uint64) ([]common.Address, error) {
-	if api.eth.blockchain.CacheConfig().StateScheme == customrawdb.FirewoodScheme {
+	if api.isFirewood() {
 		return nil, errFirewoodNotSupported
 	}
 
@@ -269,7 +269,7 @@ func (api *DebugAPI) GetModifiedAccountsByNumber(startNum uint64, endNum *uint64
 //
 // With one parameter, returns the list of accounts modified in the specified block.
 func (api *DebugAPI) GetModifiedAccountsByHash(startHash common.Hash, endHash *common.Hash) ([]common.Address, error) {
-	if api.eth.blockchain.CacheConfig().StateScheme == customrawdb.FirewoodScheme {
+	if api.isFirewood() {
 		return nil, errFirewoodNotSupported
 	}
 
@@ -339,6 +339,9 @@ func (api *DebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64, error
 	if api.eth.blockchain.TrieDB().Scheme() == rawdb.PathScheme {
 		return 0, errors.New("state history is not yet available in path-based scheme")
 	}
+	if api.isFirewood() {
+		return 0, errFirewoodNotSupported
+	}
 	var resolveNum = func(num rpc.BlockNumber) (uint64, error) {
 		// We don't have state for pending (-2), so treat it as latest
 		if num.Int64() < 0 {
@@ -383,4 +386,8 @@ func (api *DebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64, error
 		}
 	}
 	return 0, errors.New("no state found")
+}
+
+func (api *DebugAPI) isFirewood() bool {
+	return api.eth.blockchain.CacheConfig().StateScheme == customrawdb.FirewoodScheme
 }

--- a/eth/api_debug.go
+++ b/eth/api_debug.go
@@ -339,9 +339,6 @@ func (api *DebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64, error
 	if api.eth.blockchain.TrieDB().Scheme() == rawdb.PathScheme {
 		return 0, errors.New("state history is not yet available in path-based scheme")
 	}
-	if api.isFirewood() {
-		return 0, errFirewoodNotSupported
-	}
 	var resolveNum = func(num rpc.BlockNumber) (uint64, error) {
 		// We don't have state for pending (-2), so treat it as latest
 		if num.Int64() < 0 {
@@ -381,7 +378,7 @@ func (api *DebugAPI) GetAccessibleState(from, to rpc.BlockNumber) (uint64, error
 		if h == nil {
 			return 0, fmt.Errorf("missing header %d", i)
 		}
-		if ok, _ := api.eth.ChainDb().Has(h.Root[:]); ok {
+		if api.eth.BlockChain().HasState(h.Root) {
 			return uint64(i), nil
 		}
 	}

--- a/internal/ethapi/api.go
+++ b/internal/ethapi/api.go
@@ -42,6 +42,7 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/customtypes"
 	"github.com/ava-labs/coreth/rpc"
+	"github.com/ava-labs/coreth/triedb/firewood"
 	"github.com/ava-labs/libevm/accounts"
 	"github.com/ava-labs/libevm/accounts/keystore"
 	"github.com/ava-labs/libevm/accounts/scwallet"
@@ -702,6 +703,9 @@ func (s *BlockChainAPI) GetProof(ctx context.Context, address common.Address, st
 	statedb, header, err := s.b.StateAndHeaderByNumberOrHash(ctx, blockNrOrHash)
 	if statedb == nil || err != nil {
 		return nil, err
+	}
+	if _, ok := statedb.Database().TrieDB().Backend().(*firewood.Database); ok {
+		return nil, errors.New("firewood database does not yet support getProof")
 	}
 	codeHash := statedb.GetCodeHash(address)
 	storageRoot := statedb.GetStorageRoot(address)

--- a/plugin/evm/config/config.md
+++ b/plugin/evm/config/config.md
@@ -186,6 +186,11 @@ Adds the following RPC calls to the `debug_*` namespace. Defaults to `false`.
 - `debug_getModifiedAccountsByHash`
 - `debug_getAccessibleState`
 
+The following RPC calls are disabled for any nodes with `state-scheme = firewood`:
+- `debug_storageRangeAt`
+- `debug_getModifiedAccountsByNumber`
+- `debug_getModifiedAccountsByHash`
+
 ### `net`
 
 Adds the following RPC calls to the `net_*` namespace. Defaults to `true`.
@@ -250,6 +255,8 @@ Adds the following RPC calls to the `eth_*` namespace. Defaults to `true`.
 - `eth_call`
 - `eth_estimateGas`
 - `eth_createAccessList`
+
+`eth_getProof` is disabled for any node with `state-scheme = firewood`
 
 ### `internal-transaction`
 


### PR DESCRIPTION
## Why this should be merged

Some of the eth APIs use `trie.StateTrie`, which is specific to geth's two-tier in-memory trie. These are not safe to be used with Firewood, since the intermediate nodes will not be found as expected. 

A long-term fix, if these APIs are necessary, would be to implement a Firewood-specific iterator in the FFI, and an easily-parsable proof method.

## How this works

This just returns an error if Firewood is used for these nodes.

## How this was tested

This is really hard to test. It can only occur in a production environment.

## Need to be documented?

Yes.

## Need to update RELEASES.md?

Yes.
