### PR TITLE
Add time check for bootstrapping 

### DIFF
--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -29,7 +29,7 @@ import (
 
 // invalidateDelegateTime is the Unix timestamp for August 2nd, 2025, midnight Eastern Time
 // (August 2nd, 2025, 04:00 UTC)
-const invalidateDelegateTime = 1754107200
+const invalidateDelegateUnix = 1754107200
 
 type RulesExtra extras.Rules
 
@@ -143,7 +143,7 @@ func makePrecompile(contract contract.StatefulPrecompiledContract) libevm.Precom
 
 		callType := env.IncomingCallType()
 		isDissallowedCallType := callType == vm.DelegateCall || callType == vm.CallCode
-		if env.BlockTime() >= invalidateDelegateTime {
+		if env.BlockTime() >= invalidateDelegateUnix {
 			if isDissallowedCallType {
 				env.InvalidateExecution(fmt.Errorf("precompile cannot be called with %s", callType))
 			}


### PR DESCRIPTION
## Why this should be merged
This PR establishes a time a check in `makePrecompile` to fix historical execution bootstrapping errors. 

```
// invalidateDelegateTime is the Unix timestamp for August 2nd, 2025, midnight Eastern Time
// (August 2nd, 2025, 04:00 UTC)
const invalidateDelegateTime = 1754107200
```

## How this was tested
Existing CI

## Need to be documented?
No

## Need to update RELEASES.md?
No