### PR TITLE
Remove duplicate gossip instantiation

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -854,17 +854,6 @@ func (vm *VM) initBlockBuilding() error {
 		vm.shutdownWg.Done()
 	}()
 
-	vm.shutdownWg.Add(1)
-	go func() {
-		avalanchegossip.Every(ctx, vm.ctx.Log, ethTxPushGossiper, vm.config.PushGossipFrequency.Duration)
-		vm.shutdownWg.Done()
-	}()
-	vm.shutdownWg.Add(1)
-	go func() {
-		avalanchegossip.Every(ctx, vm.ctx.Log, vm.ethTxPullGossiper, vm.config.PullGossipFrequency.Duration)
-		vm.shutdownWg.Done()
-	}()
-
 	return nil
 }
 


### PR DESCRIPTION
## Why this should be merged

During the atomic vm refactor, we seem to have accidentally created two eth tx gossiper routines for the pull gossiper and the push gossiper.

## How this works

Removes the duplicate registration.

## How this was tested

CI.

## Need to be documented?

No.

## Need to update RELEASES.md?

No.