### PR TITLE
chore: change dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,28 +9,8 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    ignore:
-      - dependency-name: "github.com/ava-labs/avalanchego" # manually updated
-      - dependency-name: "github.com/ava-labs/libevm" # manually updated
-      - dependency-name: "github.com/VictoriaMetrics/fastcache" # geth dependency
-      - dependency-name: "github.com/davecgh/go-spew" # geth dependency
-      - dependency-name: "ithub.com/deckarep/golang-set/v2" # geth dependency
-      - dependency-name: "github.com/hashicorp/go-bexpr" # geth dependency
-      - dependency-name: "github.com/holiman/billy" # geth dependency
-      - dependency-name: "github.com/holiman/bloomfilter/v2" # geth dependency
-      - dependency-name: "github.com/holiman/uint256" # geth dependency
-      - dependency-name: "github.com/mattn/go-colorable" # geth dependency
-      - dependency-name: "github.com/mattn/go-isatty" # geth dependency
-      - dependency-name: "github.com/tyler-smith/go-bip39" # geth dependency
-      - dependency-name: "github.com/urfave/cli/v2" # geth dependency
-      - dependency-name: "golang.org/x/time" # geth dependency
-      - dependency-name: "gopkg.in/natefinch/lumberjack.v2" # geth dependency
+    open-pull-requests-limit: 0 # Disable non-security version updates
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: "weekly"
-    ignore:
-      - dependency-name: "ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd" # manually updated
-      - dependency-name: "golangci/golangci-lint-action"
-        versions:
-          - ">=7.0.0" # versions from 7.0.0 only support golangci-lint v2.x.x
+      interval: weekly

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,3 +14,8 @@ updates:
     directory: "/"
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd" # manually updated
+      - dependency-name: "golangci/golangci-lint-action"
+        versions:
+          - ">=7.0.0" # versions from 7.0.0 only support golangci-lint v2.x.x

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,7 +13,7 @@ updates:
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
-      interval: weekly
+      interval: "weekly"
     ignore:
       - dependency-name: "ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd" # manually updated
       - dependency-name: "golangci/golangci-lint-action"


### PR DESCRIPTION
## Why this should be merged

This changed dependabot to alert only for security updates

## How this works

aligns avalanchego dependabot.yml file

## How this was tested

Dependabot notifications?

## Need to be documented?

No

## Need to update RELEASES.md?

No
