### PR TITLE
Fix summary metrics + flaky test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/onsi/ginkgo/v2 v2.13.1
 	github.com/prometheus/client_golang v1.22.0
 	github.com/prometheus/client_model v0.6.1
+	github.com/prometheus/common v0.62.0
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.12.0
@@ -122,7 +123,6 @@ require (
 	github.com/pires/go-proxyproto v0.6.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/rogpeppe/go-internal v1.12.0 // indirect

--- a/metrics/prometheus/prometheus.go
+++ b/metrics/prometheus/prometheus.go
@@ -174,7 +174,8 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 		}, nil
 	case metrics.ResettingTimer:
 		snapshot := m.Snapshot()
-		if snapshot.Count() == 0 {
+		count := snapshot.Count()
+		if count == 0 {
 			return nil, fmt.Errorf("%w: %q resetting timer metric count is zero", errMetricSkip, name)
 		}
 
@@ -193,7 +194,8 @@ func metricFamily(registry Registry, name string) (mf *dto.MetricFamily, err err
 			Type: dto.MetricType_SUMMARY.Enum(),
 			Metric: []*dto.Metric{{
 				Summary: &dto.Summary{
-					SampleCount: ptrTo(uint64(snapshot.Count())), //nolint:gosec
+					SampleCount: ptrTo(uint64(count)), //nolint:gosec
+					SampleSum:   ptrTo(float64(count) * snapshot.Mean()),
 					Quantile:    dtoQuantiles,
 				},
 			}},


### PR DESCRIPTION
## Why this should be merged

1. When I run the `TestGatherer_Gather` test locally, it fails consistently with:

```
--- FAIL: TestGatherer_Gather (0.00s)
    /Users/stephen/go/src/github.com/ava-labs/coreth/metrics/prometheus/prometheus_test.go:90: 
        	Error Trace:	/Users/stephen/go/src/github.com/ava-labs/coreth/metrics/prometheus/prometheus_test.go:90
        	Error:      	Not equal: 
        	            	expected: []string{"name:\"test_counter\" type:COUNTER metric:{counter:{value:12345}}", "name:\"test_counter_float64\" type:COUNTER metric:{counter:{value:1.1}}", "name:\"test_gauge\" type:GAUGE metric:{gauge:{value:23456}}", "name:\"test_gauge_float64\" type:GAUGE metric:{gauge:{value:34567.89}}", "name:\"test_histogram\" type:SUMMARY metric:{summary:{sample_count:0 sample_sum:0 quantile:{quantile:0.5 value:0} quantile:{quantile:0.75 value:0} quantile:{quantile:0.95 value:0} quantile:{quantile:0.99 value:0} quantile:{quantile:0.999 value:0} quantile:{quantile:0.9999 value:0}}}", "name:\"test_meter\" type:GAUGE metric:{gauge:{value:9.999999e+06}}", "name:\"test_resetting_timer\" type:SUMMARY metric:{summary:{sample_count:1 quantile:{quantile:50 value:1e+09} quantile:{quantile:95 value:1e+09} quantile:{quantile:99 value:1e+09}}}", "name:\"test_timer\" type:SUMMARY metric:{summary:{sample_count:6 sample_sum:2.3e+08 quantile:{quantile:0.5 value:2.25e+07} quantile:{quantile:0.75 value:4.8e+07} quantile:{quantile:0.95 value:1.2e+08} quantile:{quantile:0.99 value:1.2e+08} quantile:{quantile:0.999 value:1.2e+08} quantile:{quantile:0.9999 value:1.2e+08}}}"}
        	            	actual  : []string{"name:\"test_counter\"  type:COUNTER  metric:{counter:{value:12345}}", "name:\"test_counter_float64\"  type:COUNTER  metric:{counter:{value:1.1}}", "name:\"test_gauge\"  type:GAUGE  metric:{gauge:{value:23456}}", "name:\"test_gauge_float64\"  type:GAUGE  metric:{gauge:{value:34567.89}}", "name:\"test_histogram\"  type:SUMMARY  metric:{summary:{sample_count:0  sample_sum:0  quantile:{quantile:0.5  value:0}  quantile:{quantile:0.75  value:0}  quantile:{quantile:0.95  value:0}  quantile:{quantile:0.99  value:0}  quantile:{quantile:0.999  value:0}  quantile:{quantile:0.9999  value:0}}}", "name:\"test_meter\"  type:GAUGE  metric:{gauge:{value:9.999999e+06}}", "name:\"test_resetting_timer\"  type:SUMMARY  metric:{summary:{sample_count:1  quantile:{quantile:50  value:1e+09}  quantile:{quantile:95  value:1e+09}  quantile:{quantile:99  value:1e+09}}}", "name:\"test_timer\"  type:SUMMARY  metric:{summary:{sample_count:6  sample_sum:2.3e+08  quantile:{quantile:0.5  value:2.25e+07}  quantile:{quantile:0.75  value:4.8e+07}  quantile:{quantile:0.95  value:1.2e+08}  quantile:{quantile:0.99  value:1.2e+08}  quantile:{quantile:0.999  value:1.2e+08}  quantile:{quantile:0.9999  value:1.2e+08}}}"}
        	            	
        	            	Diff:
        	            	--- Expected
        	            	+++ Actual
        	            	@@ -1,10 +1,10 @@
        	            	 ([]string) (len=8) {
        	            	- (string) (len=63) "name:\"test_counter\" type:COUNTER metric:{counter:{value:12345}}",
        	            	- (string) (len=69) "name:\"test_counter_float64\" type:COUNTER metric:{counter:{value:1.1}}",
        	            	- (string) (len=57) "name:\"test_gauge\" type:GAUGE metric:{gauge:{value:23456}}",
        	            	- (string) (len=68) "name:\"test_gauge_float64\" type:GAUGE metric:{gauge:{value:34567.89}}",
        	            	- (string) (len=281) "name:\"test_histogram\" type:SUMMARY metric:{summary:{sample_count:0 sample_sum:0 quantile:{quantile:0.5 value:0} quantile:{quantile:0.75 value:0} quantile:{quantile:0.95 value:0} quantile:{quantile:0.99 value:0} quantile:{quantile:0.999 value:0} quantile:{quantile:0.9999 value:0}}}",
        	            	- (string) (len=64) "name:\"test_meter\" type:GAUGE metric:{gauge:{value:9.999999e+06}}",
        	            	- (string) (len=179) "name:\"test_resetting_timer\" type:SUMMARY metric:{summary:{sample_count:1 quantile:{quantile:50 value:1e+09} quantile:{quantile:95 value:1e+09} quantile:{quantile:99 value:1e+09}}}",
        	            	- (string) (len=320) "name:\"test_timer\" type:SUMMARY metric:{summary:{sample_count:6 sample_sum:2.3e+08 quantile:{quantile:0.5 value:2.25e+07} quantile:{quantile:0.75 value:4.8e+07} quantile:{quantile:0.95 value:1.2e+08} quantile:{quantile:0.99 value:1.2e+08} quantile:{quantile:0.999 value:1.2e+08} quantile:{quantile:0.9999 value:1.2e+08}}}"
        	            	+ (string) (len=65) "name:\"test_counter\"  type:COUNTER  metric:{counter:{value:12345}}",
        	            	+ (string) (len=71) "name:\"test_counter_float64\"  type:COUNTER  metric:{counter:{value:1.1}}",
        	            	+ (string) (len=59) "name:\"test_gauge\"  type:GAUGE  metric:{gauge:{value:23456}}",
        	            	+ (string) (len=70) "name:\"test_gauge_float64\"  type:GAUGE  metric:{gauge:{value:34567.89}}",
        	            	+ (string) (len=296) "name:\"test_histogram\"  type:SUMMARY  metric:{summary:{sample_count:0  sample_sum:0  quantile:{quantile:0.5  value:0}  quantile:{quantile:0.75  value:0}  quantile:{quantile:0.95  value:0}  quantile:{quantile:0.99  value:0}  quantile:{quantile:0.999  value:0}  quantile:{quantile:0.9999  value:0}}}",
        	            	+ (string) (len=66) "name:\"test_meter\"  type:GAUGE  metric:{gauge:{value:9.999999e+06}}",
        	            	+ (string) (len=187) "name:\"test_resetting_timer\"  type:SUMMARY  metric:{summary:{sample_count:1  quantile:{quantile:50  value:1e+09}  quantile:{quantile:95  value:1e+09}  quantile:{quantile:99  value:1e+09}}}",
        	            	+ (string) (len=335) "name:\"test_timer\"  type:SUMMARY  metric:{summary:{sample_count:6  sample_sum:2.3e+08  quantile:{quantile:0.5  value:2.25e+07}  quantile:{quantile:0.75  value:4.8e+07}  quantile:{quantile:0.95  value:1.2e+08}  quantile:{quantile:0.99  value:1.2e+08}  quantile:{quantile:0.999  value:1.2e+08}  quantile:{quantile:0.9999  value:1.2e+08}}}"
        	            	 }
        	Test:       	TestGatherer_Gather
FAIL
coverage: 9.4% of statements in all
FAIL	github.com/ava-labs/coreth/metrics/prometheus	0.562s
```

I don't know why the spacing is different locally (on my version there are `"  "` separators rather than `" "` in the test.

2. The summary metric includes a `Sum` field that we are currently ignoring (and therefore reporting as 0).

## How this works

1. Rather than utilizing the (non-standard) proto string format. This encodes the actual prometheus string format and parses it into a proto message using the canonical parser. The resulting proto messages are then compared to the proto messages returned from `Gather`.
2. `Sum` is calculated from `Count()` and `Mean()`.

## How this was tested

Unit tests.

## Need to be documented?

Nah.

## Need to update RELEASES.md?

No.