### PR TITLE
Refactor atomic tx gas price calculations

### DIFF
--- a/plugin/evm/atomic/tx.go
+++ b/plugin/evm/atomic/tx.go
@@ -40,6 +40,7 @@ var (
 	ErrNilTx          = errors.New("tx is nil")
 	errNoValueOutput  = errors.New("output has no value")
 	ErrNoValueInput   = errors.New("input has no value")
+	ErrNoGasUsed      = errors.New("no gas used")
 	errNilOutput      = errors.New("nil output")
 	errNilInput       = errors.New("nil input")
 	errEmptyAssetID   = errors.New("empty asset ID is not valid")
@@ -286,6 +287,37 @@ func (ins *innerSortInputsAndSigners) Swap(i, j int) {
 // SortEVMInputsAndSigners sorts the list of EVMInputs based on the addresses and assetIDs
 func SortEVMInputsAndSigners(inputs []EVMInput, signers [][]*secp256k1.PrivateKey) {
 	sort.Sort(&innerSortInputsAndSigners{inputs: inputs, signers: signers})
+}
+
+// EffectiveGasPrice returns the price per gas that the transaction is paying
+// denominated in aAVAX/gas.
+//
+// The result is rounded down to the nearest aAVAX/gas.
+func EffectiveGasPrice(
+	tx UnsignedTx,
+	avaxAssetID ids.ID,
+	isApricotPhase5 bool,
+) (uint256.Int, error) {
+	gasUsed, err := tx.GasUsed(isApricotPhase5)
+	if err != nil {
+		return uint256.Int{}, err
+	}
+	if gasUsed == 0 {
+		return uint256.Int{}, ErrNoGasUsed
+	}
+	burned, err := tx.Burned(avaxAssetID)
+	if err != nil {
+		return uint256.Int{}, err
+	}
+
+	var bigGasUsed uint256.Int
+	bigGasUsed.SetUint64(gasUsed)
+
+	var gasPrice uint256.Int // gasPrice = burned * x2cRate / gasUsed
+	gasPrice.SetUint64(burned)
+	gasPrice.Mul(&gasPrice, X2CRate)
+	gasPrice.Div(&gasPrice, &bigGasUsed)
+	return gasPrice, nil
 }
 
 // calculates the amount of AVAX that must be burned by an atomic transaction

--- a/plugin/evm/atomic/tx_test.go
+++ b/plugin/evm/atomic/tx_test.go
@@ -1,0 +1,143 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
+package atomic
+
+import (
+	"testing"
+
+	"github.com/ava-labs/avalanchego/ids"
+	"github.com/ava-labs/avalanchego/utils/math"
+	"github.com/ava-labs/avalanchego/utils/units"
+	"github.com/ava-labs/avalanchego/vms/components/avax"
+	"github.com/ava-labs/avalanchego/vms/secp256k1fx"
+	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap5"
+	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEffectiveGasPrice(t *testing.T) {
+	avaxAssetID := ids.GenerateTestID()
+	tests := []struct {
+		name            string
+		tx              UnsignedTx
+		isApricotPhase5 bool
+		want            uint256.Int
+		wantErr         error
+	}{
+		{
+			name:    "no gas used",
+			tx:      &UnsignedImportTx{},
+			wantErr: ErrNoGasUsed,
+		},
+		{
+			name: "invalid amount burned",
+			tx: &UnsignedImportTx{
+				ImportedInputs: []*avax.TransferableInput{
+					{
+						Asset: avax.Asset{
+							ID: ids.GenerateTestID(),
+						},
+						In: &secp256k1fx.TransferInput{
+							Amt: 1,
+							Input: secp256k1fx.Input{
+								SigIndices: []uint32{0},
+							},
+						},
+					},
+				},
+				Outs: []EVMOutput{
+					{
+						Amount:  units.NanoAvax,
+						AssetID: avaxAssetID,
+					},
+				},
+			},
+			wantErr: math.ErrUnderflow,
+		},
+		{
+			name: "valid",
+			tx: &UnsignedImportTx{
+				ImportedInputs: []*avax.TransferableInput{
+					{
+						Asset: avax.Asset{
+							ID: avaxAssetID,
+						},
+						In: &secp256k1fx.TransferInput{
+							Amt: units.NanoAvax,
+							Input: secp256k1fx.Input{
+								SigIndices: []uint32{0},
+							},
+						},
+					},
+				},
+			},
+			want: *uint256.NewInt(
+				(units.NanoAvax * X2CRateUint64) / secp256k1fx.CostPerSignature,
+			),
+		},
+		{
+			name: "valid multiple assets",
+			tx: &UnsignedImportTx{
+				ImportedInputs: []*avax.TransferableInput{
+					{
+						Asset: avax.Asset{
+							ID: avaxAssetID,
+						},
+						In: &secp256k1fx.TransferInput{
+							Amt: units.NanoAvax,
+							Input: secp256k1fx.Input{
+								SigIndices: []uint32{0},
+							},
+						},
+					},
+					{
+						Asset: avax.Asset{
+							ID: ids.GenerateTestID(),
+						},
+						In: &secp256k1fx.TransferInput{
+							Amt: 1,
+							Input: secp256k1fx.Input{
+								SigIndices: []uint32{0},
+							},
+						},
+					},
+				},
+			},
+			want: *uint256.NewInt(
+				(units.NanoAvax * X2CRateUint64) / (2 * secp256k1fx.CostPerSignature),
+			),
+		},
+		{
+			name: "valid post AP5",
+			tx: &UnsignedImportTx{
+				ImportedInputs: []*avax.TransferableInput{
+					{
+						Asset: avax.Asset{
+							ID: avaxAssetID,
+						},
+						In: &secp256k1fx.TransferInput{
+							Amt: units.NanoAvax,
+							Input: secp256k1fx.Input{
+								SigIndices: []uint32{0},
+							},
+						},
+					},
+				},
+			},
+			isApricotPhase5: true,
+			want: *uint256.NewInt(
+				(units.NanoAvax * X2CRateUint64) / (ap5.AtomicTxIntrinsicGas + secp256k1fx.CostPerSignature),
+			),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			require := require.New(t)
+
+			got, err := EffectiveGasPrice(test.tx, avaxAssetID, test.isApricotPhase5)
+			require.ErrorIs(err, test.wantErr)
+			require.Equal(test.want, got)
+		})
+	}
+}

--- a/plugin/evm/atomic/txpool/mempool_test.go
+++ b/plugin/evm/atomic/txpool/mempool_test.go
@@ -71,7 +71,7 @@ func TestMempoolAddNoGas(t *testing.T) {
 
 	tx := atomictest.GenerateTestImportTxWithGas(0, 1)
 	err = m.Add(tx)
-	require.ErrorIs(err, ErrNoGasUsed)
+	require.ErrorIs(err, atomic.ErrNoGasUsed)
 }
 
 // Add should return an error if a tx doesn't consume any gas

--- a/plugin/evm/atomic/txpool/tx_heap.go
+++ b/plugin/evm/atomic/txpool/tx_heap.go
@@ -7,13 +7,14 @@ import (
 	"container/heap"
 
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/holiman/uint256"
 
 	"github.com/ava-labs/avalanchego/ids"
 )
 
 type txEntry struct {
 	id       ids.ID
-	gasPrice uint64
+	gasPrice uint256.Int
 	tx       *atomic.Tx
 	index    int
 }
@@ -37,9 +38,9 @@ func (th internalTxHeap) Len() int { return len(th.items) }
 
 func (th internalTxHeap) Less(i, j int) bool {
 	if th.isMinHeap {
-		return th.items[i].gasPrice < th.items[j].gasPrice
+		return th.items[i].gasPrice.Lt(&th.items[j].gasPrice)
 	}
-	return th.items[i].gasPrice > th.items[j].gasPrice
+	return th.items[i].gasPrice.Gt(&th.items[j].gasPrice)
 }
 
 func (th internalTxHeap) Swap(i, j int) {
@@ -91,7 +92,7 @@ func newTxHeap(maxSize int) *txHeap {
 	}
 }
 
-func (th *txHeap) Push(tx *atomic.Tx, gasPrice uint64) {
+func (th *txHeap) Push(tx *atomic.Tx, gasPrice uint256.Int) {
 	txID := tx.ID()
 	oldLen := th.Len()
 	heap.Push(th.maxHeap, &txEntry{
@@ -109,13 +110,13 @@ func (th *txHeap) Push(tx *atomic.Tx, gasPrice uint64) {
 }
 
 // Assumes there is non-zero items
-func (th *txHeap) PeekMax() (*atomic.Tx, uint64) {
+func (th *txHeap) PeekMax() (*atomic.Tx, uint256.Int) {
 	txEntry := th.maxHeap.items[0]
 	return txEntry.tx, txEntry.gasPrice
 }
 
 // Assumes there is non-zero items
-func (th *txHeap) PeekMin() (*atomic.Tx, uint64) {
+func (th *txHeap) PeekMin() (*atomic.Tx, uint256.Int) {
 	txEntry := th.minHeap.items[0]
 	return txEntry.tx, txEntry.gasPrice
 }

--- a/plugin/evm/atomic/txpool/tx_heap_test.go
+++ b/plugin/evm/atomic/txpool/tx_heap_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
+	"github.com/holiman/uint256"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -47,7 +48,7 @@ func TestTxHeap(t *testing.T) {
 		assert.Zero(t, h.Len())
 
 		assert := assert.New(t)
-		h.Push(tx0, 5)
+		h.Push(tx0, *uint256.NewInt(5))
 		assert.True(h.Has(id0))
 		gTx0, gHas0 := h.Get(id0)
 		assert.Equal(tx0, gTx0)
@@ -55,7 +56,7 @@ func TestTxHeap(t *testing.T) {
 		h.Remove(id0)
 		assert.False(h.Has(id0))
 		assert.Zero(h.Len())
-		h.Push(tx0, 5)
+		h.Push(tx0, *uint256.NewInt(5))
 		assert.True(h.Has(id0))
 		assert.Equal(1, h.Len())
 	})
@@ -65,13 +66,13 @@ func TestTxHeap(t *testing.T) {
 		assert.Zero(t, h.Len())
 
 		assert := assert.New(t)
-		h.Push(tx1, 10)
+		h.Push(tx1, *uint256.NewInt(10))
 		assert.True(h.Has(id1))
 		gTx1, gHas1 := h.Get(id1)
 		assert.Equal(tx1, gTx1)
 		assert.True(gHas1)
 
-		h.Push(tx2, 2)
+		h.Push(tx2, *uint256.NewInt(2))
 		assert.True(h.Has(id2))
 		gTx2, gHas2 := h.Get(id2)
 		assert.Equal(tx2, gTx2)
@@ -118,27 +119,27 @@ func TestTxHeap(t *testing.T) {
 		h := newTxHeap(3)
 		assert.Zero(t, h.Len())
 
-		h.Push(tx0, 5)
-		h.Push(tx1, 10)
-		h.Push(tx2, 2)
+		h.Push(tx0, *uint256.NewInt(5))
+		h.Push(tx1, *uint256.NewInt(10))
+		h.Push(tx2, *uint256.NewInt(2))
 		verifyRemovalOrder(t, h)
 	})
 	t.Run("drop (alt order)", func(t *testing.T) {
 		h := newTxHeap(3)
 		assert.Zero(t, h.Len())
 
-		h.Push(tx0, 5)
-		h.Push(tx2, 2)
-		h.Push(tx1, 10)
+		h.Push(tx0, *uint256.NewInt(5))
+		h.Push(tx2, *uint256.NewInt(2))
+		h.Push(tx1, *uint256.NewInt(10))
 		verifyRemovalOrder(t, h)
 	})
 	t.Run("drop (alt order 2)", func(t *testing.T) {
 		h := newTxHeap(3)
 		assert.Zero(t, h.Len())
 
-		h.Push(tx2, 2)
-		h.Push(tx0, 5)
-		h.Push(tx1, 10)
+		h.Push(tx2, *uint256.NewInt(2))
+		h.Push(tx0, *uint256.NewInt(5))
+		h.Push(tx1, *uint256.NewInt(10))
 		verifyRemovalOrder(t, h)
 	})
 }

--- a/plugin/evm/atomic/txpool/txs.go
+++ b/plugin/evm/atomic/txpool/txs.go
@@ -4,7 +4,6 @@
 package txpool
 
 import (
-	"errors"
 	"sync"
 
 	"github.com/ava-labs/avalanchego/cache/lru"
@@ -16,8 +15,6 @@ import (
 )
 
 const discardedTxsCacheSize = 50
-
-var ErrNoGasUsed = errors.New("no gas used")
 
 // Txs stores the transactions inside of the mempool.
 //
@@ -84,22 +81,6 @@ func (t *Txs) PendingLen() int {
 	defer t.lock.RUnlock()
 
 	return t.pendingTxs.Len()
-}
-
-// atomicTxGasPrice returns the gasPrice of a transaction in nAVAX/gas.
-func (t *Txs) atomicTxGasPrice(tx *atomic.Tx) (uint64, error) {
-	gasUsed, err := tx.GasUsed(true)
-	if err != nil {
-		return 0, err
-	}
-	if gasUsed == 0 {
-		return 0, ErrNoGasUsed
-	}
-	burned, err := tx.Burned(t.ctx.AVAXAssetID)
-	if err != nil {
-		return 0, err
-	}
-	return burned / gasUsed, nil
 }
 
 // Iterate applies f to all Pending transactions. If f returns false, the
@@ -226,7 +207,9 @@ func (t *Txs) CancelCurrentTxs() {
 // Assumes the lock is held.
 func (t *Txs) cancelTx(tx *atomic.Tx) {
 	txID := tx.ID()
-	gasPrice, err := t.atomicTxGasPrice(tx)
+	gasPrice, err := atomic.EffectiveGasPrice(tx, t.ctx.AVAXAssetID, true)
+	// Should never error to calculate the gas price of a transaction already in
+	// the mempool
 	if err != nil {
 		log.Error("failed to calculate atomic tx gas price while canceling current tx",
 			"txID", txID,


### PR DESCRIPTION
## Why this should be merged

SAE needs to calculate the effective gas price of an atomic transaction (to align with eth transactions).

## How this works

The mempool currently calculates the gas price of an atomic transaction to sort the mempool. This changes the gas price to be denominated in aAVAX/gas rather than nAVAX/gas and exposes it as a helper for other parts of the code to be able to use.

## How this was tested

- [X] Added unit tests
- [X] Existing unit tests

## Need to be documented?

No.

## Need to update RELEASES.md?

No.