### PR TITLE
ci: Add line display for avalanchego version script

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -118,4 +118,4 @@ tasks:
 
   update-avalanchego-version:
     desc: Update AvalancheGo version in go.mod and sync GitHub Actions workflow custom action version
-    cmd: ./scripts/update_avalanchego_version.sh # ci.yml 
+    cmd: bash -x ./scripts/update_avalanchego_version.sh # ci.yml 


### PR DESCRIPTION
Adds an option to running the update avalanchego script, to help coders identify any failures in CI.
