### PR TITLE
Simplify atomic mempool tx signaling

### DIFF
--- a/plugin/evm/atomic/txpool/mempool.go
+++ b/plugin/evm/atomic/txpool/mempool.go
@@ -287,13 +287,10 @@ func (m *Mempool) addTx(tx *atomic.Tx, local bool, force bool) error {
 
 	// When adding a transaction to the mempool, we make sure that there is an
 	// item in Pending to signal the VM to produce a block.
-	//
-	// If the VM's buildStatus has already been set to something other than
-	// dontBuild, this will be ignored and won't be reset until the engine calls
-	// BuildBlock. This case is handled in [Txs.IssueCurrentTxs] and
-	// [Txs.CancelCurrentTxs].
-	m.addPending()
-
+	select {
+	case m.pending <- struct{}{}:
+	default:
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

Prior to the `WaitForEvent` refactor, this logic was required. However, now we are guaranteed that `PendingLen` will be called after `BuildBlock`. This means we never need to push a notification to the block builder while the block builder is handling a build block event.

## How this works

Removes code that is no longer required.

## How this was tested

Existing VM tests still pass.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.