### PR TITLE
Disable non-security related dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,4 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
-    ignore:
-      - dependency-name: "ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd" # manually updated
-      - dependency-name: "golangci/golangci-lint-action"
-        versions:
-          - ">=7.0.0" # versions from 7.0.0 only support golangci-lint v2.x.x
+    open-pull-requests-limit: 0 # Disable non-security version updates


### PR DESCRIPTION
## Why this should be merged

I think we talked in the last retro that we wanted to disable these.

## How this works

Disables non-security github actions updates

## How this was tested

n/a

## Need to be documented?

no

## Need to update RELEASES.md?

no