### PR TITLE
fix: flake in test

### DIFF
--- a/sync/blocksync/syncer.go
+++ b/sync/blocksync/syncer.go
@@ -87,8 +87,7 @@ func (s *blockSyncer) Wait(ctx context.Context) error {
 		return err
 	case <-ctx.Done():
 		s.cancel()
-		<-s.err // wait for the syncer to finish
-		return ctx.Err()
+		return <-s.err
 	}
 }
 

--- a/sync/client/test_client.go
+++ b/sync/client/test_client.go
@@ -119,6 +119,9 @@ func (ml *TestClient) GetBlocks(ctx context.Context, blockHash common.Hash, heig
 	if err != nil {
 		return nil, err
 	}
+	if response == nil && ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	client := &client{blockParser: newTestBlockParser()} // Hack to avoid duplicate code
 	blocksRes, numBlocks, err := client.parseBlocks(ml.codec, request, response)

--- a/sync/client/test_client.go
+++ b/sync/client/test_client.go
@@ -119,7 +119,9 @@ func (ml *TestClient) GetBlocks(ctx context.Context, blockHash common.Hash, heig
 	if err != nil {
 		return nil, err
 	}
-	if response == nil && ctx.Err() != nil {
+	// Actual client retries until the context is canceled.
+	if response == nil {
+		<-ctx.Done()
 		return nil, ctx.Err()
 	}
 


### PR DESCRIPTION
## Why this should be merged

If the context is canceled in the test syncer, it didn't actually return the context error, but rather `(nil, nil)`, which wasn't properly marshalable by the codec (the error is generally unclear).

## How this works

If `(nil, nil)` is returned, wait for ctx to cancel

## How this was tested

Existing UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
