### PR TITLE
Refactor atomic mempool initialization

### DIFF
--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -6,144 +6,44 @@ package txpool
 import (
 	"errors"
 	"fmt"
-	"sync"
 
-	"github.com/ava-labs/coreth/plugin/evm/atomic"
-
-	"github.com/ava-labs/avalanchego/cache/lru"
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/network/p2p/gossip"
-	"github.com/ava-labs/avalanchego/snow"
-	"github.com/prometheus/client_golang/prometheus"
-
+	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/libevm/log"
-	"github.com/ava-labs/libevm/metrics"
+	"github.com/prometheus/client_golang/prometheus"
 )
 
-const (
-	discardedTxsCacheSize = 50
-)
-
-var (
-	_ gossip.Set[*atomic.Tx] = (*Mempool)(nil)
-
-	errTxAlreadyKnown          = errors.New("tx already known")
-	errNoGasUsed               = errors.New("no gas used")
-	ErrConflictingAtomicTx     = errors.New("conflicting atomic tx present")
-	ErrInsufficientAtomicTxFee = errors.New("atomic tx fee too low for atomic mempool")
-	ErrTooManyAtomicTx         = errors.New("too many atomic tx")
-)
-
-// mempoolMetrics defines the metrics for the atomic mempool
-type mempoolMetrics struct {
-	pendingTxs metrics.Gauge // Gauge of currently pending transactions in the txHeap
-	currentTxs metrics.Gauge // Gauge of current transactions to be issued into a block
-	issuedTxs  metrics.Gauge // Gauge of transactions that have been issued into a block
-
-	addedTxs     metrics.Counter // Count of all transactions added to the mempool
-	discardedTxs metrics.Counter // Count of all discarded transactions
-}
-
-// newMempoolMetrics constructs metrics for the atomic mempool
-func newMempoolMetrics() *mempoolMetrics {
-	return &mempoolMetrics{
-		pendingTxs:   metrics.GetOrRegisterGauge("atomic_mempool_pending_txs", nil),
-		currentTxs:   metrics.GetOrRegisterGauge("atomic_mempool_current_txs", nil),
-		issuedTxs:    metrics.GetOrRegisterGauge("atomic_mempool_issued_txs", nil),
-		addedTxs:     metrics.GetOrRegisterCounter("atomic_mempool_added_txs", nil),
-		discardedTxs: metrics.GetOrRegisterCounter("atomic_mempool_discarded_txs", nil),
-	}
-}
+var _ gossip.Set[*atomic.Tx] = (*Mempool)(nil)
 
 // Mempool is a simple mempool for atomic transactions
 type Mempool struct {
-	lock sync.RWMutex
-
-	ctx *snow.Context
-	// maxSize is the maximum number of transactions allowed to be kept in mempool
-	maxSize int
-	// currentTxs is the set of transactions about to be added to a block.
-	currentTxs map[ids.ID]*atomic.Tx
-	// issuedTxs is the set of transactions that have been issued into a new block
-	issuedTxs map[ids.ID]*atomic.Tx
-	// discardedTxs is an LRU Cache of transactions that have been discarded after failing
-	// verification.
-	discardedTxs *lru.Cache[ids.ID, *atomic.Tx]
-	// pending is a channel of length one, which the mempool ensures has an item on
-	// it as long as there is an unissued transaction remaining in [txs]
-	pending chan struct{}
-	// txHeap is a sorted record of all txs in the mempool by [gasPrice]
-	// NOTE: [txHeap] ONLY contains pending txs
-	txHeap *txHeap
-	// utxoSpenders maps utxoIDs to the transaction consuming them in the mempool
-	utxoSpenders map[ids.ID]*atomic.Tx
+	*Txs
 	// bloom is a bloom filter containing the txs in the mempool
-	bloom *gossip.BloomFilter
-
-	metrics *mempoolMetrics
-
+	bloom  *gossip.BloomFilter
 	verify func(tx *atomic.Tx) error
 }
 
