### PR TITLE
skip verify block fee if is 0

### DIFF
--- a/plugin/evm/customheader/block_gas_cost.go
+++ b/plugin/evm/customheader/block_gas_cost.go
@@ -146,6 +146,10 @@ func VerifyBlockFee(
 	if requiredBlockGasCost == nil || !requiredBlockGasCost.IsUint64() {
 		return fmt.Errorf("%w: %d", errInvalidRequiredBlockGasCostApricotPhase4, requiredBlockGasCost)
 	}
+	// If the required block gas cost is 0, we don't need to verify the block fee
+	if requiredBlockGasCost.Sign() == 0 {
+		return nil
+	}
 
 	var (
 		gasUsed              = new(big.Int)

--- a/plugin/evm/customheader/block_gas_cost_test.go
+++ b/plugin/evm/customheader/block_gas_cost_test.go
@@ -4,11 +4,11 @@
 package customheader
 
 import (
+	"math"
 	"math/big"
 	"testing"
 
 	"github.com/ava-labs/libevm/common"
-	"github.com/ava-labs/libevm/common/math"
 	"github.com/ava-labs/libevm/core/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -437,6 +437,14 @@ func TestVerifyBlockFee(t *testing.T) {
 			receipts: []*types.Receipt{
 				{GasUsed: 1000},
 			},
+			extraStateContribution: nil,
+		},
+		"zero block gas cost": {
+			baseFee:                big.NewInt(100),
+			parentBlockGasCost:     big.NewInt(0),
+			timeElapsed:            ap4.TargetBlockRate + 1,
+			txs:                    nil,
+			receipts:               nil,
 			extraStateContribution: nil,
 		},
 	}


### PR DESCRIPTION
## Why this should be merged

We don't need to verify the block fee if the block gas cost is 0

## How this works

skips verify block fee if block gas cost is 0

## How this was tested

added test

## Need to be documented?

No

## Need to update RELEASES.md?

No
