### PR TITLE
chore: update libevm version to v1.13.14-0.3.0.rc.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.13.4-rc.2
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9
-	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.3
+	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0
 	github.com/fjl/gencodec v0.1.1

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 h1:zw0g+cUbZDsGdWx1PKmBChkpy+
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.3 h1:qYwmFh5fG8T4ShagvJs6TNXTfVMdSyvQYwVZb3tx+4k=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.3/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
+github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6 h1:tyM659nDOknwTeU4A0fUVsGNIU7k0v738wYN92nqs/Y=
+github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,6 @@ github.com/ava-labs/avalanchego v1.13.4-rc.2 h1:xAf98V/C3TWTmNRP/io5sdKmpaFgZ7eJ
 github.com/ava-labs/avalanchego v1.13.4-rc.2/go.mod h1:w4sWmDbm1ngkRjh89kUqirZUpSbBCmxd7yA+J4SMZNA=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 h1:zw0g+cUbZDsGdWx1PKmBChkpy+ixL3QgiI86DUOuXvo=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
-github.com/ava-labs/libevm v1.13.14-0.3.0.rc.3 h1:qYwmFh5fG8T4ShagvJs6TNXTfVMdSyvQYwVZb3tx+4k=
-github.com/ava-labs/libevm v1.13.14-0.3.0.rc.3/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6 h1:tyM659nDOknwTeU4A0fUVsGNIU7k0v738wYN92nqs/Y=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -4,6 +4,7 @@
 package params
 
 import (
+	"fmt"
 	"maps"
 	"math/big"
 	"slices"
@@ -131,6 +132,10 @@ func makePrecompile(contract contract.StatefulPrecompiledContract) libevm.Precom
 				time:             env.BlockTime(),
 				predicateResults: predicateResults,
 			},
+		}
+
+		if callType := env.IncomingCallType(); callType == vm.DelegateCall || callType == vm.CallCode {
+			env.InvalidateExecution(fmt.Errorf("precompile %s cannot be called with %s", contract, callType))
 		}
 		return contract.Run(accessibleState, env.Addresses().Caller, env.Addresses().Self, input, suppliedGas, env.ReadOnly())
 	}


### PR DESCRIPTION
## Why this should be merged

Updates libevm to use additional eth updates and statedb refactor

## How this works

Adds check from libevm interface change

## How this was tested

UT

## Need to be documented?

No.

## Need to update RELEASES.md?

No.
