### PR TITLE
feat: Firewood metrics

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 - Demoted unnecessary error log in `core/txpool/legacypool.go` to warning, displaying unexpected but valid behavior.
 - Removed the `snowman-api-enabled` flag and the corresponding API implementation.
 - Enable expermiental `state-scheme` flag to specify Firewood as a state database.
+- Added prometheus metrics for Firewood if it is enabled and expensive metrics are being used.
 
 ## [v0.15.1](https://github.com/ava-labs/coreth/releases/tag/v0.15.1)
 

--- a/plugin/evm/config/config.md
+++ b/plugin/evm/config/config.md
@@ -536,7 +536,7 @@ Maximum duration a non-executable transaction will be allowed in the poll. Defau
 
 _Boolean_
 
-Enables expensive metrics. Defaults to `true`.
+Enables expensive metrics. This includes Firewood metrics. Defaults to `true`.
 
 ## Snapshots
 

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -535,7 +535,7 @@ func (vm *VM) initializeMetrics() error {
 		return err
 	}
 
-	if vm.config.MetricsExpensiveEnabled && vm.ethConfig.StateScheme == customrawdb.FirewoodScheme {
+	if vm.config.MetricsExpensiveEnabled && vm.config.StateScheme == customrawdb.FirewoodScheme {
 		if err := ffi.StartMetrics(); err != nil {
 			return fmt.Errorf("failed to start firewood metrics collection: %w", err)
 		}

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/extension"
 	"github.com/ava-labs/coreth/plugin/evm/gossip"
 	"github.com/ava-labs/coreth/plugin/evm/vmerrors"
+	"github.com/ava-labs/firewood-go-ethhash/ffi"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
@@ -532,6 +533,15 @@ func (vm *VM) initializeMetrics() error {
 	gatherer := corethprometheus.NewGatherer(metrics.DefaultRegistry)
 	if err := vm.ctx.Metrics.Register(ethMetricsPrefix, gatherer); err != nil {
 		return err
+	}
+
+	if vm.config.MetricsExpensiveEnabled && vm.ethConfig.StateScheme == customrawdb.FirewoodScheme {
+		if err := ffi.StartMetrics(); err != nil {
+			return fmt.Errorf("failed to start firewood metrics collection: %w", err)
+		}
+		if err := vm.ctx.Metrics.Register("firewood", ffi.Gatherer{}); err != nil {
+			return fmt.Errorf("failed to register firewood metrics: %w", err)
+		}
 	}
 	return vm.ctx.Metrics.Register(sdkMetricsPrefix, vm.sdkMetrics)
 }

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -263,7 +263,7 @@ func getConfig(scheme, otherConfig string) string {
 		if len(innerConfig) > 0 {
 			innerConfig += ", "
 		}
-		innerConfig += fmt.Sprintf(`"state-scheme": "%s", "snapshot-cache": 0, "pruning-enabled": true, "state-sync-enabled": false`, customrawdb.FirewoodScheme)
+		innerConfig += fmt.Sprintf(`"state-scheme": "%s", "snapshot-cache": 0, "pruning-enabled": true, "state-sync-enabled": false, "metrics-expensive-enabled": false`, customrawdb.FirewoodScheme)
 	}
 
 	return fmt.Sprintf(`{%s}`, innerConfig)


### PR DESCRIPTION
## Why this should be merged

Metrics inside Firewood's code are not yet tracked. This enables them.

## How this works

Firewood implemented a `Gatherer` that can be scraped by prometheus on the global metrics recorder in Rust via FFI.

## How this was tested

Tested locally using `tmpnet`.

## Need to be documented?

Yes.

## Need to update RELEASES.md?

Yes.
