### PR TITLE
refactor: use Sync instead of Start and Wait

### DIFF
--- a/plugin/evm/atomic/sync/syncer.go
+++ b/plugin/evm/atomic/sync/syncer.go
@@ -192,7 +192,7 @@ func newSyncer(config *Config) (*syncer, error) {
 
 	syncer.syncer = syncclient.NewCallbackLeafSyncer(config.Client, tasks, &syncclient.LeafSyncerConfig{
 		RequestSize: config.RequestSize,
-		NumWorkers:  config.NumWorkers,
+		NumWorkers:  numWorkers,
 		OnFailure:   syncer.onSyncFailure,
 	})
 	return syncer, nil

--- a/plugin/evm/atomic/sync/syncer.go
+++ b/plugin/evm/atomic/sync/syncer.go
@@ -193,7 +193,7 @@ func newSyncer(config *Config) (*syncer, error) {
 	syncer.syncer = syncclient.NewCallbackLeafSyncer(config.Client, tasks, &syncclient.LeafSyncerConfig{
 		RequestSize: config.RequestSize,
 		NumWorkers:  numWorkers,
-		OnFailure:   syncer.onSyncFailure,
+		OnFailure:   func() {}, // No-op since we flush progress to disk at the regular commit interval.
 	})
 	return syncer, nil
 }
@@ -275,10 +275,6 @@ func (s *syncer) onFinish() error {
 	}
 	return nil
 }
-
-// onSyncFailure is a no-op since we flush progress to disk at the regular commit interval when syncing
-// the atomic trie.
-func (s *syncer) onSyncFailure() {}
 
 type syncerLeafTask struct {
 	syncer *syncer

--- a/plugin/evm/atomic/sync/syncer.go
+++ b/plugin/evm/atomic/sync/syncer.go
@@ -198,7 +198,7 @@ func newSyncer(config *Config) (*syncer, error) {
 	return syncer, nil
 }
 
-// Start begins syncing the target atomic root with the configured number of worker goroutines.
+// Sync begins syncing the target atomic root with the configured number of worker goroutines.
 func (s *syncer) Sync(ctx context.Context) error {
 	return s.syncer.Sync(ctx)
 }
@@ -278,9 +278,7 @@ func (s *syncer) onFinish() error {
 
 // onSyncFailure is a no-op since we flush progress to disk at the regular commit interval when syncing
 // the atomic trie.
-func (s *syncer) onSyncFailure(error) error {
-	return nil
-}
+func (s *syncer) onSyncFailure() {}
 
 type syncerLeafTask struct {
 	syncer *syncer

--- a/plugin/evm/atomic/sync/syncer_test.go
+++ b/plugin/evm/atomic/sync/syncer_test.go
@@ -215,12 +215,7 @@ func TestConfigValidation(t *testing.T) {
 
 			// Test validation
 			err := config.Validate()
-
-			if tt.expectedErr == nil {
-				require.NoError(t, err, tt.description)
-			} else {
-				require.ErrorIs(t, err, tt.expectedErr, tt.description)
-			}
+			require.ErrorIs(t, err, tt.expectedErr, tt.description)
 		})
 	}
 }
@@ -425,9 +420,13 @@ func runParallelizationTest(t *testing.T, ctx context.Context, mockClient *syncc
 	}
 
 	syncer := createTestSyncer(t, config)
+	workerType := "default workers"
+	if !useDefaultWorkers {
+		workerType = fmt.Sprintf("%d workers", numWorkers)
+	}
 
 	// Wait for completion.
-	require.NoError(t, syncer.Sync(ctx))
+	require.NoError(t, syncer.Sync(ctx), "syncer should complete successfully with %s", workerType)
 }
 
 // testSyncer creates a leaf handler with [serverTrieDB] and tests to ensure that the atomic syncer can sync correctly

--- a/plugin/evm/atomic/sync/syncer_test.go
+++ b/plugin/evm/atomic/sync/syncer_test.go
@@ -463,8 +463,7 @@ func testSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight uint64
 		}
 
 		err = syncer.Sync(ctx)
-		require.Error(t, err, "Expected syncer to fail at checkpoint with numLeaves %d", numLeaves)
-		require.ErrorContains(t, err, "failed to fetch leafs")
+		require.ErrorIs(t, err, syncclient.ErrFailedToFetchLeafs)
 
 		require.Equal(t, checkpoint.expectedNumLeavesSynced, int64(numLeaves), "unexpected number of leaves received at checkpoint %d", i)
 		// Replace the target root and height for the next checkpoint

