### PR TITLE
chore: prepare release for v0.15.3

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,8 @@
 
 ## Pending Release
 
+## [v0.15.3](https://github.com/ava-labs/coreth/releases/tag/v0.15.3)
+
 - Removed legacy warp message handlers in favor of ACP-118 SDK handlers.
 - Use `state-history` eth config flag to designate the number of recent states queryable.
 - Added maximum number of addresses (1000) to be queried in a single filter.
@@ -11,6 +13,9 @@
 - Enable expermiental `state-scheme` flag to specify Firewood as a state database.
 - Added prometheus metrics for Firewood if it is enabled and expensive metrics are being used.
 - Disable incompatible APIs for Firewood.
+
+## [v0.15.2](https://github.com/ava-labs/coreth/releases/tag/v0.15.2)
+
 
 ## [v0.15.1](https://github.com/ava-labs/coreth/releases/tag/v0.15.1)
 

--- a/docs/releasing/README.md
+++ b/docs/releasing/README.md
@@ -35,7 +35,7 @@ export VERSION=v0.15.0
 1. Create a pull request (PR) from your branch targeting master, for example using [`gh`](https://cli.github.com/):
 
     ```bash
-    gh pr create --repo github.com/ava-labs/subnet-evm --base master --title "chore: release $VERSION_RC"
+    gh pr create --repo github.com/ava-labs/coreth --base master --title "chore: release $VERSION_RC"
     ```
 
 1. Wait for the PR checks to pass with
@@ -83,7 +83,7 @@ Following the previous example in the [Release candidate section](#release-candi
     ```
 
 1. Create a new release on Github, either using:
-    - the [Github web interface](https://github.com/ava-labs/subnet-evm/releases/new)
+    - the [Github web interface](https://github.com/ava-labs/coreth/releases/new)
         1. In the "Choose a tag" box, select the tag previously created `$VERSION` (`v0.15.0`)
         1. Pick the previous tag, for example as `v0.14.0`.
         1. Set the "Release title" to `$VERSION` (`v0.15.0`)

--- a/plugin/evm/version.go
+++ b/plugin/evm/version.go
@@ -9,7 +9,7 @@ var (
 	// GitCommit is set by the build script
 	GitCommit string
 	// Version is the version of Coreth
-	Version string = "v0.15.1"
+	Version string = "v0.15.3"
 )
 
 func init() {


### PR DESCRIPTION
## Why this should be merged

Prepares the repo for v0.15.3 release

## How this works

Updates the `Releases.md`, fixes typo in releasing readme and bumps `version.go`

## How this was tested

CI

## Need to be documented?

no

## Need to update RELEASES.md?

Yes
