### PR TITLE
Remove unused types from codec registration

### DIFF
--- a/plugin/evm/atomic/codec.go
+++ b/plugin/evm/atomic/codec.go
@@ -36,9 +36,13 @@ func init() {
 	lc.SkipRegistrations(3)
 	errs.Add(
 		lc.RegisterType(&secp256k1fx.TransferInput{}),
-		lc.RegisterType(&secp256k1fx.MintOutput{}),
+	)
+	lc.SkipRegistrations(1)
+	errs.Add(
 		lc.RegisterType(&secp256k1fx.TransferOutput{}),
-		lc.RegisterType(&secp256k1fx.MintOperation{}),
+	)
+	lc.SkipRegistrations(1)
+	errs.Add(
 		lc.RegisterType(&secp256k1fx.Credential{}),
 		lc.RegisterType(&secp256k1fx.Input{}),
 		lc.RegisterType(&secp256k1fx.OutputOwners{}),


### PR DESCRIPTION
## Why this should be merged

I noticed that we currently register some types that should never be used on the C-chain.

Removing them from the codec means we never need to handle them later on (fail fast rather than fail late).

## How this works

Skips registering `secp256k1fx.MintOutput` and `secp256k1fx.MintOperation`

## How this was tested

CI

## Need to be documented?

no

## Need to update RELEASES.md?
