### PR TITLE
refactor(sync): add `blockSyncer` as a new syncer implementation

### DIFF
--- a/plugin/evm/syncervm_test.go
+++ b/plugin/evm/syncervm_test.go
@@ -63,7 +63,7 @@ func TestSkipStateSync(t *testing.T) {
 		stateSyncMinBlocks: 300, // must be greater than [syncableInterval] to skip sync
 		syncMode:           block.StateSyncSkipped,
 	}
-	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.ParentsToFetch)
+	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.BlocksToFetch)
 
 	testSyncerVM(t, vmSetup, test)
 }
@@ -75,14 +75,14 @@ func TestStateSyncFromScratch(t *testing.T) {
 		stateSyncMinBlocks: 50, // must be less than [syncableInterval] to perform sync
 		syncMode:           block.StateSyncStatic,
 	}
-	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.ParentsToFetch)
+	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.BlocksToFetch)
 
 	testSyncerVM(t, vmSetup, test)
 }
 
 func TestStateSyncFromScratchExceedParent(t *testing.T) {
 	rand.Seed(1)
-	numToGen := syncervm.ParentsToFetch + uint64(32)
+	numToGen := syncervm.BlocksToFetch + uint64(32)
 	test := syncTest{
 		syncableInterval:   numToGen,
 		stateSyncMinBlocks: 50, // must be less than [syncableInterval] to perform sync
@@ -121,7 +121,7 @@ func TestStateSyncToggleEnabledToDisabled(t *testing.T) {
 		},
 		expectedErr: context.Canceled,
 	}
-	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.ParentsToFetch)
+	vmSetup := createSyncServerAndClientVMs(t, test, syncervm.BlocksToFetch)
 
 	// Perform sync resulting in early termination.
 	testSyncerVM(t, vmSetup, test)
@@ -274,7 +274,7 @@ func TestVMShutdownWhileSyncing(t *testing.T) {
 		},
 		expectedErr: context.Canceled,
 	}
-	vmSetup = createSyncServerAndClientVMs(t, test, syncervm.ParentsToFetch)
+	vmSetup = createSyncServerAndClientVMs(t, test, syncervm.BlocksToFetch)
 	// Perform sync resulting in early termination.
 	testSyncerVM(t, vmSetup, test)
 }

--- a/sync/blocksync/syncer.go
+++ b/sync/blocksync/syncer.go
@@ -1,0 +1,137 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package blocksync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	synccommon "github.com/ava-labs/coreth/sync"
+	statesyncclient "github.com/ava-labs/coreth/sync/client"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/ava-labs/libevm/log"
+)
+
+var (
+	_ synccommon.Syncer = (*blockSyncer)(nil)
+
+	errNilClient       = errors.New("Client cannot be nil")
+	errNilDatabase     = errors.New("Database cannot be nil")
+	errInvalidFromHash = errors.New("FromHash cannot be empty")
+)
+
+type BlockSyncerConfig struct {
+	ChainDB      ethdb.Database
+	Client       statesyncclient.Client
+	FromHash     common.Hash
+	FromHeight   uint64
+	ParentsToGet uint64
+}
+
+func (c *BlockSyncerConfig) Validate() error {
+	if c.ChainDB == nil {
+		return errNilDatabase
+	}
+	if c.Client == nil {
+		return errNilClient
+	}
+	if c.FromHash == (common.Hash{}) {
+		return errInvalidFromHash
+	}
+	return nil
+}
+
+type blockSyncer struct {
+	*BlockSyncerConfig
+
+	err    chan error
+	cancel context.CancelFunc
+}
+
+func NewBlockSyncer(config *BlockSyncerConfig) (*blockSyncer, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+	return &blockSyncer{
+		BlockSyncerConfig: config,
+		err:               make(chan error),
+	}, nil
+}
+
+func (syncer *blockSyncer) Start(ctx context.Context) error {
+	cancelCtx, cancel := context.WithCancel(ctx)
+	syncer.cancel = cancel
+	go func() {
+		syncer.err <- syncer.syncBlocks(cancelCtx)
+	}()
+	return nil
+}
+
+func (syncer *blockSyncer) Wait(ctx context.Context) error {
+	if syncer.cancel == nil {
+		return synccommon.ErrWaitBeforeStart
+	}
+
+	select {
+	case err := <-syncer.err:
+		return err
+	case <-ctx.Done():
+		syncer.cancel()
+		<-syncer.err // wait for the syncer to finish
+		return ctx.Err()
+	}
+}
+
+// syncBlocks fetches (up to) [parentsToGet] blocks from peers
+// using [client] and writes them to disk.
+// the process begins with [fromHash] and it fetches parents recursively.
+// fetching starts from the first ancestor not found on disk
+func (syncer *blockSyncer) syncBlocks(ctx context.Context) error {
+	nextHash := syncer.FromHash
+	nextHeight := syncer.FromHeight
+	parentsPerRequest := uint16(32)
+
+	// first, check for blocks already available on disk so we don't
+	// request them from peers.
+	for syncer.ParentsToGet >= 0 {
+		blk := rawdb.ReadBlock(syncer.ChainDB, nextHash, nextHeight)
+		if blk != nil {
+			// block exists
+			nextHash = blk.ParentHash()
+			nextHeight--
+			syncer.ParentsToGet--
+			continue
+		}
+
+		// block was not found
+		break
+	}
+
+	// get any blocks we couldn't find on disk from peers and write
+	// them to disk.
+	batch := syncer.ChainDB.NewBatch()
+	for i := syncer.ParentsToGet - 1; i >= 0 && (nextHash != common.Hash{}); {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		blocks, err := syncer.Client.GetBlocks(ctx, nextHash, nextHeight, parentsPerRequest)
+		if err != nil {
+			return fmt.Errorf("could not get blocks from peer: err: %w, nextHash: %s, remaining: %d", err, nextHash, i+1)
+		}
+		for _, block := range blocks {
+			rawdb.WriteBlock(batch, block)
+			rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
+
+			i--
+			nextHash = block.ParentHash()
+			nextHeight--
+		}
+		log.Info("fetching blocks from peer", "remaining", i+1, "total", syncer.ParentsToGet)
+	}
+	log.Info("fetched blocks from peer", "total", syncer.ParentsToGet)
+	return batch.Write()
+}

