### PR TITLE
fix: database inspection

### DIFF
--- a/plugin/evm/vm_database.go
+++ b/plugin/evm/vm_database.go
@@ -35,7 +35,7 @@ func (vm *VM) initializeDBs(db avalanchedatabase.Database) {
 func (vm *VM) inspectDatabases() error {
 	start := time.Now()
 	log.Info("Starting database inspection")
-	if err := rawdb.InspectDatabase(vm.chaindb, nil, nil); err != nil {
+	if err := rawdb.InspectDatabase(vm.chaindb, nil, nil, rawdb.WithSkipFreezers()); err != nil {
 		return err
 	}
 	if err := inspectDB(vm.acceptedBlockDB, "acceptedBlockDB"); err != nil {


### PR DESCRIPTION
## Why this should be merged

As mentioned in #1137, starting an instance of Coreth with database inspection enabled will fail as Coreth doesn't use freezers but upstream code (Libevm) previously assumed so. With https://github.com/ava-labs/libevm/pull/220 now available, we can now skip freezer inspection.

## How this works

Adds an option to skip freezer inspection when inspecting the database.

## How this was tested

Upstream: https://github.com/ava-labs/libevm/blob/ba9ab538b90236c480c412c54816717f3eb501e9/core/rawdb/database.libevm_test.go#L25-L49

## Need to be documented?

Not sure

## Need to update RELEASES.md?

Not sure