### PR TITLE
refactor: move header time verification

### DIFF
--- a/consensus/dummy/consensus.go
+++ b/consensus/dummy/consensus.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
-	"time"
 
 	"github.com/ava-labs/avalanchego/utils/timer/mockable"
 	"github.com/ava-labs/avalanchego/vms/components/gas"
@@ -26,9 +25,6 @@ import (
 )
 
 var (
-	allowedFutureBlockTime = 10 * time.Second // Max time from current time allowed for blocks, before they're considered future blocks
-
-	errInvalidBlockTime                    = errors.New("timestamp less than parent's")
 	errUnclesUnsupported                   = errors.New("uncles unsupported")
 	errExtDataGasUsedNil                   = errors.New("extDataGasUsed is nil")
 	errExtDataGasUsedTooLarge              = errors.New("extDataGasUsed is not uint64")
@@ -224,15 +220,6 @@ func (eng *DummyEngine) verifyHeader(chain consensus.ChainHeaderReader, header *
 		return err
 	}
 
-	// Verify the header's timestamp
-	if header.Time > uint64(eng.clock.Time().Add(allowedFutureBlockTime).Unix()) {
-		return consensus.ErrFutureBlock
-	}
-	// Verify the header's timestamp is not earlier than parent's
-	// it does include equality(==), so multiple blocks per second is ok
-	if header.Time < parent.Time {
-		return errInvalidBlockTime
-	}
 	// Verify that the block number is parent's +1
 	if diff := new(big.Int).Sub(header.Number, parent.Number); diff.Cmp(big.NewInt(1)) != 0 {
 		return consensus.ErrInvalidNumber

--- a/ethclient/simulated/backend.go
+++ b/ethclient/simulated/backend.go
@@ -132,9 +132,7 @@ func newWithNode(stack *node.Node, conf *eth.Config, blockPeriod uint64) (*Backe
 	clock := &mockable.Clock{}
 	clock.Set(time.Unix(0, 0))
 
-	engine := dummy.NewFakerWithModeAndClock(
-		dummy.Mode{ModeSkipCoinbase: true}, clock,
-	)
+	engine := dummy.NewCoinbaseFaker()
 
 	backend, err := eth.New(
 		stack, conf, &fakePushGossiper{}, chaindb, eth.Settings{}, common.Hash{},

--- a/plugin/evm/customheader/time.go
+++ b/plugin/evm/customheader/time.go
@@ -29,13 +29,12 @@ var (
 // VerifyTime verifies that the header's Time and TimeMilliseconds fields are
 // consistent with the given rules and the current time.
 // This includes:
-// - Time is not too far in the future
 // - TimeMilliseconds is nil before Granite activation
 // - TimeMilliseconds is non-nil after Granite activation
 // - Time matches TimeMilliseconds/1000 after Granite activation
-// - (TODO) Time is strictly increasing if parent is also after Granite activation
+// - Time/TimeMilliseconds is not too far in the future
+// - Time/TimeMilliseconds is non-decreasing
 // - (TODO) Minimum block delay is enforced
-// - (TODO) More time-related checks from dummy.VerifyHeader
 func VerifyTime(extraConfig *extras.ChainConfig, parent *types.Header, header *types.Header, now time.Time) error {
 	var (
 		headerExtra = customtypes.GetHeaderExtra(header)

--- a/plugin/evm/customheader/time.go
+++ b/plugin/evm/customheader/time.go
@@ -19,6 +19,7 @@ var (
 	// and fail verification
 	MaxFutureBlockTime = 10 * time.Second
 
+	ErrBlockTooOld                   = errors.New("block timestamp is too old")
 	ErrBlockTooFarInFuture           = errors.New("block timestamp is too far in the future")
 	ErrTimeMillisecondsRequired      = errors.New("TimeMilliseconds is required after Granite activation")
 	ErrTimeMillisecondsMismatched    = errors.New("TimeMilliseconds does not match header.Time")
@@ -48,7 +49,7 @@ func VerifyTime(extraConfig *extras.ChainConfig, parent *types.Header, header *t
 	// Verify the header's timestamp is not earlier than parent's
 	// it does include equality(==), so multiple blocks per second is ok
 	if header.Time < parent.Time {
-		return fmt.Errorf("block time too old: %d < parent %d", header.Time, parent.Time)
+		return fmt.Errorf("%w: %d < parent %d", ErrBlockTooOld, header.Time, parent.Time)
 	}
 
 	// Validate TimeMilliseconds field isn't present prior to Granite

--- a/plugin/evm/customheader/time_test.go
+++ b/plugin/evm/customheader/time_test.go
@@ -15,82 +15,141 @@ import (
 	"github.com/ava-labs/coreth/utils"
 )
 
+func generateHeader(timeSeconds uint64, timeMilliseconds *uint64) *types.Header {
+	return customtypes.WithHeaderExtra(
+		&types.Header{
+			Time: timeSeconds,
+		},
+		&customtypes.HeaderExtra{
+			TimeMilliseconds: timeMilliseconds,
+		},
+	)
+}
+
 func TestVerifyTime(t *testing.T) {
 	var (
-		time        = time.Unix(1714339200, 123_456_789)
-		timeSeconds = uint64(time.Unix())
-		timeMillis  = uint64(time.UnixMilli())
+		now         = time.Unix(1714339200, 123_456_789)
+		timeSeconds = uint64(now.Unix())
+		timeMillis  = uint64(now.UnixMilli())
 	)
 	tests := []struct {
 		name             string
+		header           *types.Header
+		parentHeader     *types.Header
 		timeSeconds      uint64
 		timeMilliseconds *uint64
 		extraConfig      *extras.ChainConfig
 		expectedErr      error
 	}{
 		{
-			name:             "pre_granite_time_milliseconds_should_fail",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: utils.NewUint64(timeMillis),
-			extraConfig:      extras.TestFortunaChainConfig,
-			expectedErr:      ErrTimeMillisecondsBeforeGranite,
+			name:        "pre_granite_time_milliseconds_should_fail",
+			header:      generateHeader(timeSeconds, utils.NewUint64(timeMillis)),
+			extraConfig: extras.TestFortunaChainConfig,
+			expectedErr: ErrTimeMillisecondsBeforeGranite,
 		},
 		{
-			name:             "pre_granite_time_nil_milliseconds_should_work",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: nil,
-			extraConfig:      extras.TestFortunaChainConfig,
-			expectedErr:      nil,
+			name:        "pre_granite_time_nil_milliseconds_should_work",
+			header:      generateHeader(timeSeconds, nil),
+			extraConfig: extras.TestFortunaChainConfig,
 		},
 		{
-			name:             "granite_time_milliseconds_should_be_non_nil_and_fail",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: nil,
-			extraConfig:      extras.TestGraniteChainConfig,
-			expectedErr:      ErrTimeMillisecondsRequired,
+			name:        "granite_time_milliseconds_should_be_non_nil_and_fail",
+			header:      generateHeader(timeSeconds, nil),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: ErrTimeMillisecondsRequired,
 		},
 		{
-			name:             "granite_time_milliseconds_matching_time_should_work",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: utils.NewUint64(timeSeconds * 1000),
-			extraConfig:      extras.TestGraniteChainConfig,
-			expectedErr:      nil,
+			name:        "granite_time_milliseconds_matching_time_should_work",
+			header:      generateHeader(timeSeconds, utils.NewUint64(timeSeconds*1000)),
+			extraConfig: extras.TestGraniteChainConfig,
 		},
 		{
-			name:             "granite_time_milliseconds_matching_time_rounded_should_work",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: utils.NewUint64(timeMillis),
-			extraConfig:      extras.TestGraniteChainConfig,
-			expectedErr:      nil,
+			name:        "granite_time_milliseconds_matching_time_rounded_should_work",
+			header:      generateHeader(timeSeconds, utils.NewUint64(timeMillis)),
+			extraConfig: extras.TestGraniteChainConfig,
 		},
 		{
-			name:             "granite_time_milliseconds_less_than_time_should_fail",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: utils.NewUint64(timeSeconds*1000 - 1),
-			extraConfig:      extras.TestGraniteChainConfig,
-			expectedErr:      ErrTimeMillisecondsMismatched,
+			name:        "granite_time_milliseconds_less_than_time_should_fail",
+			header:      generateHeader(timeSeconds, utils.NewUint64((timeSeconds-1)*1000)),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: ErrTimeMillisecondsMismatched,
 		},
 		{
-			name:             "granite_time_milliseconds_greater_than_time_should_fail",
-			timeSeconds:      timeSeconds,
-			timeMilliseconds: utils.NewUint64(timeSeconds * 1001),
-			extraConfig:      extras.TestGraniteChainConfig,
-			expectedErr:      ErrTimeMillisecondsMismatched,
+			name:        "granite_time_milliseconds_greater_than_time_should_fail",
+			header:      generateHeader(timeSeconds, utils.NewUint64((timeSeconds+1)*1000)),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: ErrTimeMillisecondsMismatched,
+		},
+		{
+			name:         "pre_granite_time_earlier_than_parent_should_fail",
+			header:       generateHeader(timeSeconds, nil),
+			parentHeader: generateHeader(timeSeconds+1, nil),
+			extraConfig:  extras.TestFortunaChainConfig,
+			expectedErr:  errBlockTooOld,
+		},
+		{
+			name:   "granite_time_earlier_than_parent_should_fail",
+			header: generateHeader(timeSeconds, utils.NewUint64(timeSeconds*1000)),
+			parentHeader: generateHeader(
+				timeSeconds+1,
+				utils.NewUint64((timeSeconds+1)*1000),
+			),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: errBlockTooOld,
+		},
+		{
+			name: "granite_time_milliseconds_earlier_than_parent_should_fail",
+			header: generateHeader(
+				timeSeconds,
+				utils.NewUint64(timeSeconds*1000),
+			),
+			parentHeader: generateHeader(
+				timeSeconds,
+				utils.NewUint64(timeSeconds*1000+1),
+			),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: errBlockTooOld,
+		},
+		{
+			name:        "pre_granite_time_too_far_in_future_should_fail",
+			header:      generateHeader(uint64(now.Add(MaxFutureBlockTime).Add(1*time.Second).Unix()), nil),
+			extraConfig: extras.TestFortunaChainConfig,
+			expectedErr: ErrBlockTooFarInFuture,
+		},
+		{
+			name: "granite_time_too_far_in_future_should_fail",
+			header: generateHeader(
+				uint64(now.Add(MaxFutureBlockTime).Add(1*time.Second).Unix()),
+				utils.NewUint64(uint64(now.Add(MaxFutureBlockTime).Add(1*time.Second).UnixMilli())),
+			),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: ErrBlockTooFarInFuture,
+		},
+		{
+			name: "granite_time_milliseconds_too_far_in_future_should_fail",
+			header: generateHeader(
+				uint64(now.Add(MaxFutureBlockTime).Unix()),
+				utils.NewUint64(uint64(now.Add(MaxFutureBlockTime).Add(1*time.Millisecond).UnixMilli())),
+			),
+			extraConfig: extras.TestGraniteChainConfig,
+			expectedErr: ErrBlockTooFarInFuture,
+		},
+		{
+			name:         "first_granite_block_should_work",
+			header:       generateHeader(timeSeconds, utils.NewUint64(timeMillis)),
+			parentHeader: generateHeader(timeSeconds, nil),
+			extraConfig:  extras.TestGraniteChainConfig,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			header := customtypes.WithHeaderExtra(
-				&types.Header{
-					Time: test.timeSeconds,
-				},
-				&customtypes.HeaderExtra{
-					TimeMilliseconds: test.timeMilliseconds,
-				},
-			)
-			parentHeader := types.CopyHeader(header)
-			err := VerifyTime(test.extraConfig, parentHeader, header, time)
+			// if parentHeader is nil, copy the current header
+			parentHeader := test.parentHeader
+			if test.parentHeader == nil {
+				parentHeader = types.CopyHeader(test.header)
+			}
+			err := VerifyTime(test.extraConfig, parentHeader, test.header, now)
 			require.ErrorIs(t, err, test.expectedErr)
 		})
 	}

--- a/plugin/evm/customheader/time_test.go
+++ b/plugin/evm/customheader/time_test.go
@@ -89,7 +89,8 @@ func TestVerifyTime(t *testing.T) {
 					TimeMilliseconds: test.timeMilliseconds,
 				},
 			)
-			err := VerifyTime(test.extraConfig, header, time)
+			parentHeader := types.CopyHeader(header)
+			err := VerifyTime(test.extraConfig, parentHeader, header, time)
 			require.ErrorIs(t, err, test.expectedErr)
 		})
 	}

--- a/plugin/evm/customheader/time_test.go
+++ b/plugin/evm/customheader/time_test.go
@@ -33,13 +33,11 @@ func TestVerifyTime(t *testing.T) {
 		timeMillis  = uint64(now.UnixMilli())
 	)
 	tests := []struct {
-		name             string
-		header           *types.Header
-		parentHeader     *types.Header
-		timeSeconds      uint64
-		timeMilliseconds *uint64
-		extraConfig      *extras.ChainConfig
-		expectedErr      error
+		name         string
+		header       *types.Header
+		parentHeader *types.Header
+		extraConfig  *extras.ChainConfig
+		expectedErr  error
 	}{
 		{
 			name:        "pre_granite_time_milliseconds_should_fail",

--- a/plugin/evm/customheader/time_test.go
+++ b/plugin/evm/customheader/time_test.go
@@ -142,7 +142,8 @@ func TestVerifyTime(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			// if parentHeader is nil, copy the current header
+			// Unless the parentHeader is explicitly set, make it a copy of the header.
+			// parentHeader == header will pass if and only if header is correct.
 			parentHeader := test.parentHeader
 			if test.parentHeader == nil {
 				parentHeader = types.CopyHeader(test.header)

--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -554,7 +554,6 @@ func (vm *VM) initializeChain(lastAcceptedHash common.Hash) error {
 		dummy.NewDummyEngine(
 			vm.extensionConfig.ConsensusCallbacks,
 			dummy.Mode{},
-			vm.clock,
 			desiredTargetExcess,
 		),
 		vm.clock,

--- a/plugin/evm/wrapped_block.go
+++ b/plugin/evm/wrapped_block.go
@@ -48,6 +48,7 @@ var (
 var (
 	errInvalidExcessBlobGasBeforeCancun    = errors.New("invalid excessBlobGas before cancun")
 	errInvalidBlobGasUsedBeforeCancun      = errors.New("invalid blobGasUsed before cancun")
+	errInvalidParent                       = errors.New("parent header not found")
 	errInvalidParentBeaconRootBeforeCancun = errors.New("invalid parentBeaconRoot before cancun")
 	errMissingExcessBlobGas                = errors.New("header is missing excessBlobGas")
 	errMissingBlobGasUsed                  = errors.New("header is missing blobGasUsed")
@@ -345,9 +346,14 @@ func (b *wrappedBlock) verifyIntrinsicGas() error {
 
 // semanticVerify verifies that a *Block is internally consistent.
 func (b *wrappedBlock) semanticVerify() error {
-	// Ensure Time and TimeMilliseconds are consistent with rules.
 	extraConfig := params.GetExtra(b.vm.chainConfig)
-	if err := customheader.VerifyTime(extraConfig, b.ethBlock.Header(), b.vm.clock.Time()); err != nil {
+	parent := b.vm.blockChain.GetHeader(b.ethBlock.ParentHash(), b.ethBlock.NumberU64()-1)
+	if parent == nil {
+		return fmt.Errorf("%w: %s at height %d", errInvalidParent, b.ethBlock.ParentHash(), b.ethBlock.NumberU64()-1)
+	}
+
+	// Ensure Time and TimeMilliseconds are consistent with rules.
+	if err := customheader.VerifyTime(extraConfig, parent, b.ethBlock.Header(), b.vm.clock.Time()); err != nil {
 		return err
 	}
 
@@ -460,23 +466,7 @@ func (b *wrappedBlock) syntacticVerify() error {
 	}
 
 	// Verify the existence / non-existence of excessBlobGas
-	cancun := rules.IsCancun
-	if !cancun && ethHeader.ExcessBlobGas != nil {
-		return fmt.Errorf("%w: have %d, expected nil", errInvalidExcessBlobGasBeforeCancun, *ethHeader.ExcessBlobGas)
-	}
-	if !cancun && ethHeader.BlobGasUsed != nil {
-		return fmt.Errorf("%w: have %d, expected nil", errInvalidBlobGasUsedBeforeCancun, *ethHeader.BlobGasUsed)
-	}
-	if cancun && ethHeader.ExcessBlobGas == nil {
-		return errMissingExcessBlobGas
-	}
-	if cancun && ethHeader.BlobGasUsed == nil {
-		return errMissingBlobGasUsed
-	}
-	if !cancun && ethHeader.ParentBeaconRoot != nil {
-		return fmt.Errorf("%w: have %x, expected nil", errInvalidParentBeaconRootBeforeCancun, *ethHeader.ParentBeaconRoot)
-	}
-	if cancun {
+	if rules.IsCancun {
 		switch {
 		case ethHeader.ParentBeaconRoot == nil:
 			return errMissingParentBeaconRoot
@@ -488,6 +478,20 @@ func (b *wrappedBlock) syntacticVerify() error {
 		} else if *ethHeader.BlobGasUsed > 0 {
 			return fmt.Errorf("%w: used %d blob gas, expected 0", errBlobsNotEnabled, *ethHeader.BlobGasUsed)
 		}
+	} else {
+		switch {
+		case ethHeader.ExcessBlobGas != nil:
+			return fmt.Errorf("%w: have %d, expected nil", errInvalidExcessBlobGasBeforeCancun, *ethHeader.ExcessBlobGas)
+		case ethHeader.BlobGasUsed != nil:
+			return fmt.Errorf("%w: have %d, expected nil", errInvalidBlobGasUsedBeforeCancun, *ethHeader.BlobGasUsed)
+		case ethHeader.ExcessBlobGas == nil:
+			return errMissingExcessBlobGas
+		case ethHeader.BlobGasUsed == nil:
+			return errMissingBlobGasUsed
+		case ethHeader.ParentBeaconRoot != nil:
+			return fmt.Errorf("%w: have %x, expected nil", errInvalidParentBeaconRootBeforeCancun, *ethHeader.ParentBeaconRoot)
+		}
+
 	}
 
 	if b.extension != nil {


### PR DESCRIPTION
## Why this should be merged

It's more sensible to do all time verification for block headers in a single location for ACP-226, since it is spread currently between `semanticVerify` and `eng.VerifyHeader`, which is unnecessary. One fun side effect is that we no longer need to provide a clock to the consensus callback engine.

Closes #1211

## How this works

Moves a check from consensus callbacks

## How this was tested

Existing UT, added one

## Need to be documented?

No.

## Need to update RELEASES.md?

No.
