### PR TITLE
refactor(plugin/evm): move atomic sync code back to plugin/evm

### DIFF
--- a/plugin/evm/atomic/sync/extender.go
+++ b/plugin/evm/atomic/sync/extender.go
@@ -1,6 +1,6 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-package atomic
+package sync
 
 import (
 	"context"

--- a/plugin/evm/atomic/sync/leaf_handler.go
+++ b/plugin/evm/atomic/sync/leaf_handler.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package atomic
+package sync
 
 import (
 	"context"

--- a/plugin/evm/atomic/sync/summary.go
+++ b/plugin/evm/atomic/sync/summary.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package atomic
+package sync
 
 import (
 	"context"

--- a/plugin/evm/atomic/sync/summary_parser.go
+++ b/plugin/evm/atomic/sync/summary_parser.go
@@ -1,6 +1,6 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-package atomic
+package sync
 
 import (
 	"fmt"

--- a/plugin/evm/atomic/sync/summary_provider.go
+++ b/plugin/evm/atomic/sync/summary_provider.go
@@ -1,6 +1,6 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-package atomic
+package sync
 
 import (
 	"fmt"

--- a/plugin/evm/atomic/sync/summary_test.go
+++ b/plugin/evm/atomic/sync/summary_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package atomic
+package sync
 
 import (
 	"context"

--- a/plugin/evm/atomic/sync/syncer.go
+++ b/plugin/evm/atomic/sync/syncer.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package atomic
+package sync
 
 import (
 	"bytes"

--- a/plugin/evm/atomic/sync/syncer_test.go
+++ b/plugin/evm/atomic/sync/syncer_test.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package atomic
+package sync
 
 import (
 	"bytes"

--- a/plugin/evm/atomic/vm/vm.go
+++ b/plugin/evm/atomic/vm/vm.go
@@ -11,10 +11,10 @@ import (
 	"net/http"
 	"sync"
 
+	atomicsync "github.com/ava-labs/coreth/plugin/evm/atomic/sync"
+
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	atomicstate "github.com/ava-labs/coreth/plugin/evm/atomic/state"
-	atomicsync "github.com/ava-labs/coreth/sync/atomic"
-
 	"github.com/ava-labs/coreth/plugin/evm/atomic/txpool"
 
 	"github.com/ava-labs/avalanchego/codec"


### PR DESCRIPTION
## Why this should be merged
To keep with the separation that most of our code should reside in `plugin/evm` and to avoid import cycles. This change was synced with @ceyonur.

## How this works
Non functional change.

## How this was tested
just running the existing tests is enough

## Need to be documented?
no

## Need to update RELEASES.md?
no