-// Initialize initializes the Mempool with `maxSize`
-func (m *Mempool) Initialize(ctx *snow.Context, registerer prometheus.Registerer, maxSize int, verify func(tx *atomic.Tx) error) error {
+func NewMempool(
+	txs *Txs,
+	registerer prometheus.Registerer,
+	verify func(tx *atomic.Tx) error,
+) (*Mempool, error) {
 	bloom, err := gossip.NewBloomFilter(registerer, "atomic_mempool_bloom_filter",
 		config.TxGossipBloomMinTargetElements,
 		config.TxGossipBloomTargetFalsePositiveRate,
 		config.TxGossipBloomResetFalsePositiveRate,
 	)
 	if err != nil {
-		return fmt.Errorf("failed to initialize bloom filter: %w", err)
+		return nil, fmt.Errorf("failed to initialize bloom filter: %w", err)
 	}
 
-	m.ctx = ctx
-	m.issuedTxs = make(map[ids.ID]*atomic.Tx)
-	m.discardedTxs = lru.NewCache[ids.ID, *atomic.Tx](discardedTxsCacheSize)
-	m.currentTxs = make(map[ids.ID]*atomic.Tx)
-	m.pending = make(chan struct{}, 1)
-	m.txHeap = newTxHeap(maxSize)
-	m.maxSize = maxSize
-	m.utxoSpenders = make(map[ids.ID]*atomic.Tx)
-	m.bloom = bloom
-	m.metrics = newMempoolMetrics()
-	m.verify = verify
-	return nil
-}
-
-// PendingLen returns the number of pending transactions in the mempool
-func (m *Mempool) PendingLen() int {
-	return m.Len()
-}
-
-// Len returns the number of transactions in the mempool
-func (m *Mempool) Len() int {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.length()
-}
-
-// assumes the lock is held
-func (m *Mempool) length() int {
-	return m.txHeap.Len() + len(m.issuedTxs)
-}
-
-// atomicTxGasPrice is the [gasPrice] paid by a transaction to burn a given
-// amount of [AVAXAssetID] given the value of [gasUsed].
-func (m *Mempool) atomicTxGasPrice(tx *atomic.Tx) (uint64, error) {
-	gasUsed, err := tx.GasUsed(true)
-	if err != nil {
-		return 0, err
-	}
-	if gasUsed == 0 {
-		return 0, errNoGasUsed
-	}
-	burned, err := tx.Burned(m.ctx.AVAXAssetID)
-	if err != nil {
-		return 0, err
-	}
-	return burned / gasUsed, nil
+	return &Mempool{
+		Txs:    txs,
+		bloom:  bloom,
+		verify: verify,
+	}, nil
 }
 
 func (m *Mempool) Add(tx *atomic.Tx) error {
@@ -196,6 +96,13 @@ func (m *Mempool) ForceAddTx(tx *atomic.Tx) error {
 	defer m.lock.Unlock()
 
 	return m.addTx(tx, true, true)
+}
+
+func (m *Mempool) GetFilter() ([]byte, []byte) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.bloom.Marshal()
 }
 
 // checkConflictTx checks for any transactions in the mempool that spend the same input UTXOs as [tx].
@@ -348,246 +255,4 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 	m.addPending()
 
 	return nil
-}
-
-func (m *Mempool) Iterate(f func(tx *atomic.Tx) bool) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	for _, item := range m.txHeap.maxHeap.items {
-		if !f(item.tx) {
-			return
-		}
-	}
-}
-
-func (m *Mempool) GetFilter() ([]byte, []byte) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.bloom.Marshal()
-}
-
-// NextTx returns a transaction to be issued from the mempool.
-func (m *Mempool) NextTx() (*atomic.Tx, bool) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	// We include atomic transactions in blocks sorted by the [gasPrice] they
-	// pay.
-	if m.txHeap.Len() > 0 {
-		tx := m.txHeap.PopMax()
-		m.currentTxs[tx.ID()] = tx
-		m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-		m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-		return tx, true
-	}
-
-	return nil, false
-}
-
-// GetPendingTx returns the transaction [txID] and true if it is
-// currently in the [txHeap] waiting to be issued into a block.
-// Returns nil, false otherwise.
-func (m *Mempool) GetPendingTx(txID ids.ID) (*atomic.Tx, bool) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.txHeap.Get(txID)
-}
-
-// GetTx returns the transaction [txID] if it was issued
-// by this node and returns whether it was dropped and whether
-// it exists.
-func (m *Mempool) GetTx(txID ids.ID) (*atomic.Tx, bool, bool) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	if tx, ok := m.txHeap.Get(txID); ok {
-		return tx, false, true
-	}
-	if tx, ok := m.issuedTxs[txID]; ok {
-		return tx, false, true
-	}
-	if tx, ok := m.currentTxs[txID]; ok {
-		return tx, false, true
-	}
-	if tx, exists := m.discardedTxs.Get(txID); exists {
-		return tx, true, true
-	}
-
-	return nil, false, false
-}
-
-// Has returns true if the mempool contains [txID] or it was issued.
-func (m *Mempool) Has(txID ids.ID) bool {
-	_, dropped, found := m.GetTx(txID)
-	return found && !dropped
-}
-
-// IssueCurrentTx marks [currentTx] as issued if there is one
-func (m *Mempool) IssueCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	for txID := range m.currentTxs {
-		m.issuedTxs[txID] = m.currentTxs[txID]
-		delete(m.currentTxs, txID)
-	}
-	m.metrics.issuedTxs.Update(int64(len(m.issuedTxs)))
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-
-	// If there are more transactions to be issued, add an item
-	// to Pending.
-	if m.txHeap.Len() > 0 {
-		m.addPending()
-	}
-}
-
-// CancelCurrentTx marks the attempt to issue [txID]
-// as being aborted. This should be called after NextTx returns [txID]
-// and the transaction [txID] cannot be included in the block, but should
-// not be discarded. For example, CancelCurrentTx should be called if including
-// the transaction will put the block above the atomic tx gas limit.
-func (m *Mempool) CancelCurrentTx(txID ids.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if tx, ok := m.currentTxs[txID]; ok {
-		m.cancelTx(tx)
-	}
-}
-
-// [CancelCurrentTxs] marks the attempt to issue [currentTxs]
-// as being aborted. If this is called after a buildBlock error
-// caused by the atomic transaction, then DiscardCurrentTx should have been called
-// such that this call will have no effect and should not re-issue the invalid tx.
-func (m *Mempool) CancelCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	// If building a block failed, put the currentTx back in [txs]
-	// if it exists.
-	for _, tx := range m.currentTxs {
-		m.cancelTx(tx)
-	}
-
-	// If there are more transactions to be issued, add an item
-	// to Pending.
-	if m.txHeap.Len() > 0 {
-		m.addPending()
-	}
-}
-
-// cancelTx removes [tx] from current transactions and moves it back into the
-// tx heap.
-// assumes the lock is held.
-func (m *Mempool) cancelTx(tx *atomic.Tx) {
-	// Add tx to heap sorted by gasPrice
-	gasPrice, err := m.atomicTxGasPrice(tx)
-	if err == nil {
-		m.txHeap.Push(tx, gasPrice)
-		m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-	} else {
-		// If the err is not nil, we simply discard the transaction because it is
-		// invalid. This should never happen but we guard against the case it does.
-		log.Error("failed to calculate atomic tx gas price while canceling current tx", "err", err)
-		m.removeSpenders(tx)
-		m.discardedTxs.Put(tx.ID(), tx)
-		m.metrics.discardedTxs.Inc(1)
-	}
-
-	delete(m.currentTxs, tx.ID())
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-}
-
-// DiscardCurrentTx marks a [tx] in the [currentTxs] map as invalid and aborts the attempt
-// to issue it since it failed verification.
-func (m *Mempool) DiscardCurrentTx(txID ids.ID) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	if tx, ok := m.currentTxs[txID]; ok {
-		m.discardCurrentTx(tx)
-	}
-}
-
-// DiscardCurrentTxs marks all txs in [currentTxs] as discarded.
-func (m *Mempool) DiscardCurrentTxs() {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	for _, tx := range m.currentTxs {
-		m.discardCurrentTx(tx)
-	}
-}
-
-// discardCurrentTx discards [tx] from the set of current transactions.
-// Assumes the lock is held.
-func (m *Mempool) discardCurrentTx(tx *atomic.Tx) {
-	m.removeSpenders(tx)
-	m.discardedTxs.Put(tx.ID(), tx)
-	delete(m.currentTxs, tx.ID())
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-	m.metrics.discardedTxs.Inc(1)
-}
-
-// removeTx removes [txID] from the mempool.
-// Note: removeTx will delete all entries from [utxoSpenders] corresponding
-// to input UTXOs of [txID]. This means that when replacing a conflicting tx,
-// removeTx must be called for all conflicts before overwriting the utxoSpenders
-// map.
-// Assumes lock is held.
-func (m *Mempool) removeTx(tx *atomic.Tx, discard bool) {
-	txID := tx.ID()
-
-	// Remove from [currentTxs], [txHeap], and [issuedTxs].
-	delete(m.currentTxs, txID)
-	m.txHeap.Remove(txID)
-	delete(m.issuedTxs, txID)
-
-	if discard {
-		m.discardedTxs.Put(txID, tx)
-		m.metrics.discardedTxs.Inc(1)
-	} else {
-		m.discardedTxs.Evict(txID)
-	}
-	m.metrics.pendingTxs.Update(int64(m.txHeap.Len()))
-	m.metrics.currentTxs.Update(int64(len(m.currentTxs)))
-	m.metrics.issuedTxs.Update(int64(len(m.issuedTxs)))
-
-	// Remove all entries from [utxoSpenders].
-	m.removeSpenders(tx)
-}
-
-// removeSpenders deletes the entries for all input UTXOs of [tx] from the
-// [utxoSpenders] map.
-// Assumes the lock is held.
-func (m *Mempool) removeSpenders(tx *atomic.Tx) {
-	for utxoID := range tx.InputUTXOs() {
-		delete(m.utxoSpenders, utxoID)
-	}
-}
-
-// RemoveTx removes [txID] from the mempool completely.
-// Evicts [tx] from the discarded cache if present.
-func (m *Mempool) RemoveTx(tx *atomic.Tx) {
-	m.lock.Lock()
-	defer m.lock.Unlock()
-
-	m.removeTx(tx, false)
-}
-
-// addPending makes sure that an item is in the Pending channel.
-func (m *Mempool) addPending() {
-	select {
-	case m.pending <- struct{}{}:
-	default:
-	}
-}
-
-// SubscribePendingTxs implements the BuilderMempool interface and returns a channel
-// that signals when there is at least one pending transaction in the mempool
-func (m *Mempool) SubscribePendingTxs() <-chan struct{} {
-	return m.pending
 }

