### PR TITLE
Continue atomic mempool cleanup

### DIFF
--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -870,13 +870,9 @@ func testConflictingImportTxs(t *testing.T, fork upgradetest.Fork, scheme string
 	// the VM returns an error when it attempts to issue the conflict into the mempool
 	// and when it attempts to build a block with the conflict force added to the mempool.
 	for i, tx := range conflictTxs[:2] {
-		if err := tvm.atomicVM.AtomicMempool.AddLocalTx(tx); err == nil {
-			t.Fatal("Expected issueTx to fail due to conflicting transaction")
-		}
+		require.ErrorIs(t, tvm.atomicVM.AtomicMempool.AddLocalTx(tx), atomicvm.ErrConflictingAtomicInputs)
 		// Force issue transaction directly to the mempool
-		if err := tvm.atomicVM.AtomicMempool.ForceAddTx(tx); err != nil {
-			t.Fatal(err)
-		}
+		require.NoError(t, tvm.atomicVM.AtomicMempool.ForceAddTx(tx))
 		require.Equal(t, commonEng.PendingTxs, tvm.WaitForEvent(context.Background()))
 
 		tvm.vm.clock.Set(tvm.vm.clock.Time().Add(2 * time.Second))


### PR DESCRIPTION
## Why this should be merged

This is a placeholder PR that includes all the changes I'd like to make to improve the atomic mempool.

## How this works

1. Removes deadcode `Len()`
2. Only includes `pendingTxs` in `PendingLen()`
3. Includes `currentTxs` in `length()`
4. Returns `atomicTxGasPrice()` errors if they occur during `addTx()`
5. Documents the different transaction statuses
6. Adds test for a bug where the `bloom` filter can diverge from the `pendingTxs` heap

## How this was tested

Unit tests + CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.