--- a/plugin/evm/atomic/sync/syncer_test.go
+++ b/plugin/evm/atomic/sync/syncer_test.go
@@ -464,6 +464,7 @@ func testSyncer(t *testing.T, serverTrieDB *triedb.Database, targetHeight uint64
 
 		err = syncer.Sync(ctx)
 		require.Error(t, err, "Expected syncer to fail at checkpoint with numLeaves %d", numLeaves)
+		require.ErrorContains(t, err, "failed to fetch leafs")
 
 		require.Equal(t, checkpoint.expectedNumLeavesSynced, int64(numLeaves), "unexpected number of leaves received at checkpoint %d", i)
 		// Replace the target root and height for the next checkpoint

--- a/sync/blocksync/syncer.go
+++ b/sync/blocksync/syncer.go
@@ -49,9 +49,6 @@ func (c *Config) Validate() error {
 
 type blockSyncer struct {
 	config *Config
-
-	err    chan error
-	cancel context.CancelFunc
 }
 
 func NewSyncer(config *Config) (*blockSyncer, error) {
@@ -60,7 +57,6 @@ func NewSyncer(config *Config) (*blockSyncer, error) {
 	}
 	return &blockSyncer{
 		config: config,
-		err:    make(chan error, 1),
 	}, nil
 }
 

--- a/sync/blocksync/syncer_test.go
+++ b/sync/blocksync/syncer_test.go
@@ -162,21 +162,13 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 
 func TestBlockSyncer_ContextCancellation(t *testing.T) {
 	env := newTestEnvironment(t, 10)
-
 	syncer, err := env.createSyncer(5, 3)
 	require.NoError(t, err)
 
+	// Immediately cancel the context to simulate cancellation.
 	ctx, cancel := context.WithCancel(context.Background())
-	start := make(chan struct{})
-	errChan := make(chan error, 1)
-	go func() {
-		<-start
-		errChan <- syncer.Sync(ctx)
-	}()
-	cancel() // Cancel the context to simulate cancellation
-	close(start)
-
-	err = <-errChan
+	cancel()
+	err = syncer.Sync(ctx)
 	require.ErrorIs(t, err, context.Canceled)
 }
 

--- a/sync/blocksync/syncer_test.go
+++ b/sync/blocksync/syncer_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
 	"github.com/ava-labs/coreth/plugin/evm/message"
-	synccommon "github.com/ava-labs/coreth/sync"
 	syncclient "github.com/ava-labs/coreth/sync/client"
 	"github.com/ava-labs/coreth/sync/handlers"
 	handlerstats "github.com/ava-labs/coreth/sync/handlers/stats"
@@ -67,30 +66,6 @@ func TestConfigValidation(t *testing.T) {
 			require.ErrorIs(t, err, tt.wantErr)
 		})
 	}
-}
-
-func TestWaitBeforeStart(t *testing.T) {
-	env := newTestEnvironment(t, 10)
-
-	syncer, err := env.createSyncer(5, 3)
-	require.NoError(t, err)
-	require.NotNil(t, syncer)
-
-	err = syncer.Wait(context.Background())
-	require.ErrorIs(t, err, synccommon.ErrWaitBeforeStart)
-}
-
-func TestDuplicateStart(t *testing.T) {
-	env := newTestEnvironment(t, 10)
-
-	syncer, err := env.createSyncer(5, 3)
-	require.NoError(t, err)
-	require.NotNil(t, syncer)
-
-	require.NoError(t, syncer.Start(context.Background()))
-
-	err = syncer.Start(context.Background())
-	require.ErrorIs(t, err, synccommon.ErrSyncerAlreadyStarted)
 }
 
 func TestBlockSyncer_ParameterizedTests(t *testing.T) {
@@ -173,9 +148,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 			syncer, err := env.createSyncer(tt.fromHeight, tt.blocksToFetch)
 			require.NoError(t, err)
 
-			ctx := context.Background()
-			require.NoError(t, syncer.Start(ctx))
-			require.NoError(t, syncer.Wait(ctx))
+			require.NoError(t, syncer.Sync(context.Background()))
 
 			env.verifyBlocksInDB(t, tt.expectedBlocks)
 
@@ -194,12 +167,16 @@ func TestBlockSyncer_ContextCancellation(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	require.NoError(t, syncer.Start(ctx))
+	start := make(chan struct{})
+	errChan := make(chan error, 1)
+	go func() {
+		<-start
+		errChan <- syncer.Sync(ctx)
+	}()
+	cancel() // Cancel the context to simulate cancellation
+	close(start)
 
-	// Cancel context immediately
-	cancel()
-
-	err = syncer.Wait(ctx)
+	err = <-errChan
 	require.ErrorIs(t, err, context.Canceled)
 }
 

--- a/sync/client/leaf_syncer.go
+++ b/sync/client/leaf_syncer.go
@@ -74,7 +74,6 @@ func (c *CallbackLeafSyncer) workerLoop(ctx context.Context) error {
 				return err
 			}
 		case <-ctx.Done():
-			fmt.Println("context cancelled, stopping worker loop")
 			return ctx.Err()
 		}
 	}

--- a/sync/client/leaf_syncer.go
+++ b/sync/client/leaf_syncer.go
@@ -70,6 +70,7 @@ func (c *CallbackLeafSyncer) workerLoop(ctx context.Context) error {
 				return err
 			}
 		case <-ctx.Done():
+			fmt.Println("context cancelled, stopping worker loop")
 			return ctx.Err()
 		}
 	}