--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -175,7 +175,7 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 		if highestGasPrice >= gasPrice {
 			return fmt.Errorf(
 				"%w: issued tx (%s) gas price %d <= conflict tx (%s) gas price %d (%d total conflicts in mempool)",
-				ErrConflictingAtomicTx,
+				ErrConflictingTx,
 				txID,
 				gasPrice,
 				highestGasPriceConflictTxID,
@@ -200,7 +200,7 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 			if minGasPrice >= gasPrice {
 				return fmt.Errorf(
 					"%w currentMin=%d provided=%d",
-					ErrInsufficientAtomicTxFee,
+					ErrInsufficientFee,
 					minGasPrice,
 					gasPrice,
 				)
@@ -210,7 +210,7 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 		} else {
 			// This could occur if we have used our entire size allowance on
 			// transactions that are currently processing.
-			return ErrTooManyAtomicTx
+			return ErrMempoolFull
 		}
 	}
 

--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -61,7 +61,7 @@ func (m *Mempool) AddRemoteTx(tx *atomic.Tx) error {
 
 	err := m.addTx(tx, false, false)
 	// Do not attempt to discard the tx if it was already known
-	if errors.Is(err, errTxAlreadyKnown) {
+	if errors.Is(err, ErrTxAlreadyKnown) {
 		return err
 	}
 
@@ -83,7 +83,7 @@ func (m *Mempool) AddLocalTx(tx *atomic.Tx) error {
 	defer m.lock.Unlock()
 
 	err := m.addTx(tx, true, false)
-	if errors.Is(err, errTxAlreadyKnown) {
+	if errors.Is(err, ErrTxAlreadyKnown) {
 		return nil
 	}
 
@@ -144,17 +144,17 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 	// If [txID] has already been issued or is in the currentTxs map
 	// there's no need to add it.
 	if _, exists := m.issuedTxs[txID]; exists {
-		return fmt.Errorf("%w: tx %s was issued previously", errTxAlreadyKnown, tx.ID())
+		return fmt.Errorf("%w: tx %s was issued previously", ErrTxAlreadyKnown, tx.ID())
 	}
 	if _, exists := m.currentTxs[txID]; exists {
-		return fmt.Errorf("%w: tx %s is being built into a block", errTxAlreadyKnown, tx.ID())
+		return fmt.Errorf("%w: tx %s is being built into a block", ErrTxAlreadyKnown, tx.ID())
 	}
 	if _, exists := m.txHeap.Get(txID); exists {
-		return fmt.Errorf("%w: tx %s is pending", errTxAlreadyKnown, tx.ID())
+		return fmt.Errorf("%w: tx %s is pending", ErrTxAlreadyKnown, tx.ID())
 	}
 	if !local {
 		if _, exists := m.discardedTxs.Get(txID); exists {
-			return fmt.Errorf("%w: tx %s was discarded", errTxAlreadyKnown, tx.ID())
+			return fmt.Errorf("%w: tx %s was discarded", ErrTxAlreadyKnown, tx.ID())
 		}
 	}
 	if !force && m.verify != nil {

--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -105,13 +105,6 @@ func (m *Mempool) ForceAddTx(tx *atomic.Tx) error {
 	return m.addTx(tx, true, true)
 }
 
-func (m *Mempool) GetFilter() ([]byte, []byte) {
-	m.lock.RLock()
-	defer m.lock.RUnlock()
-
-	return m.bloom.Marshal()
-}
-
 // checkConflictTx checks for any transactions in the mempool that spend the same input UTXOs as [tx].
 // If any conflicts are present, it returns the highest gas price of any conflicting transaction, the
 // txID of the corresponding tx and the full list of transactions that conflict with [tx].
@@ -262,4 +255,11 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 	m.addPending()
 
 	return nil
+}
+
+func (m *Mempool) GetFilter() ([]byte, []byte) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	return m.bloom.Marshal()
 }

--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -15,7 +15,14 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-var _ gossip.Set[*atomic.Tx] = (*Mempool)(nil)
+var (
+	_ gossip.Set[*atomic.Tx] = (*Mempool)(nil)
+
+	ErrTxAlreadyKnown  = errors.New("tx already known")
+	ErrConflictingTx   = errors.New("conflicting tx present")
+	ErrInsufficientFee = errors.New("insufficient fee")
+	ErrMempoolFull     = errors.New("mempool full")
+)
 
 // Mempool is a simple mempool for atomic transactions
 type Mempool struct {

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -170,7 +170,7 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 	// try to add one more tx
 	tx2 := atomictest.GenerateTestImportTx()
 	err = mempool.AddRemoteTx(tx2)
-	require.ErrorIs(err, ErrTooManyAtomicTx)
+	require.ErrorIs(err, ErrMempoolFull)
 	require.False(mempool.Has(tx2.ID()))
 }
 
@@ -192,7 +192,7 @@ func TestMempoolPriorityDrop(t *testing.T) {
 
 	tx2 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
 	err = mempool.AddRemoteTx(tx2)
-	require.ErrorIs(err, ErrInsufficientAtomicTxFee)
+	require.ErrorIs(err, ErrInsufficientFee)
 	require.True(mempool.Has(tx1.ID()))
 	require.False(mempool.Has(tx2.ID()))
 

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -62,7 +62,7 @@ func TestMempoolAdd(t *testing.T) {
 
 	require.NoError(m.Add(tx))
 	err = m.Add(tx)
-	require.ErrorIs(err, ErrTxAlreadyKnown)
+	require.ErrorIs(err, ErrAlreadyKnown)
 }
 
 func TestAtomicMempoolIterate(t *testing.T) {

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -6,20 +6,24 @@ package txpool
 import (
 	"testing"
 
-	"github.com/ava-labs/coreth/plugin/evm/atomic"
-	"github.com/ava-labs/coreth/plugin/evm/atomic/atomictest"
-
 	"github.com/ava-labs/avalanchego/ids"
 	"github.com/ava-labs/avalanchego/snow/snowtest"
+	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/coreth/plugin/evm/atomic/atomictest"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/require"
 )
 
 func TestMempoolAddTx(t *testing.T) {
 	require := require.New(t)
-	m := &Mempool{}
+
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
+	m, err := NewMempool(
+		NewTxs(ctx, 5_000),
+		prometheus.NewRegistry(),
+		nil,
+	)
+	require.NoError(err)
 
 	txs := make([]*atomic.Tx, 0)
 	for i := 0; i < 3_000; i++ {
@@ -41,9 +45,14 @@ func TestMempoolAddTx(t *testing.T) {
 // Add should return an error if a tx is already known
 func TestMempoolAdd(t *testing.T) {
 	require := require.New(t)
-	m := &Mempool{}
+
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 5_000, nil))
+	m, err := NewMempool(
+		NewTxs(ctx, 5_000),
+		prometheus.NewRegistry(),
+		nil,
+	)
+	require.NoError(err)
 
 	tx := &atomic.Tx{
 		UnsignedAtomicTx: &atomictest.TestUnsignedTx{
@@ -52,7 +61,7 @@ func TestMempoolAdd(t *testing.T) {
 	}
 
 	require.NoError(m.Add(tx))
-	err := m.Add(tx)
+	err = m.Add(tx)
 	require.ErrorIs(err, errTxAlreadyKnown)
 }
 
@@ -105,9 +114,14 @@ func TestAtomicMempoolIterate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			require := require.New(t)
+
 			ctx := snowtest.Context(t, snowtest.CChainID)
-			m := &Mempool{}
-			require.NoError(m.Initialize(ctx, prometheus.NewRegistry(), 10, nil))
+			m, err := NewMempool(
+				NewTxs(ctx, 10),
+				prometheus.NewRegistry(),
+				nil,
+			)
+			require.NoError(err)
 
 			for _, add := range tt.add {
 				require.NoError(m.Add(add))
@@ -137,8 +151,12 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 	require := require.New(t)
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	mempool := &Mempool{}
-	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 1, nil))
+	mempool, err := NewMempool(
+		NewTxs(ctx, 1),
+		prometheus.NewRegistry(),
+		nil,
+	)
+	require.NoError(err)
 	// create candidate tx (we will drop before validation)
 	tx := atomictest.GenerateTestImportTx()
 
@@ -151,7 +169,7 @@ func TestMempoolMaxSizeHandling(t *testing.T) {
 
 	// try to add one more tx
 	tx2 := atomictest.GenerateTestImportTx()
-	err := mempool.AddRemoteTx(tx2)
+	err = mempool.AddRemoteTx(tx2)
 	require.ErrorIs(err, ErrTooManyAtomicTx)
 	require.False(mempool.Has(tx2.ID()))
 }
@@ -161,15 +179,19 @@ func TestMempoolPriorityDrop(t *testing.T) {
 	require := require.New(t)
 
 	ctx := snowtest.Context(t, snowtest.CChainID)
-	mempool := &Mempool{}
-	require.NoError(mempool.Initialize(ctx, prometheus.NewRegistry(), 1, nil))
+	mempool, err := NewMempool(
+		NewTxs(ctx, 1),
+		prometheus.NewRegistry(),
+		nil,
+	)
+	require.NoError(err)
 
 	tx1 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
 	require.NoError(mempool.AddRemoteTx(tx1))
 	require.True(mempool.Has(tx1.ID()))
 
 	tx2 := atomictest.GenerateTestImportTxWithGas(1, 2) // lower fee
-	err := mempool.AddRemoteTx(tx2)
+	err = mempool.AddRemoteTx(tx2)
 	require.ErrorIs(err, ErrInsufficientAtomicTxFee)
 	require.True(mempool.Has(tx1.ID()))
 	require.False(mempool.Has(tx2.ID()))

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -62,7 +62,7 @@ func TestMempoolAdd(t *testing.T) {
 
 	require.NoError(m.Add(tx))
 	err = m.Add(tx)
-	require.ErrorIs(err, errTxAlreadyKnown)
+	require.ErrorIs(err, ErrTxAlreadyKnown)
 }
 
 func TestAtomicMempoolIterate(t *testing.T) {

--- a/plugin/evm/atomic/txpool/metrics.go
+++ b/plugin/evm/atomic/txpool/metrics.go
@@ -1,0 +1,27 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txpool
+
+import (
+	metricspkg "github.com/ava-labs/libevm/metrics"
+)
+
+type metrics struct {
+	pendingTxs metricspkg.Gauge // Gauge of currently pending transactions in the txHeap
+	currentTxs metricspkg.Gauge // Gauge of current transactions to be issued into a block
+	issuedTxs  metricspkg.Gauge // Gauge of transactions that have been issued into a block
+
+	addedTxs     metricspkg.Counter // Count of all transactions added to the mempool
+	discardedTxs metricspkg.Counter // Count of all discarded transactions
+}
+
+func newMetrics() *metrics {
+	return &metrics{
+		pendingTxs:   metricspkg.GetOrRegisterGauge("atomic_mempool_pending_txs", nil),
+		currentTxs:   metricspkg.GetOrRegisterGauge("atomic_mempool_current_txs", nil),
+		issuedTxs:    metricspkg.GetOrRegisterGauge("atomic_mempool_issued_txs", nil),
+		addedTxs:     metricspkg.GetOrRegisterCounter("atomic_mempool_added_txs", nil),
+		discardedTxs: metricspkg.GetOrRegisterCounter("atomic_mempool_discarded_txs", nil),
+	}
+}

--- a/plugin/evm/atomic/txpool/txs.go
+++ b/plugin/evm/atomic/txpool/txs.go
@@ -18,11 +18,11 @@ import (
 const discardedTxsCacheSize = 50
 
 var (
-	errTxAlreadyKnown          = errors.New("tx already known")
-	errNoGasUsed               = errors.New("no gas used")
-	ErrConflictingAtomicTx     = errors.New("conflicting atomic tx present")
-	ErrInsufficientAtomicTxFee = errors.New("atomic tx fee too low for atomic mempool")
-	ErrTooManyAtomicTx         = errors.New("too many atomic tx")
+	errTxAlreadyKnown  = errors.New("tx already known")
+	errNoGasUsed       = errors.New("no gas used")
+	ErrConflictingTx   = errors.New("conflicting tx present")
+	ErrInsufficientFee = errors.New("insufficient fee")
+	ErrMempoolFull     = errors.New("mempool full")
 )
 
 type Txs struct {

--- a/plugin/evm/atomic/txpool/txs.go
+++ b/plugin/evm/atomic/txpool/txs.go
@@ -17,13 +17,7 @@ import (
 
 const discardedTxsCacheSize = 50
 
-var (
-	ErrTxAlreadyKnown  = errors.New("tx already known")
-	ErrNoGasUsed       = errors.New("no gas used")
-	ErrConflictingTx   = errors.New("conflicting tx present")
-	ErrInsufficientFee = errors.New("insufficient fee")
-	ErrMempoolFull     = errors.New("mempool full")
-)
+var ErrNoGasUsed = errors.New("no gas used")
 
 type Txs struct {
 	ctx     *snow.Context

--- a/plugin/evm/atomic/txpool/txs.go
+++ b/plugin/evm/atomic/txpool/txs.go
@@ -18,8 +18,8 @@ import (
 const discardedTxsCacheSize = 50
 
 var (
-	errTxAlreadyKnown  = errors.New("tx already known")
-	errNoGasUsed       = errors.New("no gas used")
+	ErrTxAlreadyKnown  = errors.New("tx already known")
+	ErrNoGasUsed       = errors.New("no gas used")
 	ErrConflictingTx   = errors.New("conflicting tx present")
 	ErrInsufficientFee = errors.New("insufficient fee")
 	ErrMempoolFull     = errors.New("mempool full")
@@ -90,7 +90,7 @@ func (t *Txs) atomicTxGasPrice(tx *atomic.Tx) (uint64, error) {
 		return 0, err
 	}
 	if gasUsed == 0 {
-		return 0, errNoGasUsed
+		return 0, ErrNoGasUsed
 	}
 	burned, err := tx.Burned(t.ctx.AVAXAssetID)
 	if err != nil {

--- a/plugin/evm/atomic/txpool/txs.go
+++ b/plugin/evm/atomic/txpool/txs.go
@@ -1,0 +1,335 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package txpool
+
+import (
+	"errors"
+	"sync"
+
+	"github.com/ava-labs/avalanchego/cache/lru"
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/snow"
+
+	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/ava-labs/libevm/log"
+)
+
+const discardedTxsCacheSize = 50
+
+var (
+	errTxAlreadyKnown          = errors.New("tx already known")
+	errNoGasUsed               = errors.New("no gas used")
+	ErrConflictingAtomicTx     = errors.New("conflicting atomic tx present")
+	ErrInsufficientAtomicTxFee = errors.New("atomic tx fee too low for atomic mempool")
+	ErrTooManyAtomicTx         = errors.New("too many atomic tx")
+)
+
+type Txs struct {
+	ctx     *snow.Context
+	metrics *metrics
+	// maxSize is the maximum number of transactions allowed to be kept in mempool
+	maxSize int
+
+	lock sync.RWMutex
+
+	// currentTxs is the set of transactions about to be added to a block.
+	currentTxs map[ids.ID]*atomic.Tx
+	// issuedTxs is the set of transactions that have been issued into a new block
+	issuedTxs map[ids.ID]*atomic.Tx
+	// discardedTxs is an LRU Cache of transactions that have been discarded after failing
+	// verification.
+	discardedTxs *lru.Cache[ids.ID, *atomic.Tx]
+	// pending is a channel of length one, which the mempool ensures has an item on
+	// it as long as there is an unissued transaction remaining in [txs]
+	pending chan struct{}
+	// txHeap is a sorted record of all txs in the mempool by [gasPrice]
+	// NOTE: [txHeap] ONLY contains pending txs
+	txHeap *txHeap
+	// utxoSpenders maps utxoIDs to the transaction consuming them in the mempool
+	utxoSpenders map[ids.ID]*atomic.Tx
+}
+
+func NewTxs(ctx *snow.Context, maxSize int) *Txs {
+	return &Txs{
+		ctx:          ctx,
+		metrics:      newMetrics(),
+		maxSize:      maxSize,
+		currentTxs:   make(map[ids.ID]*atomic.Tx),
+		issuedTxs:    make(map[ids.ID]*atomic.Tx),
+		discardedTxs: lru.NewCache[ids.ID, *atomic.Tx](discardedTxsCacheSize),
+		pending:      make(chan struct{}, 1),
+		txHeap:       newTxHeap(maxSize),
+		utxoSpenders: make(map[ids.ID]*atomic.Tx),
+	}
+}
+
+// PendingLen returns the number of pending transactions
+func (t *Txs) PendingLen() int {
+	return t.Len()
+}
+
+// Len returns the number of transactions
+func (t *Txs) Len() int {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.length()
+}
+
+// assumes the lock is held
+func (t *Txs) length() int {
+	return t.txHeap.Len() + len(t.issuedTxs)
+}
+
+// atomicTxGasPrice is the [gasPrice] paid by a transaction to burn a given
+// amount of [AVAXAssetID] given the value of [gasUsed].
+func (t *Txs) atomicTxGasPrice(tx *atomic.Tx) (uint64, error) {
+	gasUsed, err := tx.GasUsed(true)
+	if err != nil {
+		return 0, err
+	}
+	if gasUsed == 0 {
+		return 0, errNoGasUsed
+	}
+	burned, err := tx.Burned(t.ctx.AVAXAssetID)
+	if err != nil {
+		return 0, err
+	}
+	return burned / gasUsed, nil
+}
+
+func (t *Txs) Iterate(f func(tx *atomic.Tx) bool) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	for _, item := range t.txHeap.maxHeap.items {
+		if !f(item.tx) {
+			return
+		}
+	}
+}
+
+// NextTx returns a transaction to be issued from the mempool.
+func (t *Txs) NextTx() (*atomic.Tx, bool) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// We include atomic transactions in blocks sorted by the [gasPrice] they
+	// pay.
+	if t.txHeap.Len() > 0 {
+		tx := t.txHeap.PopMax()
+		t.currentTxs[tx.ID()] = tx
+		t.metrics.pendingTxs.Update(int64(t.txHeap.Len()))
+		t.metrics.currentTxs.Update(int64(len(t.currentTxs)))
+		return tx, true
+	}
+
+	return nil, false
+}
+
+// GetPendingTx returns the transaction [txID] and true if it is
+// currently in the [txHeap] waiting to be issued into a block.
+// Returns nil, false otherwise.
+func (t *Txs) GetPendingTx(txID ids.ID) (*atomic.Tx, bool) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	return t.txHeap.Get(txID)
+}
+
+// GetTx returns the transaction [txID] if it was issued
+// by this node and returns whether it was dropped and whether
+// it exists.
+func (t *Txs) GetTx(txID ids.ID) (*atomic.Tx, bool, bool) {
+	t.lock.RLock()
+	defer t.lock.RUnlock()
+
+	if tx, ok := t.txHeap.Get(txID); ok {
+		return tx, false, true
+	}
+	if tx, ok := t.issuedTxs[txID]; ok {
+		return tx, false, true
+	}
+	if tx, ok := t.currentTxs[txID]; ok {
+		return tx, false, true
+	}
+	if tx, exists := t.discardedTxs.Get(txID); exists {
+		return tx, true, true
+	}
+
+	return nil, false, false
+}
+
+// Has returns true if the mempool contains [txID] or it was issued.
+func (t *Txs) Has(txID ids.ID) bool {
+	_, dropped, found := t.GetTx(txID)
+	return found && !dropped
+}
+
+// IssueCurrentTx marks [currentTx] as issued if there is one
+func (t *Txs) IssueCurrentTxs() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	for txID := range t.currentTxs {
+		t.issuedTxs[txID] = t.currentTxs[txID]
+		delete(t.currentTxs, txID)
+	}
+	t.metrics.issuedTxs.Update(int64(len(t.issuedTxs)))
+	t.metrics.currentTxs.Update(int64(len(t.currentTxs)))
+
+	// If there are more transactions to be issued, add an item
+	// to Pending.
+	if t.txHeap.Len() > 0 {
+		t.addPending()
+	}
+}
+
+// CancelCurrentTx marks the attempt to issue [txID]
+// as being aborted. This should be called after NextTx returns [txID]
+// and the transaction [txID] cannot be included in the block, but should
+// not be discarded. For example, CancelCurrentTx should be called if including
+// the transaction will put the block above the atomic tx gas limit.
+func (t *Txs) CancelCurrentTx(txID ids.ID) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if tx, ok := t.currentTxs[txID]; ok {
+		t.cancelTx(tx)
+	}
+}
+
+// [CancelCurrentTxs] marks the attempt to issue [currentTxs]
+// as being aborted. If this is called after a buildBlock error
+// caused by the atomic transaction, then DiscardCurrentTx should have been called
+// such that this call will have no effect and should not re-issue the invalid tx.
+func (t *Txs) CancelCurrentTxs() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	// If building a block failed, put the currentTx back in [txs]
+	// if it exists.
+	for _, tx := range t.currentTxs {
+		t.cancelTx(tx)
+	}
+
+	// If there are more transactions to be issued, add an item
+	// to Pending.
+	if t.txHeap.Len() > 0 {
+		t.addPending()
+	}
+}
+
+// cancelTx removes [tx] from current transactions and moves it back into the
+// tx heap.
+// assumes the lock is held.
+func (t *Txs) cancelTx(tx *atomic.Tx) {
+	// Add tx to heap sorted by gasPrice
+	gasPrice, err := t.atomicTxGasPrice(tx)
+	if err == nil {
+		t.txHeap.Push(tx, gasPrice)
+		t.metrics.pendingTxs.Update(int64(t.txHeap.Len()))
+	} else {
+		// If the err is not nil, we simply discard the transaction because it is
+		// invalid. This should never happen but we guard against the case it does.
+		log.Error("failed to calculate atomic tx gas price while canceling current tx", "err", err)
+		t.removeSpenders(tx)
+		t.discardedTxs.Put(tx.ID(), tx)
+		t.metrics.discardedTxs.Inc(1)
+	}
+
+	delete(t.currentTxs, tx.ID())
+	t.metrics.currentTxs.Update(int64(len(t.currentTxs)))
+}
+
+// DiscardCurrentTx marks a [tx] in the [currentTxs] map as invalid and aborts the attempt
+// to issue it since it failed verification.
+func (t *Txs) DiscardCurrentTx(txID ids.ID) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	if tx, ok := t.currentTxs[txID]; ok {
+		t.discardCurrentTx(tx)
+	}
+}
+
+// DiscardCurrentTxs marks all txs in [currentTxs] as discarded.
+func (t *Txs) DiscardCurrentTxs() {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	for _, tx := range t.currentTxs {
+		t.discardCurrentTx(tx)
+	}
+}
+
+// discardCurrentTx discards [tx] from the set of current transactions.
+// Assumes the lock is held.
+func (t *Txs) discardCurrentTx(tx *atomic.Tx) {
+	t.removeSpenders(tx)
+	t.discardedTxs.Put(tx.ID(), tx)
+	delete(t.currentTxs, tx.ID())
+	t.metrics.currentTxs.Update(int64(len(t.currentTxs)))
+	t.metrics.discardedTxs.Inc(1)
+}
+
+// removeTx removes [txID] from the mempool.
+// Note: removeTx will delete all entries from [utxoSpenders] corresponding
+// to input UTXOs of [txID]. This means that when replacing a conflicting tx,
+// removeTx must be called for all conflicts before overwriting the utxoSpenders
+// map.
+// Assumes lock is held.
+func (t *Txs) removeTx(tx *atomic.Tx, discard bool) {
+	txID := tx.ID()
+
+	// Remove from [currentTxs], [txHeap], and [issuedTxs].
+	delete(t.currentTxs, txID)
+	t.txHeap.Remove(txID)
+	delete(t.issuedTxs, txID)
+
+	if discard {
+		t.discardedTxs.Put(txID, tx)
+		t.metrics.discardedTxs.Inc(1)
+	} else {
+		t.discardedTxs.Evict(txID)
+	}
+	t.metrics.pendingTxs.Update(int64(t.txHeap.Len()))
+	t.metrics.currentTxs.Update(int64(len(t.currentTxs)))
+	t.metrics.issuedTxs.Update(int64(len(t.issuedTxs)))
+
+	// Remove all entries from [utxoSpenders].
+	t.removeSpenders(tx)
+}
+
+// removeSpenders deletes the entries for all input UTXOs of [tx] from the
+// [utxoSpenders] map.
+// Assumes the lock is held.
+func (t *Txs) removeSpenders(tx *atomic.Tx) {
+	for utxoID := range tx.InputUTXOs() {
+		delete(t.utxoSpenders, utxoID)
+	}
+}
+
+// RemoveTx removes [txID] from the mempool completely.
+// Evicts [tx] from the discarded cache if present.
+func (t *Txs) RemoveTx(tx *atomic.Tx) {
+	t.lock.Lock()
+	defer t.lock.Unlock()
+
+	t.removeTx(tx, false)
+}
+
+// addPending makes sure that an item is in the Pending channel.
+func (t *Txs) addPending() {
+	select {
+	case t.pending <- struct{}{}:
+	default:
+	}
+}
+
+// SubscribePendingTxs implements the BuilderMempool interface and returns a channel
+// that signals when there is at least one pending transaction in the mempool
+func (t *Txs) SubscribePendingTxs() <-chan struct{} {
+	return t.pending
+}

--- a/plugin/evm/atomic/vm/vm.go
+++ b/plugin/evm/atomic/vm/vm.go
@@ -150,7 +150,7 @@ func (vm *VM) Initialize(
 		Handler:    leafHandler,
 	}
 
-	txPoolTxs := txpool.NewTxs(chainCtx, defaultMempoolSize)
+	atomicTxs := txpool.NewTxs(chainCtx, defaultMempoolSize)
 	extensionConfig := &extension.Config{
 		ConsensusCallbacks:         vm.createConsensusCallbacks(),
 		BlockExtender:              blockExtender,
@@ -158,7 +158,7 @@ func (vm *VM) Initialize(
 		SyncExtender:               syncExtender,
 		SyncSummaryProvider:        syncProvider,
 		ExtraSyncLeafHandlerConfig: atomicLeafTypeConfig,
-		ExtraMempool:               txPoolTxs,
+		ExtraMempool:               atomicTxs,
 		Clock:                      &vm.clock,
 	}
 	if err := vm.InnerVM.SetExtensionConfig(extensionConfig); err != nil {
@@ -179,12 +179,11 @@ func (vm *VM) Initialize(
 		return fmt.Errorf("failed to initialize inner VM: %w", err)
 	}
 
-	// Now we can initialize the mempool and so
-	mempool, err := txpool.NewMempool(txPoolTxs, vm.InnerVM.MetricRegistry(), vm.verifyTxAtTip)
+	atomicMempool, err := txpool.NewMempool(atomicTxs, vm.InnerVM.MetricRegistry(), vm.verifyTxAtTip)
 	if err != nil {
 		return fmt.Errorf("failed to initialize mempool: %w", err)
 	}
-	vm.AtomicMempool = mempool
+	vm.AtomicMempool = atomicMempool
 
 	// initialize bonus blocks on mainnet
 	var (

--- a/plugin/evm/mempool_atomic_gossiping_test.go
+++ b/plugin/evm/mempool_atomic_gossiping_test.go
@@ -58,7 +58,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 
 			// try to add a conflicting tx
 			err = tvm.atomicVM.AtomicMempool.AddLocalTx(conflictingTx)
-			assert.ErrorIs(err, atomictxpool.ErrConflictingAtomicTx)
+			assert.ErrorIs(err, atomictxpool.ErrConflictingTx)
 			has = mempool.Has(conflictingTxID)
 			assert.False(has, "conflicting tx in mempool")
 

--- a/plugin/evm/mempool_atomic_gossiping_test.go
+++ b/plugin/evm/mempool_atomic_gossiping_test.go
@@ -58,7 +58,7 @@ func TestMempoolAddLocallyCreateAtomicTx(t *testing.T) {
 
 			// try to add a conflicting tx
 			err = tvm.atomicVM.AtomicMempool.AddLocalTx(conflictingTx)
-			assert.ErrorIs(err, atomictxpool.ErrConflictingTx)
+			assert.ErrorIs(err, atomictxpool.ErrConflict)
 			has = mempool.Has(conflictingTxID)
 			assert.False(has, "conflicting tx in mempool")
 

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1076,8 +1076,8 @@ func testReissueAtomicTxHigherGasPrice(t *testing.T, scheme string) {
 				t.Fatal(err)
 			}
 
-			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingTx) {
-				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingTx, err)
+			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflict) {
+				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflict, err)
 			}
 
 			assert.True(t, vm.AtomicMempool.Has(importTx1.ID()))

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -1076,8 +1076,8 @@ func testReissueAtomicTxHigherGasPrice(t *testing.T, scheme string) {
 				t.Fatal(err)
 			}
 
-			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingAtomicTx) {
-				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingAtomicTx, err)
+			if err := vm.AtomicMempool.AddLocalTx(reissuanceTx1); !errors.Is(err, atomictxpool.ErrConflictingTx) {
+				t.Fatalf("Expected to fail with err: %s, but found err: %s", atomictxpool.ErrConflictingTx, err)
 			}
 
 			assert.True(t, vm.AtomicMempool.Has(importTx1.ID()))


### PR DESCRIPTION
## Why this should be merged

This is the first of (what may be a few) mempool cleanups. The goal of this PR is to avoid passing around uninitialized mempools.

## How this works

Separates the mempool into two components. The first component `Txs` supports block building. The second component `Mempool` supports adding txs to the mempool.

- `Txs` does not depend on the `InnerVM`, yet implements everything required by the `InnerVM`. So it can be created prior to the `InnerVM` being initialized.
- `Mempool` is created after the `InnerVM` is initialized and has a reference to `Txs`.

## How this was tested

Existing CI

## Need to be documented?

No

## Need to update RELEASES.md?

No