### PR TITLE
fix: Remove race between commits and reads

### DIFF
--- a/triedb/firewood/database.go
+++ b/triedb/firewood/database.go
@@ -503,6 +503,9 @@ type reader struct {
 // Node retrieves the trie node with the given node hash. No error will be
 // returned if the node is not found.
 func (reader *reader) Node(_ common.Hash, path []byte, _ common.Hash) ([]byte, error) {
+	// TODO: remove these locks once Firewood supports concurrent reads and commits.
+	reader.db.proposalLock.RLock()
+	defer reader.db.proposalLock.RUnlock()
 	// This function relies on Firewood's internal locking to ensure concurrent reads are safe.
 	// This is safe even if a proposal is being committed concurrently.
 	start := time.Now()


### PR DESCRIPTION
## Why this should be merged

A flaky test revealed that Firewood does not yet handle an edge case for committing a revision and reading from it at the same time. This fix does guarantee correctness, but removes a 5x performance increase. The next version of Firewood released will have a fix for this, and this change can be reverted.

## How this works

Uses the same lock as proposing and committing to ensure no contention.

## How this was tested

Bug identified in ava-labs/firewood#1138, ran 1000 times locally to provide confidence this was the issue.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.