--- a/sync/client/leaf_syncer.go
+++ b/sync/client/leaf_syncer.go
@@ -106,7 +106,7 @@ func (c *CallbackLeafSyncer) syncTask(ctx context.Context, task LeafSyncTask) er
 			NodeType: task.NodeType(),
 		})
 		if err != nil {
-			return fmt.Errorf("%s: %w", ErrFailedToFetchLeafs, err)
+			return fmt.Errorf("%w: %w", ErrFailedToFetchLeafs, err)
 		}
 
 		// resize [leafsResponse.Keys] and [leafsResponse.Vals] in case

--- a/sync/client/leaf_syncer.go
+++ b/sync/client/leaf_syncer.go
@@ -34,11 +34,16 @@ type LeafSyncTask interface {
 	OnFinish(ctx context.Context) error // Callback when there are no more leaves in the trie to sync or when we reach End()
 }
 
+type LeafSyncerConfig struct {
+	RequestSize uint16            // Number of leafs to request from a peer at a time
+	NumWorkers  int               // Number of workers to process leaf sync tasks
+	OnFailure   func(error) error // Callback for handling errors during sync
+}
+
 type CallbackLeafSyncer struct {
-	client      LeafClient
-	done        chan error
-	tasks       <-chan LeafSyncTask
-	requestSize uint16
+	config *LeafSyncerConfig
+	client LeafClient
+	tasks  <-chan LeafSyncTask
 }
 
 type LeafClient interface {
@@ -48,12 +53,11 @@ type LeafClient interface {
 }
 
 // NewCallbackLeafSyncer creates a new syncer object to perform leaf sync of tries.
-func NewCallbackLeafSyncer(client LeafClient, tasks <-chan LeafSyncTask, requestSize uint16) *CallbackLeafSyncer {
+func NewCallbackLeafSyncer(client LeafClient, tasks <-chan LeafSyncTask, config *LeafSyncerConfig) *CallbackLeafSyncer {
 	return &CallbackLeafSyncer{
-		client:      client,
-		done:        make(chan error),
-		tasks:       tasks,
-		requestSize: requestSize,
+		config: config,
+		client: client,
+		tasks:  tasks,
 	}
 }
 
@@ -100,7 +104,7 @@ func (c *CallbackLeafSyncer) syncTask(ctx context.Context, task LeafSyncTask) er
 			Root:     root,
 			Account:  task.Account(),
 			Start:    start,
-			Limit:    c.requestSize,
+			Limit:    c.config.RequestSize,
 			NodeType: task.NodeType(),
 		})
 		if err != nil {
@@ -147,26 +151,20 @@ func (c *CallbackLeafSyncer) syncTask(ctx context.Context, task LeafSyncTask) er
 
 // Start launches [numWorkers] worker goroutines to process LeafSyncTasks from [c.tasks].
 // onFailure is called if the sync completes with an error.
-func (c *CallbackLeafSyncer) Start(ctx context.Context, numWorkers int, onFailure func(error) error) {
+func (c *CallbackLeafSyncer) Sync(ctx context.Context) error {
 	// Start the worker threads with the desired context.
 	eg, egCtx := errgroup.WithContext(ctx)
-	for i := 0; i < numWorkers; i++ {
+	for i := 0; i < c.config.NumWorkers; i++ {
 		eg.Go(func() error {
 			return c.workerLoop(egCtx)
 		})
 	}
 
-	go func() {
-		err := eg.Wait()
-		if err != nil {
-			if err := onFailure(err); err != nil {
-				log.Error("error handling onFailure callback", "err", err)
-			}
+	err := eg.Wait()
+	if err != nil {
+		if err := c.config.OnFailure(err); err != nil {
+			log.Error("error handling onFailure callback", "err", err)
 		}
-		c.done <- err
-		close(c.done)
-	}()
+	}
+	return err
 }
-
-// Done returns a channel which produces any error that occurred during syncing or nil on success.
-func (c *CallbackLeafSyncer) Done() <-chan error { return c.done }

--- a/sync/statesync/code_syncer.go
+++ b/sync/statesync/code_syncer.go
@@ -25,8 +25,8 @@ const (
 )
 
 var (
-	errWaitBeforeStart              = errors.New("Wait() called before Start() - call Start() first")
 	errFailedToAddCodeHashesToQueue = errors.New("failed to add code hashes to queue")
+	errWaitBeforeStart              = errors.New("Wait() called before Start() - call Start() first")
 )
 
 // CodeSyncerConfig defines the configuration of the code syncer

--- a/sync/statesync/code_syncer.go
+++ b/sync/statesync/code_syncer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/message"
-	synccommon "github.com/ava-labs/coreth/sync"
 	statesyncclient "github.com/ava-labs/coreth/sync/client"
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
@@ -26,8 +25,8 @@ const (
 )
 
 var (
-	errFailedToAddCodeHashesToQueue                   = errors.New("failed to add code hashes to queue")
-	_                               synccommon.Syncer = (*codeSyncer)(nil)
+	errWaitBeforeStart              = errors.New("Wait() called before Start() - call Start() first")
+	errFailedToAddCodeHashesToQueue = errors.New("failed to add code hashes to queue")
 )
 
 // CodeSyncerConfig defines the configuration of the code syncer
@@ -113,7 +112,7 @@ func (c *codeSyncer) Start(ctx context.Context) error {
 // This method must be called after start() has been called.
 func (c *codeSyncer) Wait(ctx context.Context) error {
 	if c.cancel == nil {
-		return synccommon.ErrWaitBeforeStart
+		return errWaitBeforeStart
 	}
 
 	select {

--- a/sync/statesync/code_syncer_test.go
+++ b/sync/statesync/code_syncer_test.go
@@ -69,7 +69,7 @@ func testCodeSyncer(t *testing.T, test codeSyncerTest) {
 	}
 	go func() {
 		for _, codeHashes := range test.codeRequestHashes {
-			if err := codeSyncer.addCode(codeHashes); err != nil {
+			if err := codeSyncer.AddCode(codeHashes); err != nil {
 				require.ErrorIs(t, err, test.err)
 			}
 		}

--- a/sync/statesync/code_syncer_test.go
+++ b/sync/statesync/code_syncer_test.go
@@ -19,12 +19,16 @@ import (
 	"github.com/ava-labs/libevm/common"
 	"github.com/ava-labs/libevm/core/rawdb"
 	"github.com/ava-labs/libevm/crypto"
+	"github.com/ava-labs/libevm/ethdb"
 	"github.com/ava-labs/libevm/ethdb/memorydb"
 
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
+const testOutstandingCodeHashes = 10
+
 type codeSyncerTest struct {
+	clientDB          ethdb.Database
 	setupCodeSyncer   func(*codeSyncer)
 	codeRequestHashes [][]common.Hash
 	codeByteSlices    [][]byte
@@ -48,47 +52,40 @@ func testCodeSyncer(t *testing.T, test codeSyncerTest) {
 	mockClient := statesyncclient.NewTestClient(message.Codec, nil, codeRequestHandler, nil)
 	mockClient.GetCodeIntercept = test.getCodeIntercept
 
-	clientDB := rawdb.NewMemoryDatabase()
+	clientDB := test.clientDB
+	if clientDB == nil {
+		clientDB = rawdb.NewMemoryDatabase()
+	}
 
-	codeSyncer := newCodeSyncer(CodeSyncerConfig{
-		MaxOutstandingCodeHashes: DefaultMaxOutstandingCodeHashes,
+	codeSyncer, err := newCodeSyncer(CodeSyncerConfig{
+		MaxOutstandingCodeHashes: testOutstandingCodeHashes,
 		NumCodeFetchingWorkers:   DefaultNumCodeFetchingWorkers,
 		Client:                   mockClient,
 		DB:                       clientDB,
 	})
+	require.NoError(t, err)
 	if test.setupCodeSyncer != nil {
 		test.setupCodeSyncer(codeSyncer)
 	}
-	if err := codeSyncer.Start(context.Background()); err != nil {
-		t.Fatal(err)
-	}
-
-	for _, codeHashes := range test.codeRequestHashes {
-		if err := codeSyncer.addCode(codeHashes); err != nil {
-			if test.err == nil {
-				t.Fatal(err)
-			} else {
-				assert.ErrorIs(t, err, test.err)
+	go func() {
+		for _, codeHashes := range test.codeRequestHashes {
+			if err := codeSyncer.addCode(codeHashes); err != nil {
+				require.ErrorIs(t, err, test.err)
 			}
 		}
-	}
-	codeSyncer.notifyAccountTrieCompleted()
+		codeSyncer.notifyAccountTrieCompleted()
+	}()
 
-	err := codeSyncer.Wait(context.Background())
-	if test.err != nil {
-		if err == nil {
-			t.Fatal(t, "expected non-nil error: %s", test.err)
-		}
-		assert.ErrorIs(t, err, test.err)
-		return
-	} else if err != nil {
-		t.Fatal(err)
+	err = codeSyncer.Sync(context.Background())
+	require.ErrorIs(t, err, test.err)
+	if err != nil {
+		return // don't check the state
 	}
 
 	// Assert that the client synced the code correctly.
 	for i, codeHash := range codeHashes {
 		codeBytes := rawdb.ReadCode(clientDB, codeHash)
-		assert.Equal(t, test.codeByteSlices[i], codeBytes)
+		require.Equal(t, test.codeByteSlices[i], codeBytes)
 	}
 }
 
@@ -138,17 +135,17 @@ func TestCodeSyncerRequestErrors(t *testing.T) {
 func TestCodeSyncerAddsInProgressCodeHashes(t *testing.T) {
 	codeBytes := utils.RandomBytes(100)
 	codeHash := crypto.Keccak256Hash(codeBytes)
+	clientDB := rawdb.NewMemoryDatabase()
+	customrawdb.AddCodeToFetch(clientDB, codeHash)
 	testCodeSyncer(t, codeSyncerTest{
-		setupCodeSyncer: func(c *codeSyncer) {
-			customrawdb.AddCodeToFetch(c.DB, codeHash)
-		},
+		clientDB:          clientDB,
 		codeRequestHashes: nil,
 		codeByteSlices:    [][]byte{codeBytes},
 	})
 }
 
 func TestCodeSyncerAddsMoreInProgressThanQueueSize(t *testing.T) {
-	numCodeSlices := 10
+	numCodeSlices := 100
 	codeHashes := make([]common.Hash, 0, numCodeSlices)
 	codeByteSlices := make([][]byte, 0, numCodeSlices)
 	for i := 0; i < numCodeSlices; i++ {
@@ -158,13 +155,13 @@ func TestCodeSyncerAddsMoreInProgressThanQueueSize(t *testing.T) {
 		codeByteSlices = append(codeByteSlices, codeBytes)
 	}
 
+	db := rawdb.NewMemoryDatabase()
+	for _, codeHash := range codeHashes {
+		customrawdb.AddCodeToFetch(db, codeHash)
+	}
+
 	testCodeSyncer(t, codeSyncerTest{
-		setupCodeSyncer: func(c *codeSyncer) {
-			for _, codeHash := range codeHashes {
-				customrawdb.AddCodeToFetch(c.DB, codeHash)
-			}
-			c.codeHashes = make(chan common.Hash, numCodeSlices/2)
-		},
+		clientDB:          db,
 		codeRequestHashes: nil,
 		codeByteSlices:    codeByteSlices,
 	})

--- a/sync/statesync/code_syncer_test.go
+++ b/sync/statesync/code_syncer_test.go
@@ -57,12 +57,12 @@ func testCodeSyncer(t *testing.T, test codeSyncerTest) {
 		clientDB = rawdb.NewMemoryDatabase()
 	}
 
-	codeSyncer, err := newCodeSyncer(CodeSyncerConfig{
-		MaxOutstandingCodeHashes: testOutstandingCodeHashes,
-		NumCodeFetchingWorkers:   DefaultNumCodeFetchingWorkers,
-		Client:                   mockClient,
-		DB:                       clientDB,
-	})
+	codeSyncer, err := newCodeSyncer(
+		clientDB,
+		mockClient,
+		testOutstandingCodeHashes,
+		DefaultNumCodeFetchingWorkers,
+	)
 	require.NoError(t, err)
 	if test.setupCodeSyncer != nil {
 		test.setupCodeSyncer(codeSyncer)

--- a/sync/statesync/state_syncer.go
+++ b/sync/statesync/state_syncer.go
@@ -246,7 +246,7 @@ func (t *stateSync) Sync(ctx context.Context) error {
 	})
 
 	// The errgroup wait will take care of returning the first error that occurs, or returning
-	// nil if both finish without an error.
+	// nil if syncing finish without an error.
 	return eg.Wait()
 }
 
@@ -283,6 +283,7 @@ func (t *stateSync) onSyncFailure() {
 		for _, segment := range trie.segments {
 			if err := segment.batch.Write(); err != nil {
 				log.Error("failed to write segment batch on sync failure", "err", err)
+				return
 			}
 		}
 	}

--- a/sync/statesync/state_syncer.go
+++ b/sync/statesync/state_syncer.go
@@ -95,12 +95,12 @@ func NewSyncer(config *Config) (synccommon.Syncer, error) {
 		OnFailure:   ss.onSyncFailure,
 	})
 	var err error
-	ss.codeSyncer, err = newCodeSyncer(CodeSyncerConfig{
-		DB:                       config.DB,
-		Client:                   config.Client,
-		MaxOutstandingCodeHashes: config.MaxOutstandingCodeHashes,
-		NumCodeFetchingWorkers:   config.NumCodeFetchingWorkers,
-	})
+	ss.codeSyncer, err = newCodeSyncer(
+		config.DB,
+		config.Client,
+		config.MaxOutstandingCodeHashes,
+		config.NumCodeFetchingWorkers,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/sync/statesync/sync_test.go
+++ b/sync/statesync/sync_test.go
@@ -206,7 +206,7 @@ func TestCancelSync(t *testing.T) {
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
 	// Create trie with 2000 accounts (more than one leaf request)
-	root := fillAccountsWithStorage(t, serverDB, serverTrieDB, common.Hash{}, 5000)
+	root := fillAccountsWithStorage(t, serverDB, serverTrieDB, common.Hash{}, 2000)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	testSync(t, syncTest{

--- a/sync/statesync/trie_sync_tasks.go
+++ b/sync/statesync/trie_sync_tasks.go
@@ -85,7 +85,7 @@ func (m *mainTrieTask) OnLeafs(db ethdb.KeyValueWriter, keys, vals [][]byte) err
 		}
 	}
 	// Add collected code hashes to the code syncer.
-	return m.sync.codeSyncer.addCode(codeHashes)
+	return m.sync.codeSyncer.AddCode(codeHashes)
 }
 
 type storageTrieTask struct {

--- a/sync/types.go
+++ b/sync/types.go
@@ -5,7 +5,6 @@ package sync
 
 import (
 	"context"
-	"errors"
 
 	"github.com/ava-labs/avalanchego/database/versiondb"
 	"github.com/ava-labs/avalanchego/snow/engine/snowman/block"
@@ -14,24 +13,12 @@ import (
 	"github.com/ava-labs/libevm/core/types"
 )
 
-var (
-	// ErrWaitBeforeStart is returned when Wait() is called before Start().
-	ErrWaitBeforeStart = errors.New("Wait() called before Start() - call Start() first")
-	// ErrSyncerAlreadyStarted is returned when Start() is called on a syncer that has already been started.
-	ErrSyncerAlreadyStarted = errors.New("syncer already started")
-)
-
 // Syncer is the common interface for all sync operations.
 // This provides a unified interface for atomic state sync and state trie sync.
 type Syncer interface {
-	// Start begins the sync operation.
+	// Completes the full sync operation, returning any errors encountered.
 	// The sync will respect context cancellation.
-	Start(ctx context.Context) error
-
-	// Wait blocks until the sync operation completes or fails.
-	// Returns the final error (nil if successful).
-	// The sync will respect context cancellation.
-	Wait(ctx context.Context) error
+	Sync(ctx context.Context) error
 }
 
 // SummaryProvider is an interface for providing state summaries.

--- a/sync/vm/registry.go
+++ b/sync/vm/registry.go
@@ -52,7 +52,6 @@ func (r *SyncerRegistry) RunSyncerTasks(ctx context.Context, client *client) err
 	for _, task := range r.syncers {
 		log.Info("starting syncer", "name", task.name, "summary", client.summary)
 
-		// Log completion immediately.
 		if err := task.syncer.Sync(ctx); err != nil {
 			log.Error("failed to complete", "name", task.name, "summary", client.summary, "err", err)
 			return fmt.Errorf("%s failed: %w", task.name, err)

--- a/sync/vm/registry.go
+++ b/sync/vm/registry.go
@@ -51,15 +51,13 @@ func (r *SyncerRegistry) RunSyncerTasks(ctx context.Context, client *client) err
 
 	for _, task := range r.syncers {
 		log.Info("starting syncer", "name", task.name, "summary", client.summary)
-		err := task.syncer.Sync(ctx)
 
 		// Log completion immediately.
-		if err != nil {
+		if err := task.syncer.Sync(ctx); err != nil {
 			log.Error("failed to complete", "name", task.name, "summary", client.summary, "err", err)
 			return fmt.Errorf("%s failed: %w", task.name, err)
-		} else {
-			log.Info("completed successfully", "name", task.name, "summary", client.summary)
 		}
+		log.Info("completed successfully", "name", task.name, "summary", client.summary)
 	}
 
 	return nil

--- a/sync/vm/registry.go
+++ b/sync/vm/registry.go
@@ -51,15 +51,7 @@ func (r *SyncerRegistry) RunSyncerTasks(ctx context.Context, client *client) err
 
 	for _, task := range r.syncers {
 		log.Info("starting syncer", "name", task.name, "summary", client.summary)
-
-		// Start syncer.
-		if err := task.syncer.Start(ctx); err != nil {
-			log.Info("failed to start", "name", task.name, "summary", client.summary, "err", err)
-			return fmt.Errorf("failed to start %s: %w", task.name, err)
-		}
-
-		// Wait for completion.
-		err := task.syncer.Wait(ctx)
+		err := task.syncer.Sync(ctx)
 
 		// Log completion immediately.
 		if err != nil {

--- a/sync/vm/registry_test.go
+++ b/sync/vm/registry_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"errors"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -19,7 +18,7 @@ type mockSyncer struct {
 	started   bool // Track if already started
 }
 
-func newMockSyncer(name string, syncDelay time.Duration, syncError error) *mockSyncer {
+func newMockSyncer(name string, syncError error) *mockSyncer {
 	return &mockSyncer{
 		name:      name,
 		syncError: syncError,
@@ -53,8 +52,8 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("TestSyncer1", 0, nil)},
-				{"Syncer2", newMockSyncer("TestSyncer2", 0, nil)},
+				{"Syncer1", newMockSyncer("TestSyncer1", nil)},
+				{"Syncer2", newMockSyncer("TestSyncer2", nil)},
 			},
 			expectedError: "",
 			expectedCount: 2,
@@ -65,8 +64,8 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
-				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
+				{"Syncer1", newMockSyncer("Syncer1", nil)},
+				{"Syncer1", newMockSyncer("Syncer1", nil)},
 			},
 			expectedError: "syncer with name 'Syncer1' is already registered",
 			expectedCount: 1,
@@ -77,9 +76,9 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
-				{"Syncer2", newMockSyncer("Syncer2", 0, nil)},
-				{"Syncer3", newMockSyncer("Syncer3", 0, nil)},
+				{"Syncer1", newMockSyncer("Syncer1", nil)},
+				{"Syncer2", newMockSyncer("Syncer2", nil)},
+				{"Syncer3", newMockSyncer("Syncer3", nil)},
 			},
 			expectedCount: 3,
 		},
@@ -126,7 +125,6 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 		name    string
 		syncers []struct {
 			name      string
-			syncDelay time.Duration
 			syncError error
 		}
 		expectedError string
@@ -136,11 +134,10 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 			name: "successful execution",
 			syncers: []struct {
 				name      string
-				syncDelay time.Duration
 				syncError error
 			}{
-				{"Syncer1", 0, nil},
-				{"Syncer2", 0, nil},
+				{"Syncer1", nil},
+				{"Syncer2", nil},
 			},
 			assertState: func(t *testing.T, mockSyncers []*mockSyncer, expectedError string) {
 				for i, mockSyncer := range mockSyncers {
@@ -151,11 +148,10 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 			name: "wait error stops execution",
 			syncers: []struct {
 				name      string
-				syncDelay time.Duration
 				syncError error
 			}{
-				{"Syncer1", 0, errors.New("wait failed")},
-				{"Syncer2", 0, nil},
+				{"Syncer1", errors.New("wait failed")},
+				{"Syncer2", nil},
 			},
 			expectedError: "Syncer1 failed",
 			assertState: func(t *testing.T, mockSyncers []*mockSyncer, expectedError string) {
@@ -176,7 +172,6 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 			for i, syncerConfig := range tt.syncers {
 				mockSyncer := newMockSyncer(
 					syncerConfig.name,
-					syncerConfig.syncDelay,
 					syncerConfig.syncError,
 				)
 				mockSyncers[i] = mockSyncer

--- a/sync/vm/registry_test.go
+++ b/sync/vm/registry_test.go
@@ -14,27 +14,20 @@ import (
 
 // mockSyncer implements synccommon.Syncer for testing.
 type mockSyncer struct {
-	name       string
-	syncDelay  time.Duration
-	syncError  error
-	startCount int
-	started    bool // Track if already started
+	name      string
+	syncError error
+	started   bool // Track if already started
 }
 
 func newMockSyncer(name string, syncDelay time.Duration, syncError error) *mockSyncer {
 	return &mockSyncer{
 		name:      name,
-		syncDelay: syncDelay,
 		syncError: syncError,
 	}
 }
 
 func (m *mockSyncer) Sync(ctx context.Context) error {
 	m.started = true
-	m.startCount++
-	if m.syncDelay > 0 {
-		time.Sleep(m.syncDelay)
-	}
 	return m.syncError
 }
 

--- a/sync/vm/registry_test.go
+++ b/sync/vm/registry_test.go
@@ -9,56 +9,33 @@ import (
 	"testing"
 	"time"
 
-	synccommon "github.com/ava-labs/coreth/sync"
 	"github.com/stretchr/testify/require"
 )
 
 // mockSyncer implements synccommon.Syncer for testing.
 type mockSyncer struct {
-	name           string
-	startDelay     time.Duration
-	waitDelay      time.Duration
-	startError     error
-	waitError      error
-	startCalled    bool
-	waitCalled     bool
-	startCallCount int
-	waitCallCount  int
-	started        bool // Track if already started
+	name       string
+	syncDelay  time.Duration
+	syncError  error
+	startCount int
+	started    bool // Track if already started
 }
 
-func newMockSyncer(name string, startDelay, waitDelay time.Duration, startError, waitError error) *mockSyncer {
+func newMockSyncer(name string, syncDelay time.Duration, syncError error) *mockSyncer {
 	return &mockSyncer{
-		name:       name,
-		startDelay: startDelay,
-		waitDelay:  waitDelay,
-		startError: startError,
-		waitError:  waitError,
+		name:      name,
+		syncDelay: syncDelay,
+		syncError: syncError,
 	}
 }
 
-func (m *mockSyncer) Start(ctx context.Context) error {
-	if m.started {
-		return synccommon.ErrSyncerAlreadyStarted
-	}
-
+func (m *mockSyncer) Sync(ctx context.Context) error {
 	m.started = true
-	m.startCalled = true
-	m.startCallCount++
-	if m.startDelay > 0 {
-		time.Sleep(m.startDelay)
+	m.startCount++
+	if m.syncDelay > 0 {
+		time.Sleep(m.syncDelay)
 	}
-	return m.startError
-}
-
-func (m *mockSyncer) Wait(ctx context.Context) error {
-	m.waitCalled = true
-	m.waitCallCount++
-	if m.waitDelay > 0 {
-		time.Sleep(m.waitDelay)
-	}
-
-	return m.waitError
+	return m.syncError
 }
 
 func TestNewSyncerRegistry(t *testing.T) {
@@ -83,8 +60,8 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("TestSyncer1", 0, 0, nil, nil)},
-				{"Syncer2", newMockSyncer("TestSyncer2", 0, 0, nil, nil)},
+				{"Syncer1", newMockSyncer("TestSyncer1", 0, nil)},
+				{"Syncer2", newMockSyncer("TestSyncer2", 0, nil)},
 			},
 			expectedError: "",
 			expectedCount: 2,
@@ -95,8 +72,8 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("Syncer1", 0, 0, nil, nil)},
-				{"Syncer1", newMockSyncer("Syncer1", 0, 0, nil, nil)},
+				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
+				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
 			},
 			expectedError: "syncer with name 'Syncer1' is already registered",
 			expectedCount: 1,
@@ -107,9 +84,9 @@ func TestSyncerRegistry_Register(t *testing.T) {
 				name   string
 				syncer *mockSyncer
 			}{
-				{"Syncer1", newMockSyncer("Syncer1", 0, 0, nil, nil)},
-				{"Syncer2", newMockSyncer("Syncer2", 0, 0, nil, nil)},
-				{"Syncer3", newMockSyncer("Syncer3", 0, 0, nil, nil)},
+				{"Syncer1", newMockSyncer("Syncer1", 0, nil)},
+				{"Syncer2", newMockSyncer("Syncer2", 0, nil)},
+				{"Syncer3", newMockSyncer("Syncer3", 0, nil)},
 			},
 			expectedCount: 3,
 		},
@@ -155,11 +132,9 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 	tests := []struct {
 		name    string
 		syncers []struct {
-			name       string
-			startDelay time.Duration
-			waitDelay  time.Duration
-			startError error
-			waitError  error
+			name      string
+			syncDelay time.Duration
+			syncError error
 		}
 		expectedError string
 		assertState   func(t *testing.T, mockSyncers []*mockSyncer, expectedError string)
@@ -167,64 +142,34 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 		{
 			name: "successful execution",
 			syncers: []struct {
-				name       string
-				startDelay time.Duration
-				waitDelay  time.Duration
-				startError error
-				waitError  error
+				name      string
+				syncDelay time.Duration
+				syncError error
 			}{
-				{"Syncer1", 0, 0, nil, nil},
-				{"Syncer2", 0, 0, nil, nil},
+				{"Syncer1", 0, nil},
+				{"Syncer2", 0, nil},
 			},
 			assertState: func(t *testing.T, mockSyncers []*mockSyncer, expectedError string) {
 				for i, mockSyncer := range mockSyncers {
-					require.True(t, mockSyncer.startCalled, "Syncer %d should have been started", i)
-					require.True(t, mockSyncer.waitCalled, "Syncer %d should have been waited on", i)
+					require.True(t, mockSyncer.started, "Syncer %d should have been started", i)
 				}
 			},
-		},
-		{
-			name: "start error stops execution",
-			syncers: []struct {
-				name       string
-				startDelay time.Duration
-				waitDelay  time.Duration
-				startError error
-				waitError  error
-			}{
-				{"Syncer1", 0, 0, errors.New("start failed"), nil},
-				{"Syncer2", 0, 0, nil, nil},
-			},
-			expectedError: "failed to start Syncer1",
-			assertState: func(t *testing.T, mockSyncers []*mockSyncer, expectedError string) {
-				// First syncer should be started but not waited on.
-				require.True(t, mockSyncers[0].startCalled, "First syncer should have been started")
-				require.False(t, mockSyncers[0].waitCalled, "First syncer should not have been waited on due to start error")
-				// Second syncer should not be started.
-				require.False(t, mockSyncers[1].startCalled, "Second syncer should not have been started")
-				require.False(t, mockSyncers[1].waitCalled, "Second syncer should not have been waited on")
-			},
-		},
-		{
+		}, {
 			name: "wait error stops execution",
 			syncers: []struct {
-				name       string
-				startDelay time.Duration
-				waitDelay  time.Duration
-				startError error
-				waitError  error
+				name      string
+				syncDelay time.Duration
+				syncError error
 			}{
-				{"Syncer1", 0, 0, nil, errors.New("wait failed")},
-				{"Syncer2", 0, 0, nil, nil},
+				{"Syncer1", 0, errors.New("wait failed")},
+				{"Syncer2", 0, nil},
 			},
 			expectedError: "Syncer1 failed",
 			assertState: func(t *testing.T, mockSyncers []*mockSyncer, expectedError string) {
 				// First syncer should be started and waited on (but wait failed).
-				require.True(t, mockSyncers[0].startCalled, "First syncer should have been started")
-				require.True(t, mockSyncers[0].waitCalled, "First syncer should have been waited on")
+				require.True(t, mockSyncers[0].started, "First syncer should have been started")
 				// Second syncer should not be started.
-				require.False(t, mockSyncers[1].startCalled, "Second syncer should not have been started")
-				require.False(t, mockSyncers[1].waitCalled, "Second syncer should not have been waited on")
+				require.False(t, mockSyncers[1].started, "Second syncer should not have been started")
 			},
 		},
 	}
@@ -238,10 +183,8 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 			for i, syncerConfig := range tt.syncers {
 				mockSyncer := newMockSyncer(
 					syncerConfig.name,
-					syncerConfig.startDelay,
-					syncerConfig.waitDelay,
-					syncerConfig.startError,
-					syncerConfig.waitError,
+					syncerConfig.syncDelay,
+					syncerConfig.syncError,
 				)
 				mockSyncers[i] = mockSyncer
 				require.NoError(t, registry.Register(syncerConfig.name, mockSyncer))


### PR DESCRIPTION
## Why this should be merged

Due to the complexity of context handling and cancellation in the `Start` and `Wait` approach, this moves all syncers to the simpler `Sync` call sufficient to sync them.

One trickier part to move is the code syncer, since it needs to start prior to handling the account trie, 

## How this works

Removes channel issues (see #1096) since starting and waiting for syncers to finish are always done together.

## How this was tested

Existing UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