--- a/sync/blocksync/syncer.go
+++ b/sync/blocksync/syncer.go
@@ -19,12 +19,13 @@ import (
 var (
 	_ synccommon.Syncer = (*blockSyncer)(nil)
 
-	errNilClient       = errors.New("Client cannot be nil")
-	errNilDatabase     = errors.New("Database cannot be nil")
-	errInvalidFromHash = errors.New("FromHash cannot be empty")
+	errNilClient                     = errors.New("Client cannot be nil")
+	errNilDatabase                   = errors.New("Database cannot be nil")
+	errInvalidFromHash               = errors.New("FromHash cannot be empty")
+	errParentsToGetExceedsFromHeight = errors.New("ParentsToGet cannot exceed FromHeight")
 )
 
-type BlockSyncerConfig struct {
+type Config struct {
 	ChainDB      ethdb.Database
 	Client       statesyncclient.Client
 	FromHash     common.Hash
@@ -32,7 +33,7 @@ type BlockSyncerConfig struct {
 	ParentsToGet uint64
 }
 
-func (c *BlockSyncerConfig) Validate() error {
+func (c *Config) Validate() error {
 	if c.ChainDB == nil {
 		return errNilDatabase
 	}
@@ -42,83 +43,90 @@ func (c *BlockSyncerConfig) Validate() error {
 	if c.FromHash == (common.Hash{}) {
 		return errInvalidFromHash
 	}
+	if c.ParentsToGet > c.FromHeight {
+		return errParentsToGetExceedsFromHeight
+	}
 	return nil
 }
 
 type blockSyncer struct {
-	*BlockSyncerConfig
+	config *Config
 
 	err    chan error
 	cancel context.CancelFunc
 }
 
-func NewBlockSyncer(config *BlockSyncerConfig) (*blockSyncer, error) {
+func NewSyncer(config *Config) (*blockSyncer, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
 	return &blockSyncer{
-		BlockSyncerConfig: config,
-		err:               make(chan error),
+		config: config,
+		err:    make(chan error),
 	}, nil
 }
 
-func (syncer *blockSyncer) Start(ctx context.Context) error {
+func (s *blockSyncer) Start(ctx context.Context) error {
 	cancelCtx, cancel := context.WithCancel(ctx)
-	syncer.cancel = cancel
+	s.cancel = cancel
 	go func() {
-		syncer.err <- syncer.syncBlocks(cancelCtx)
+		s.err <- s.sync(cancelCtx)
 	}()
 	return nil
 }
 
-func (syncer *blockSyncer) Wait(ctx context.Context) error {
-	if syncer.cancel == nil {
+func (s *blockSyncer) Wait(ctx context.Context) error {
+	if s.cancel == nil {
 		return synccommon.ErrWaitBeforeStart
 	}
 
 	select {
-	case err := <-syncer.err:
+	case err := <-s.err:
 		return err
 	case <-ctx.Done():
-		syncer.cancel()
-		<-syncer.err // wait for the syncer to finish
+		s.cancel()
+		<-s.err // wait for the syncer to finish
 		return ctx.Err()
 	}
 }
 
-// syncBlocks fetches (up to) [parentsToGet] blocks from peers
-// using [client] and writes them to disk.
-// the process begins with [fromHash] and it fetches parents recursively.
+// sync fetches (up to) [ParentsToGet] blocks from peers
+// using [Client] and writes them to disk.
+// the process begins with [FromHash] and it fetches parents recursively.
 // fetching starts from the first ancestor not found on disk
-func (syncer *blockSyncer) syncBlocks(ctx context.Context) error {
-	nextHash := syncer.FromHash
-	nextHeight := syncer.FromHeight
+//
+// TODO: we will always fetch all the blocks, even if some blocks were
+// available on disk. This can happen if only the most recent block is
+// not available.
+func (s *blockSyncer) sync(ctx context.Context) error {
+	nextHash := s.config.FromHash
+	nextHeight := s.config.FromHeight
+	parentsToGet := int64(s.config.ParentsToGet)
 	parentsPerRequest := uint16(32)
 
 	// first, check for blocks already available on disk so we don't
 	// request them from peers.
-	for syncer.ParentsToGet >= 0 {
-		blk := rawdb.ReadBlock(syncer.ChainDB, nextHash, nextHeight)
-		if blk != nil {
-			// block exists
-			nextHash = blk.ParentHash()
-			nextHeight--
-			syncer.ParentsToGet--
-			continue
+	for parentsToGet >= 0 {
+		blk := rawdb.ReadBlock(s.config.ChainDB, nextHash, nextHeight)
+		if blk == nil {
+			// block was not found
+			break
 		}
 
-		// block was not found
-		break
+		// block exists
+		nextHash = blk.ParentHash()
+		nextHeight--
+		parentsToGet--
 	}
 
 	// get any blocks we couldn't find on disk from peers and write
 	// them to disk.
-	batch := syncer.ChainDB.NewBatch()
-	for i := syncer.ParentsToGet - 1; i >= 0 && (nextHash != common.Hash{}); {
+	batch := s.config.ChainDB.NewBatch()
+	for i := parentsToGet - 1; i >= 0 && (nextHash != common.Hash{}); {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		blocks, err := syncer.Client.GetBlocks(ctx, nextHash, nextHeight, parentsPerRequest)
+		blocks, err := s.config.Client.GetBlocks(ctx, nextHash, nextHeight, parentsPerRequest)
 		if err != nil {
 			return fmt.Errorf("could not get blocks from peer: err: %w, nextHash: %s, remaining: %d", err, nextHash, i+1)
 		}
@@ -130,8 +138,8 @@ func (syncer *blockSyncer) syncBlocks(ctx context.Context) error {
 			nextHash = block.ParentHash()
 			nextHeight--
 		}
-		log.Info("fetching blocks from peer", "remaining", i+1, "total", syncer.ParentsToGet)
+		log.Info("fetching blocks from peer", "remaining", i+1, "total", parentsToGet)
 	}
-	log.Info("fetched blocks from peer", "total", syncer.ParentsToGet)
+	log.Info("fetched blocks from peer", "total", parentsToGet)
 	return batch.Write()
 }

--- a/sync/blocksync/syncer.go
+++ b/sync/blocksync/syncer.go
@@ -16,21 +16,22 @@ import (
 	"github.com/ava-labs/libevm/log"
 )
 
+const blocksPerRequest = 32
+
 var (
 	_ synccommon.Syncer = (*blockSyncer)(nil)
 
-	errNilClient                     = errors.New("Client cannot be nil")
-	errNilDatabase                   = errors.New("Database cannot be nil")
-	errInvalidFromHash               = errors.New("FromHash cannot be empty")
-	errParentsToGetExceedsFromHeight = errors.New("ParentsToGet cannot exceed FromHeight")
+	errNilClient       = errors.New("Client cannot be nil")
+	errNilDatabase     = errors.New("Database cannot be nil")
+	errInvalidFromHash = errors.New("FromHash cannot be empty")
 )
 
 type Config struct {
-	ChainDB      ethdb.Database
-	Client       statesyncclient.Client
-	FromHash     common.Hash
-	FromHeight   uint64
-	ParentsToGet uint64
+	ChainDB       ethdb.Database
+	Client        statesyncclient.Client
+	FromHash      common.Hash // `FromHash` is the most recent
+	FromHeight    uint64
+	BlocksToFetch uint64 // Includes the `FromHash` block
 }
 
 func (c *Config) Validate() error {
@@ -42,9 +43,6 @@ func (c *Config) Validate() error {
 	}
 	if c.FromHash == (common.Hash{}) {
 		return errInvalidFromHash
-	}
-	if c.ParentsToGet > c.FromHeight {
-		return errParentsToGetExceedsFromHeight
 	}
 	return nil
 }
@@ -62,11 +60,15 @@ func NewSyncer(config *Config) (*blockSyncer, error) {
 	}
 	return &blockSyncer{
 		config: config,
-		err:    make(chan error),
+		err:    make(chan error, 1),
 	}, nil
 }
 
 func (s *blockSyncer) Start(ctx context.Context) error {
+	if s.cancel != nil {
+		return synccommon.ErrSyncerAlreadyStarted
+	}
+
 	cancelCtx, cancel := context.WithCancel(ctx)
 	s.cancel = cancel
 	go func() {
@@ -90,23 +92,23 @@ func (s *blockSyncer) Wait(ctx context.Context) error {
 	}
 }
 
-// sync fetches (up to) [ParentsToGet] blocks from peers
-// using [Client] and writes them to disk.
-// the process begins with [FromHash] and it fetches parents recursively.
+// sync fetches (up to) BlocksToFetch blocks from peers
+// using Client and writes them to disk.
+// the process begins with FromHash and it fetches parents recursively.
 // fetching starts from the first ancestor not found on disk
 //
-// TODO: we will always fetch all the blocks, even if some blocks were
-// available on disk. This can happen if only the most recent block is
-// not available.
+// TODO: We could inspect the database more accurately to ensure we never fetch
+// any blocks that are locally available.
+// We could also prevent overrequesting blocks, if the number of blocks needed
+// to be fetched isn't a multiple of blocksPerRequest.
 func (s *blockSyncer) sync(ctx context.Context) error {
 	nextHash := s.config.FromHash
 	nextHeight := s.config.FromHeight
-	parentsToGet := int64(s.config.ParentsToGet)
-	parentsPerRequest := uint16(32)
+	blocksToFetch := s.config.BlocksToFetch
 
 	// first, check for blocks already available on disk so we don't
 	// request them from peers.
-	for parentsToGet >= 0 {
+	for blocksToFetch > 0 {
 		blk := rawdb.ReadBlock(s.config.ChainDB, nextHash, nextHeight)
 		if blk == nil {
 			// block was not found
@@ -116,30 +118,28 @@ func (s *blockSyncer) sync(ctx context.Context) error {
 		// block exists
 		nextHash = blk.ParentHash()
 		nextHeight--
-		parentsToGet--
+		blocksToFetch--
 	}
 
 	// get any blocks we couldn't find on disk from peers and write
 	// them to disk.
 	batch := s.config.ChainDB.NewBatch()
-	for i := parentsToGet - 1; i >= 0 && (nextHash != common.Hash{}); {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		blocks, err := s.config.Client.GetBlocks(ctx, nextHash, nextHeight, parentsPerRequest)
+	for fetched := uint64(0); fetched < blocksToFetch && (nextHash != common.Hash{}); {
+		log.Info("fetching blocks from peer", "fetched", fetched, "total", blocksToFetch)
+		blocks, err := s.config.Client.GetBlocks(ctx, nextHash, nextHeight, blocksPerRequest)
 		if err != nil {
-			return fmt.Errorf("could not get blocks from peer: err: %w, nextHash: %s, remaining: %d", err, nextHash, i+1)
+			return fmt.Errorf("could not get blocks from peer: err: %w, nextHash: %s, fetched: %d", err, nextHash, fetched)
 		}
 		for _, block := range blocks {
 			rawdb.WriteBlock(batch, block)
 			rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
 
-			i--
+			fetched++
 			nextHash = block.ParentHash()
 			nextHeight--
 		}
-		log.Info("fetching blocks from peer", "remaining", i+1, "total", parentsToGet)
 	}
-	log.Info("fetched blocks from peer", "total", parentsToGet)
+
+	log.Info("fetched blocks from peer", "total", blocksToFetch)
 	return batch.Write()
 }

--- a/sync/blocksync/syncer_test.go
+++ b/sync/blocksync/syncer_test.go
@@ -1,0 +1,323 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package blocksync
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ava-labs/coreth/consensus/dummy"
+	"github.com/ava-labs/coreth/core"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/plugin/evm/message"
+	synccommon "github.com/ava-labs/coreth/sync"
+	syncclient "github.com/ava-labs/coreth/sync/client"
+	"github.com/ava-labs/coreth/sync/handlers"
+	handlerstats "github.com/ava-labs/coreth/sync/handlers/stats"
+	"github.com/ava-labs/libevm/common"
+	"github.com/ava-labs/libevm/core/rawdb"
+	"github.com/ava-labs/libevm/core/types"
+	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/ethdb"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConfigValidation(t *testing.T) {
+	mockClient := syncclient.NewTestClient(
+		message.Codec,
+		nil,
+		nil,
+		nil,
+	)
+	validHash := common.HexToHash("0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef")
+
+	tests := []struct {
+		name    string
+		config  *Config
+		wantErr error
+	}{
+		{
+			name:    "valid config",
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			wantErr: nil,
+		},
+		{
+			name:    "nil database",
+			config:  &Config{ChainDB: nil, Client: mockClient, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			wantErr: errNilDatabase,
+		},
+		{
+			name:    "nil client",
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: nil, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			wantErr: errNilClient,
+		},
+		{
+			name:    "empty from hash",
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: common.Hash{}, FromHeight: 10, ParentsToGet: 5},
+			wantErr: errInvalidFromHash,
+		},
+		{
+			name:    "parents to get exceeds from height",
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: validHash, FromHeight: 2, ParentsToGet: 5},
+			wantErr: errParentsToGetExceedsFromHeight,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.config.Validate()
+			require.ErrorIs(t, err, tt.wantErr)
+		})
+	}
+}
+
+func TestWaitBeforeStart(t *testing.T) {
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+
+	syncer, err := env.createSyncer(5, 3)
+	require.NoError(t, err)
+	require.NotNil(t, syncer)
+
+	err = syncer.Wait(context.Background())
+	require.ErrorIs(t, err, synccommon.ErrWaitBeforeStart)
+}
+
+func TestBlockSyncer_NormalCase(t *testing.T) {
+	// Test normal case where all blocks are retrieved from network
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	syncer, err := env.createSyncer(5, 3) // Sync blocks 3, 4, 5 (fromHeight=5, parentsToGet=3)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify blocks 3, 4, 5 are in database
+	env.verifyBlocksInDB(t, []int{3, 4, 5})
+}
+
+func TestBlockSyncer_AllBlocksAlreadyAvailable(t *testing.T) {
+	// Test case where all blocks are already on disk
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	// Pre-populate blocks 3, 4, 5 in the database
+	env.prePopulateBlocks(3, 4, 5)
+	syncer, err := env.createSyncer(5, 3) // Sync blocks 3, 4, 5
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify blocks 3, 4, 5 are still in database
+	env.verifyBlocksInDB(t, []int{3, 4, 5})
+
+	// Client should not have received any block requests since all blocks were on disk
+	require.Equal(t, int32(0), env.client.BlocksReceived())
+}
+
+func TestBlockSyncer_SomeBlocksAlreadyAvailable(t *testing.T) {
+	// Test case where some blocks are already on disk
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	// Pre-populate only blocks 4 and 5 in the database
+	env.prePopulateBlocks(4, 5)
+	syncer, err := env.createSyncer(5, 3) // Sync blocks 3, 4, 5
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify all blocks 3, 4, 5 are in database
+	env.verifyBlocksInDB(t, []int{3, 4, 5})
+}
+
+func TestBlockSyncer_MostRecentBlockMissing(t *testing.T) {
+	// Test case where only the most recent block is missing
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	// Pre-populate blocks 3 and 4, but not 5
+	env.prePopulateBlocks(3, 4)
+	syncer, err := env.createSyncer(5, 3) // Sync blocks 3, 4, 5
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify all blocks 3, 4, 5 are in database
+	env.verifyBlocksInDB(t, []int{3, 4, 5})
+}
+
+func TestBlockSyncer_EdgeCaseFromHeight1(t *testing.T) {
+	// Test syncing from the first generated block (height 1)
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	syncer, err := env.createSyncer(1, 1) // Sync only block 1
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify block 1 is in database
+	env.verifyBlocksInDB(t, []int{1})
+}
+
+func TestBlockSyncer_SingleBlock(t *testing.T) {
+	// Test syncing a single block in the middle of the chain
+	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+
+	syncer, err := env.createSyncer(7, 1) // Sync only block 7
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, syncer.Start(ctx))
+	require.NoError(t, syncer.Wait(ctx))
+
+	// Verify only block 7 is in database
+	env.verifyBlocksInDB(t, []int{7})
+}
+
+func TestBlockSyncer_ContextCancellation(t *testing.T) {
+	// Allow some time for startup for cancellation
+	env := newTestEnvironment(t, 10).withCustomBlockProvider(func(hash common.Hash, height uint64) *types.Block {
+		time.Sleep(100 * time.Millisecond)
+		return nil
+	})
+
+	syncer, err := env.createSyncer(5, 3)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	require.NoError(t, syncer.Start(ctx))
+
+	// Cancel context immediately
+	cancel()
+
+	err = syncer.Wait(ctx)
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// testEnvironment provides an abstraction for setting up block syncer tests
+type testEnvironment struct {
+	chainDB ethdb.Database
+	client  *syncclient.TestClient
+	blocks  []*types.Block
+}
+
+// newTestEnvironment creates a new test environment with generated blocks
+func newTestEnvironment(t *testing.T, numBlocks int) *testEnvironment {
+	t.Helper()
+
+	var (
+		key1, _        = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		key2, _        = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
+		addr1          = crypto.PubkeyToAddress(key1.PublicKey)
+		addr2          = crypto.PubkeyToAddress(key2.PublicKey)
+		genesisBalance = big.NewInt(1000000000)
+		signer         = types.HomesteadSigner{}
+	)
+
+	// Ensure that key1 has some funds in the genesis block.
+	gspec := &core.Genesis{
+		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
+		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+	}
+	engine := dummy.NewETHFaker()
+
+	_, blocks, _, err := core.GenerateChainWithGenesis(gspec, engine, numBlocks, 0, func(i int, gen *core.BlockGen) {
+		// Generate a transaction to create a unique block
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10), params.TxGas, nil, nil), signer, key1)
+		gen.AddTx(tx)
+	})
+	require.NoError(t, err)
+
+	// The genesis block is not include in the blocks slice, so we need to prepend it
+	blocks = append([]*types.Block{gspec.ToBlock()}, blocks...)
+
+	return &testEnvironment{
+		chainDB: rawdb.NewMemoryDatabase(),
+		blocks:  blocks,
+	}
+}
+
+// withCustomBlockProvider sets up the test client with a custom block provider function
+func (e *testEnvironment) withCustomBlockProvider(onGetBlock func(hash common.Hash, height uint64) *types.Block) *testEnvironment {
+	blockProvider := &handlers.TestBlockProvider{GetBlockFn: onGetBlock}
+	blockHandler := handlers.NewBlockRequestHandler(
+		blockProvider,
+		message.Codec,
+		handlerstats.NewNoopHandlerStats(),
+	)
+	e.client = syncclient.NewTestClient(
+		message.Codec,
+		nil,
+		nil,
+		blockHandler,
+	)
+	return e
+}
+
+// withDefaultBlockProvider sets up the test client with a provider that returns all blocks
+func (e *testEnvironment) withDefaultBlockProvider() *testEnvironment {
+	return e.withCustomBlockProvider(func(hash common.Hash, height uint64) *types.Block {
+		if height > uint64(len(e.blocks)) {
+			return nil
+		}
+		block := e.blocks[height]
+		if block.Hash() != hash {
+			return nil
+		}
+		return block
+	})
+}
+
+// prePopulateBlocks writes some blocks to the database before syncing (by block height)
+func (e *testEnvironment) prePopulateBlocks(blockHeights ...int) *testEnvironment {
+	batch := e.chainDB.NewBatch()
+	for _, height := range blockHeights {
+		if height <= len(e.blocks) {
+			// blocks[0] is block number 1, blocks[1] is block number 2, etc.
+			block := e.blocks[height]
+			rawdb.WriteBlock(batch, block)
+			rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
+		}
+	}
+	require.NoError(nil, batch.Write())
+	return e
+}
+
+// createSyncer creates a block syncer with the given configuration
+func (e *testEnvironment) createSyncer(fromHeight uint64, parentsToGet uint64) (*blockSyncer, error) {
+	if fromHeight > uint64(len(e.blocks)) {
+		return nil, fmt.Errorf("fromHeight %d exceeds available blocks %d", fromHeight, len(e.blocks))
+	}
+
+	config := &Config{
+		ChainDB:      e.chainDB,
+		Client:       e.client,
+		FromHash:     e.blocks[fromHeight].Hash(),
+		FromHeight:   fromHeight,
+		ParentsToGet: parentsToGet,
+	}
+
+	return NewSyncer(config)
+}
+
+// verifyBlocksInDB checks that the expected blocks are present in the database (by block height)
+func (e *testEnvironment) verifyBlocksInDB(t *testing.T, expectedBlockHeights []int) {
+	t.Helper()
+
+	// Verify expected blocks are present
+	for _, height := range expectedBlockHeights {
+		if height > len(e.blocks) {
+			continue
+		}
+		block := e.blocks[height]
+		dbBlock := rawdb.ReadBlock(e.chainDB, block.Hash(), block.NumberU64())
+		require.NotNil(t, dbBlock, "Block %d should be in database", height)
+		require.Equal(t, block.Hash(), dbBlock.Hash(), "Block %d hash mismatch", height)
+	}
+}

--- a/sync/blocksync/syncer_test.go
+++ b/sync/blocksync/syncer_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/big"
 	"testing"
-	"time"
 
 	"github.com/ava-labs/coreth/consensus/dummy"
 	"github.com/ava-labs/coreth/core"
@@ -42,28 +41,23 @@ func TestConfigValidation(t *testing.T) {
 	}{
 		{
 			name:    "valid config",
-			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: validHash, FromHeight: 10, BlocksToFetch: 5},
 			wantErr: nil,
 		},
 		{
 			name:    "nil database",
-			config:  &Config{ChainDB: nil, Client: mockClient, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			config:  &Config{ChainDB: nil, Client: mockClient, FromHash: validHash, FromHeight: 10, BlocksToFetch: 5},
 			wantErr: errNilDatabase,
 		},
 		{
 			name:    "nil client",
-			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: nil, FromHash: validHash, FromHeight: 10, ParentsToGet: 5},
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: nil, FromHash: validHash, FromHeight: 10, BlocksToFetch: 5},
 			wantErr: errNilClient,
 		},
 		{
 			name:    "empty from hash",
-			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: common.Hash{}, FromHeight: 10, ParentsToGet: 5},
+			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: common.Hash{}, FromHeight: 10, BlocksToFetch: 5},
 			wantErr: errInvalidFromHash,
-		},
-		{
-			name:    "parents to get exceeds from height",
-			config:  &Config{ChainDB: rawdb.NewMemoryDatabase(), Client: mockClient, FromHash: validHash, FromHeight: 2, ParentsToGet: 5},
-			wantErr: errParentsToGetExceedsFromHeight,
 		},
 	}
 
@@ -76,7 +70,7 @@ func TestConfigValidation(t *testing.T) {
 }
 
 func TestWaitBeforeStart(t *testing.T) {
-	env := newTestEnvironment(t, 10).withDefaultBlockProvider()
+	env := newTestEnvironment(t, 10)
 
 	syncer, err := env.createSyncer(5, 3)
 	require.NoError(t, err)
@@ -92,7 +86,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 		numBlocks                int
 		prePopulateBlocks        []int
 		fromHeight               uint64
-		parentsToGet             uint64
+		blocksToFetch            uint64
 		expectedBlocks           []int
 		verifyZeroBlocksReceived bool
 	}{
@@ -100,7 +94,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 			name:           "normal case - all blocks retrieved from network",
 			numBlocks:      10,
 			fromHeight:     5,
-			parentsToGet:   3,
+			blocksToFetch:  3,
 			expectedBlocks: []int{3, 4, 5},
 		},
 		{
@@ -108,7 +102,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 			numBlocks:                10,
 			prePopulateBlocks:        []int{3, 4, 5},
 			fromHeight:               5,
-			parentsToGet:             3,
+			blocksToFetch:            3,
 			expectedBlocks:           []int{3, 4, 5},
 			verifyZeroBlocksReceived: true,
 		},
@@ -117,7 +111,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 			numBlocks:         10,
 			prePopulateBlocks: []int{4, 5},
 			fromHeight:        5,
-			parentsToGet:      3,
+			blocksToFetch:     3,
 			expectedBlocks:    []int{3, 4, 5},
 		},
 		{
@@ -125,41 +119,41 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 			numBlocks:         10,
 			prePopulateBlocks: []int{3, 4},
 			fromHeight:        5,
-			parentsToGet:      3,
+			blocksToFetch:     3,
 			expectedBlocks:    []int{3, 4, 5},
 		},
 		{
 			name:           "edge case - from height 1",
 			numBlocks:      10,
 			fromHeight:     1,
-			parentsToGet:   1,
+			blocksToFetch:  1,
 			expectedBlocks: []int{1},
 		},
 		{
 			name:           "single block sync",
 			numBlocks:      10,
 			fromHeight:     7,
-			parentsToGet:   1,
+			blocksToFetch:  1,
 			expectedBlocks: []int{7},
 		},
 		{
 			name:           "large sync - many blocks",
 			numBlocks:      50,
 			fromHeight:     40,
-			parentsToGet:   35,
+			blocksToFetch:  35,
 			expectedBlocks: []int{6, 10, 20, 30, 40},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			env := newTestEnvironment(t, tt.numBlocks).withDefaultBlockProvider()
+			env := newTestEnvironment(t, tt.numBlocks)
 
 			if len(tt.prePopulateBlocks) > 0 {
-				env.prePopulateBlocks(tt.prePopulateBlocks...)
+				require.NoError(t, env.prePopulateBlocks(tt.prePopulateBlocks))
 			}
 
-			syncer, err := env.createSyncer(tt.fromHeight, tt.parentsToGet)
+			syncer, err := env.createSyncer(tt.fromHeight, tt.blocksToFetch)
 			require.NoError(t, err)
 
 			ctx := context.Background()
@@ -177,11 +171,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 }
 
 func TestBlockSyncer_ContextCancellation(t *testing.T) {
-	// Allow some time for startup for cancellation
-	env := newTestEnvironment(t, 10).withCustomBlockProvider(func(hash common.Hash, height uint64) *types.Block {
-		time.Sleep(100 * time.Millisecond)
-		return nil
-	})
+	env := newTestEnvironment(t, 10)
 
 	syncer, err := env.createSyncer(5, 3)
 	require.NoError(t, err)
@@ -208,24 +198,22 @@ func newTestEnvironment(t *testing.T, numBlocks int) *testEnvironment {
 	t.Helper()
 
 	var (
-		key1, _        = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
-		key2, _        = crypto.HexToECDSA("8a1f9a8f95be41cd7ccb6168179afb4504aefe388d1e14474d32c45c72ce7b7a")
-		addr1          = crypto.PubkeyToAddress(key1.PublicKey)
-		addr2          = crypto.PubkeyToAddress(key2.PublicKey)
+		key, _         = crypto.HexToECDSA("b71c71a67e1177ad4e901695e1b4b9ee17ae16c6668d313eac2f96dbcda3f291")
+		addr           = crypto.PubkeyToAddress(key.PublicKey)
 		genesisBalance = big.NewInt(1000000000)
 		signer         = types.HomesteadSigner{}
 	)
 
-	// Ensure that key1 has some funds in the genesis block.
+	// Ensure that key has some funds in the genesis block.
 	gspec := &core.Genesis{
 		Config: &params.ChainConfig{HomesteadBlock: new(big.Int)},
-		Alloc:  types.GenesisAlloc{addr1: {Balance: genesisBalance}},
+		Alloc:  types.GenesisAlloc{addr: {Balance: genesisBalance}},
 	}
 	engine := dummy.NewETHFaker()
 
 	_, blocks, _, err := core.GenerateChainWithGenesis(gspec, engine, numBlocks, 0, func(i int, gen *core.BlockGen) {
 		// Generate a transaction to create a unique block
-		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr1), addr2, big.NewInt(10), params.TxGas, nil, nil), signer, key1)
+		tx, _ := types.SignTx(types.NewTransaction(gen.TxNonce(addr), addr, big.NewInt(10), params.TxGas, nil, nil), signer, key)
 		gen.AddTx(tx)
 	})
 	require.NoError(t, err)
@@ -233,45 +221,37 @@ func newTestEnvironment(t *testing.T, numBlocks int) *testEnvironment {
 	// The genesis block is not include in the blocks slice, so we need to prepend it
 	blocks = append([]*types.Block{gspec.ToBlock()}, blocks...)
 
-	return &testEnvironment{
-		chainDB: rawdb.NewMemoryDatabase(),
-		blocks:  blocks,
-	}
-}
+	blockProvider := &handlers.TestBlockProvider{GetBlockFn: func(hash common.Hash, height uint64) *types.Block {
+		if height >= uint64(len(blocks)) {
+			return nil
+		}
+		block := blocks[height]
+		if block.Hash() != hash {
+			return nil
+		}
+		return block
+	}}
 
-// withCustomBlockProvider sets up the test client with a custom block provider function
-func (e *testEnvironment) withCustomBlockProvider(onGetBlock func(hash common.Hash, height uint64) *types.Block) *testEnvironment {
-	blockProvider := &handlers.TestBlockProvider{GetBlockFn: onGetBlock}
 	blockHandler := handlers.NewBlockRequestHandler(
 		blockProvider,
 		message.Codec,
 		handlerstats.NewNoopHandlerStats(),
 	)
-	e.client = syncclient.NewTestClient(
-		message.Codec,
-		nil,
-		nil,
-		blockHandler,
-	)
-	return e
-}
 
-// withDefaultBlockProvider sets up the test client with a provider that returns all blocks
-func (e *testEnvironment) withDefaultBlockProvider() *testEnvironment {
-	return e.withCustomBlockProvider(func(hash common.Hash, height uint64) *types.Block {
-		if height > uint64(len(e.blocks)) {
-			return nil
-		}
-		block := e.blocks[height]
-		if block.Hash() != hash {
-			return nil
-		}
-		return block
-	})
+	return &testEnvironment{
+		chainDB: rawdb.NewMemoryDatabase(),
+		blocks:  blocks,
+		client: syncclient.NewTestClient(
+			message.Codec,
+			nil,
+			nil,
+			blockHandler,
+		),
+	}
 }
 
 // prePopulateBlocks writes some blocks to the database before syncing (by block height)
-func (e *testEnvironment) prePopulateBlocks(blockHeights ...int) *testEnvironment {
+func (e *testEnvironment) prePopulateBlocks(blockHeights []int) error {
 	batch := e.chainDB.NewBatch()
 	for _, height := range blockHeights {
 		if height <= len(e.blocks) {
@@ -281,22 +261,21 @@ func (e *testEnvironment) prePopulateBlocks(blockHeights ...int) *testEnvironmen
 			rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
 		}
 	}
-	require.NoError(nil, batch.Write())
-	return e
+	return batch.Write()
 }
 
 // createSyncer creates a block syncer with the given configuration
-func (e *testEnvironment) createSyncer(fromHeight uint64, parentsToGet uint64) (*blockSyncer, error) {
+func (e *testEnvironment) createSyncer(fromHeight uint64, blocksToFetch uint64) (*blockSyncer, error) {
 	if fromHeight > uint64(len(e.blocks)) {
 		return nil, fmt.Errorf("fromHeight %d exceeds available blocks %d", fromHeight, len(e.blocks))
 	}
 
 	config := &Config{
-		ChainDB:      e.chainDB,
-		Client:       e.client,
-		FromHash:     e.blocks[fromHeight].Hash(),
-		FromHeight:   fromHeight,
-		ParentsToGet: parentsToGet,
+		ChainDB:       e.chainDB,
+		Client:        e.client,
+		FromHash:      e.blocks[fromHeight].Hash(),
+		FromHeight:    fromHeight,
+		BlocksToFetch: blocksToFetch,
 	}
 
 	return NewSyncer(config)

--- a/sync/vm/client.go
+++ b/sync/vm/client.go
@@ -202,7 +202,7 @@ func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegis
 }
 
 func (client *client) createBlockSyncer(ctx context.Context, fromHash common.Hash, fromHeight uint64, parentsToGet int) (synccommon.Syncer, error) {
-	return blocksync.NewBlockSyncer(&blocksync.BlockSyncerConfig{
+	return blocksync.NewSyncer(&blocksync.Config{
 		ChainDB:      client.ChainDB,
 		Client:       client.Client,
 		FromHash:     fromHash,

--- a/sync/vm/client.go
+++ b/sync/vm/client.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	synccommon "github.com/ava-labs/coreth/sync"
+	"github.com/ava-labs/coreth/sync/blocksync"
 	syncclient "github.com/ava-labs/coreth/sync/client"
 	"github.com/ava-labs/coreth/sync/statesync"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/log"
@@ -34,6 +34,7 @@ const (
 	ParentsToFetch = 256
 
 	atomicStateSyncOperationName = "Atomic State Sync"
+	blockStateSyncOperationName  = "Block State Sync"
 	evmStateSyncOperationName    = "EVM State Sync"
 )
 
@@ -154,10 +155,6 @@ func (client *client) ParseStateSummary(_ context.Context, summaryBytes []byte) 
 }
 
 func (client *client) stateSync(ctx context.Context) error {
-	if err := client.syncBlocks(ctx, client.summary.GetBlockHash(), client.summary.Height(), ParentsToFetch); err != nil {
-		return err
-	}
-
 	// Create and register all syncers.
 	registry := NewSyncerRegistry()
 
@@ -170,6 +167,15 @@ func (client *client) stateSync(ctx context.Context) error {
 }
 
 func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegistry) error {
+	// Register block syncer.
+	syncer, err := client.createBlockSyncer(ctx, client.summary.GetBlockHash(), client.summary.Height(), ParentsToFetch)
+	if err != nil {
+		return fmt.Errorf("failed to create block syncer: %w", err)
+	}
+	if err := registry.Register(blockStateSyncOperationName, syncer); err != nil {
+		return fmt.Errorf("failed to register block syncer: %w", err)
+	}
+
 	// Register EVM state syncer.
 	evmSyncer, err := client.createEVMSyncer()
 	if err != nil {
@@ -193,6 +199,16 @@ func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegis
 	}
 
 	return nil
+}
+
+func (client *client) createBlockSyncer(ctx context.Context, fromHash common.Hash, fromHeight uint64, parentsToGet int) (synccommon.Syncer, error) {
+	return blocksync.NewBlockSyncer(&blocksync.BlockSyncerConfig{
+		ChainDB:      client.ChainDB,
+		Client:       client.Client,
+		FromHash:     fromHash,
+		FromHeight:   fromHeight,
+		ParentsToGet: uint64(parentsToGet),
+	})
 }
 
 func (client *client) createEVMSyncer() (synccommon.Syncer, error) {
@@ -275,57 +291,6 @@ func (client *client) acceptSyncSummary(proposedSummary message.Syncable) (block
 		close(client.StateSyncDone)
 	}()
 	return block.StateSyncStatic, nil
-}
-
-// syncBlocks fetches (up to) [parentsToGet] blocks from peers
-// using [client] and writes them to disk.
-// the process begins with [fromHash] and it fetches parents recursively.
-// fetching starts from the first ancestor not found on disk
-func (client *client) syncBlocks(ctx context.Context, fromHash common.Hash, fromHeight uint64, parentsToGet int) error {
-	nextHash := fromHash
-	nextHeight := fromHeight
-	parentsPerRequest := uint16(32)
-
-	// first, check for blocks already available on disk so we don't
-	// request them from peers.
-	for parentsToGet >= 0 {
-		blk := rawdb.ReadBlock(client.ChainDB, nextHash, nextHeight)
-		if blk != nil {
-			// block exists
-			nextHash = blk.ParentHash()
-			nextHeight--
-			parentsToGet--
-			continue
-		}
-
-		// block was not found
-		break
-	}
-
-	// get any blocks we couldn't find on disk from peers and write
-	// them to disk.
-	batch := client.ChainDB.NewBatch()
-	for i := parentsToGet - 1; i >= 0 && (nextHash != common.Hash{}); {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		blocks, err := client.Client.GetBlocks(ctx, nextHash, nextHeight, parentsPerRequest)
-		if err != nil {
-			log.Error("could not get blocks from peer", "err", err, "nextHash", nextHash, "remaining", i+1)
-			return err
-		}
-		for _, block := range blocks {
-			rawdb.WriteBlock(batch, block)
-			rawdb.WriteCanonicalHash(batch, block.Hash(), block.NumberU64())
-
-			i--
-			nextHash = block.ParentHash()
-			nextHeight--
-		}
-		log.Info("fetching blocks from peer", "remaining", i+1, "total", parentsToGet)
-	}
-	log.Info("fetched blocks from peer", "total", parentsToGet)
-	return batch.Write()
 }
 
 func (client *client) Shutdown() error {

--- a/sync/vm/client.go
+++ b/sync/vm/client.go
@@ -34,7 +34,7 @@ const (
 	BlocksToFetch = 256
 
 	atomicStateSyncOperationName = "Atomic State Sync"
-	blockStateSyncOperationName  = "Block Sync"
+	blockSyncOperationName       = "Block Sync"
 	evmStateSyncOperationName    = "EVM State Sync"
 )
 
@@ -172,7 +172,7 @@ func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegis
 	if err != nil {
 		return fmt.Errorf("failed to create block syncer: %w", err)
 	}
-	if err := registry.Register(blockStateSyncOperationName, syncer); err != nil {
+	if err := registry.Register(blockSyncOperationName, syncer); err != nil {
 		return fmt.Errorf("failed to register block syncer: %w", err)
 	}
 

--- a/sync/vm/client.go
+++ b/sync/vm/client.go
@@ -29,12 +29,12 @@ import (
 )
 
 const (
-	// ParentsToFetch is the number of the block parents the state syncs to.
+	// BlocksToFetch is the number of the block parents the state syncs to.
 	// The last 256 block hashes are necessary to support the BLOCKHASH opcode.
-	ParentsToFetch = 256
+	BlocksToFetch = 256
 
 	atomicStateSyncOperationName = "Atomic State Sync"
-	blockStateSyncOperationName  = "Block State Sync"
+	blockStateSyncOperationName  = "Block Sync"
 	evmStateSyncOperationName    = "EVM State Sync"
 )
 
@@ -168,7 +168,7 @@ func (client *client) stateSync(ctx context.Context) error {
 
 func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegistry) error {
 	// Register block syncer.
-	syncer, err := client.createBlockSyncer(ctx, client.summary.GetBlockHash(), client.summary.Height(), ParentsToFetch)
+	syncer, err := client.createBlockSyncer(ctx, client.summary.GetBlockHash(), client.summary.Height())
 	if err != nil {
 		return fmt.Errorf("failed to create block syncer: %w", err)
 	}
@@ -201,13 +201,13 @@ func (client *client) registerSyncers(ctx context.Context, registry *SyncerRegis
 	return nil
 }
 
-func (client *client) createBlockSyncer(ctx context.Context, fromHash common.Hash, fromHeight uint64, parentsToGet int) (synccommon.Syncer, error) {
+func (client *client) createBlockSyncer(ctx context.Context, fromHash common.Hash, fromHeight uint64) (synccommon.Syncer, error) {
 	return blocksync.NewSyncer(&blocksync.Config{
-		ChainDB:      client.ChainDB,
-		Client:       client.Client,
-		FromHash:     fromHash,
-		FromHeight:   fromHeight,
-		ParentsToGet: uint64(parentsToGet),
+		ChainDB:       client.ChainDB,
+		Client:        client.Client,
+		FromHash:      fromHash,
+		FromHeight:    fromHeight,
+		BlocksToFetch: BlocksToFetch,
 	})
 }
 


### PR DESCRIPTION
## Why this should be merged

Requesting recent blocks should follow the same format as all other syncers.

## How this works

Wraps the old call in a `Start` and `Wait` call with cancel logic

## How this was tested

This code was completely untested before, so I added basic unit tests with a mock client to test functionality. These tests are not too thorough though

## Need to be documented?

No

## Need to update RELEASES.md?

No