### PR TITLE
perf: upgrade Firewood

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.23.9
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
 	github.com/ava-labs/avalanchego v1.13.4-rc.2
-	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9
+	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11
 	github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6
 	github.com/davecgh/go-spew v1.1.1
 	github.com/deckarep/golang-set/v2 v2.1.0

--- a/go.sum
+++ b/go.sum
@@ -62,8 +62,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/ava-labs/avalanchego v1.13.4-rc.2 h1:xAf98V/C3TWTmNRP/io5sdKmpaFgZ7eJOkac7Eykun0=
 github.com/ava-labs/avalanchego v1.13.4-rc.2/go.mod h1:w4sWmDbm1ngkRjh89kUqirZUpSbBCmxd7yA+J4SMZNA=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9 h1:zw0g+cUbZDsGdWx1PKmBChkpy+ixL3QgiI86DUOuXvo=
-github.com/ava-labs/firewood-go-ethhash/ffi v0.0.9/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11 h1:V9XDirIJ0oveor+sAPuOB0WMQ+b7FoDStScMdyGlBQ4=
+github.com/ava-labs/firewood-go-ethhash/ffi v0.0.11/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6 h1:tyM659nDOknwTeU4A0fUVsGNIU7k0v738wYN92nqs/Y=
 github.com/ava-labs/libevm v1.13.14-0.3.0.rc.6/go.mod h1:zP/DOcABRWargBmUWv1jXplyWNcfmBy9cxr0lw3LW3g=
 github.com/aymerick/raymond v2.0.3-0.20180322193309-b565731e1464+incompatible/go.mod h1:osfaiScAUVup+UC9Nfq76eWqDhXlp+4UYaA8uhTBO6g=

--- a/triedb/firewood/database.go
+++ b/triedb/firewood/database.go
@@ -504,9 +504,6 @@ type reader struct {
 // Node retrieves the trie node with the given node hash. No error will be
 // returned if the node is not found.
 func (reader *reader) Node(_ common.Hash, path []byte, _ common.Hash) ([]byte, error) {
-	// TODO: remove these locks once Firewood supports concurrent reads and commits.
-	reader.db.proposalLock.RLock()
-	defer reader.db.proposalLock.RUnlock()
 	// This function relies on Firewood's internal locking to ensure concurrent reads are safe.
 	// This is safe even if a proposal is being committed concurrently.
 	start := time.Now()


### PR DESCRIPTION
## Why this should be merged

The most recent version of Firewood has a fix for the concurrency bug (see the one code change)

## How this works

Update go.mod and go.sum

## How this was tested

CI - but also ran with race checker locally to ensure that the race condition no longer exists

## Need to be documented?

No

## Need to update RELEASES.md?

No
