### PR TITLE
Alarso16/fail lint test

### DIFF
--- a/core/blockchain_ext_test.go
+++ b/core/blockchain_ext_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/ethdb"
 	"github.com/holiman/uint256"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -172,9 +173,7 @@ func checkBlockChainState(
 	)
 
 	acceptedState, err := bc.StateAt(lastAcceptedBlock.Root())
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err)
 	if err := checkState(acceptedState); err != nil {
 		t.Fatalf("Check state failed for original blockchain due to: %s", err)
 	}

--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ava-labs/libevm/crypto"
 	"github.com/ava-labs/libevm/eth/tracers/logger"
 	"github.com/ava-labs/libevm/ethdb"
+	"github.com/stretchr/testify/assert"
 )
 
 var (
@@ -916,9 +917,7 @@ func TestDeleteThenCreate(t *testing.T) {
 			nonce++
 		}
 	})
-	if err != nil {
-		t.Fatal(err)
-	}
+	assert.NoError(t, err, "failed to generate chain with genesis")
 	// Import the canonical chain
 	chain, err := NewBlockChain(rawdb.NewMemoryDatabase(), DefaultCacheConfig, gspec, engine, vm.Config{}, common.Hash{}, false)
 	if err != nil {

--- a/plugin/evm/vm_test.go
+++ b/plugin/evm/vm_test.go
@@ -239,9 +239,7 @@ func newVM(t *testing.T, config testVMConfig) *testVM {
 
 	for addr, avaxAmount := range config.utxos {
 		txID, err := ids.ToID(hashing.ComputeHash256(addr.Bytes()))
-		if err != nil {
-			t.Fatalf("Failed to generate txID from addr: %s", err)
-		}
+		assert.NoError(t, err, "failed to compute txID from address %s", addr)
 		if _, err := addUTXO(atomicMemory, innerVM.ctx, txID, 0, innerVM.ctx.AVAXAssetID, avaxAmount, addr); err != nil {
 			t.Fatalf("Failed to add UTXO to shared memory: %s", err)
 		}


### PR DESCRIPTION
DO NOT MERGE

this is used to test #1117 and ensure that all cases are covered

3 files are edited to explicitly fail this extra lint, but one of which is an upstream file. Only the ava-labs files are linted. Additionally, notice that there are other lint errors in these files, which are not ignored. You can also see in the logs that the base branch used is not master (since this PR is not into master)
