### PR TITLE
Revert the maintainer only code owners restriction

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 
 # review whenever someone opens a pull request.
 
-* @ava-labs/platform-evm-maintainer
-/.github/ @maru-ava @ava-labs/platform-evm-maintainer
-/triedb/firewood/ @alarso16 @ava-labs/platform-evm-maintainer
+* @ava-labs/platform-evm
+/.github/ @maru-ava @ava-labs/platform-evm
+/triedb/firewood/ @alarso16 @ava-labs/platform-evm
 


### PR DESCRIPTION
## Why this should be merged

Because the PR author does not count as an owner for PR review (and they can't approve their own PR), there are bottlenecks introduced for PRs written by maintainers.

## How this works

Restores code ownership to all platform-evm team members.

Note that maintainers are still required to merge the approved PR, so maintainers are expected to ensure that a maintainer has reviewed the code prior to merging.

## How this was tested

CI

## Need to be documented?

No.

## Need to update RELEASES.md?

No.