### PR TITLE
fix: license header file

### DIFF
--- a/consensus/misc/eip4844/eip4844_test.go
+++ b/consensus/misc/eip4844/eip4844_test.go
@@ -1,6 +1,14 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
-
+//
+// This file is a derived work, based on the go-ethereum library whose original
+// notices appear below.
+//
+// It is distributed under a license compatible with the licensing terms of the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********
 // Copyright 2023 The go-ethereum Authors
 // This file is part of the go-ethereum library.
 //

--- a/log/handler.go
+++ b/log/handler.go
@@ -1,5 +1,14 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
+//
+// This file is a derived work, based on the go-ethereum library whose original
+// notices appear below.
+//
+// It is distributed under a license compatible with the licensing terms of the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********
 
 package log
 

--- a/log/logger.go
+++ b/log/logger.go
@@ -1,5 +1,14 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
+//
+// This file is a derived work, based on the go-ethereum library whose original
+// notices appear below.
+//
+// It is distributed under a license compatible with the licensing terms of the
+// original code from which it is derived.
+//
+// Much love to the original authors for their work.
+// **********
 
 package log
 

--- a/scripts/upstream_files.txt
+++ b/scripts/upstream_files.txt
@@ -14,8 +14,8 @@ triedb/*
 !accounts/abi/bind/bind_extra_test.go
 !consensus/dummy/*
 !core/blockchain_ext.go
-!core/blockchain_log_test.go
 !core/blockchain_ext_test.go
+!core/blockchain_log_test.go
 !core/bounded_buffer.go
 !core/coretest/*
 !core/extstate/*

--- a/scripts/upstream_files.txt
+++ b/scripts/upstream_files.txt
@@ -1,9 +1,18 @@
+accounts/*
+consensus/*
 core/*
 eth/*
+log/*
+miner/*
 node/*
 internal/*
+signer/*
+tests/*
+triedb/*
 
-!internal/ethapi/api_extra_test.go
+!accounts/abi/abi_extra_test.go
+!accounts/abi/bind/bind_extra_test.go
+!consensus/dummy/*
 !core/blockchain_ext.go
 !core/blockchain_log_test.go
 !core/blockchain_ext_test.go
@@ -25,3 +34,7 @@ internal/*
 !internal/ethapi/api.coreth.go
 !internal/ethapi/api.coreth_test.go
 !internal/ethapi/api_extra.go
+!internal/ethapi/api_extra_test.go
+!tests/utils/*
+!tests/warp/*
+!triedb/firewood/*

--- a/scripts/upstream_files.txt
+++ b/scripts/upstream_files.txt
@@ -2,10 +2,10 @@ accounts/*
 consensus/*
 core/*
 eth/*
+internal/*
 log/*
 miner/*
 node/*
-internal/*
 signer/*
 tests/*
 triedb/*

--- a/scripts/upstream_files.txt
+++ b/scripts/upstream_files.txt
@@ -23,10 +23,7 @@ triedb/*
 !core/main_test.go
 !core/predicate_check.go
 !core/predicate_check_test.go
-!core/state/firewood_database.go
-!core/state/database_test.go
 !core/state/snapshot/snapshot_ext.go
-!core/state/statedb_multicoin_test.go
 !core/state_manager_test.go
 !core/state_processor_ext.go
 !eth/chain_with_final_block.go


### PR DESCRIPTION
## Why this should be merged

In a comment of #1117, it was pointed out that `upstream_files.txt` is missing several files, so this is corrected.

## How this works

All files that also exist in `go-ethereum` should have the license header crediting them.

## How this was tested

Lint test

## Need to be documented?

No

## Need to update RELEASES.md?

No
