### PR TITLE
check the parent.TimeMilliSeconds in wall clock adjustment

### DIFF
--- a/miner/worker.go
+++ b/miner/worker.go
@@ -153,10 +153,11 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 	// Note: in order to support asynchronous block production, blocks are allowed to have
 	// the same timestamp as their parent. This allows more than one block to be produced
 	// per second.
-	if parent.Time >= timestamp {
+	parentExtra := customtypes.GetHeaderExtra(parent)
+	if parent.Time >= timestamp ||
+		(parentExtra.TimeMilliseconds != nil && *parentExtra.TimeMilliseconds > timestampMS) {
 		timestamp = parent.Time
 		// If the parent has a TimeMilliseconds, use it. Otherwise, use the parent time * 1000.
-		parentExtra := customtypes.GetHeaderExtra(parent)
 		if parentExtra.TimeMilliseconds != nil {
 			timestampMS = *parentExtra.TimeMilliseconds
 		} else {

--- a/miner/worker.go
+++ b/miner/worker.go
@@ -155,7 +155,7 @@ func (w *worker) commitNewWork(predicateContext *precompileconfig.PredicateConte
 	// per second.
 	parentExtra := customtypes.GetHeaderExtra(parent)
 	if parent.Time >= timestamp ||
-		(parentExtra.TimeMilliseconds != nil && *parentExtra.TimeMilliseconds > timestampMS) {
+		(parentExtra.TimeMilliseconds != nil && *parentExtra.TimeMilliseconds >= timestampMS) {
 		timestamp = parent.Time
 		// If the parent has a TimeMilliseconds, use it. Otherwise, use the parent time * 1000.
 		if parentExtra.TimeMilliseconds != nil {


### PR DESCRIPTION
## Why this should be merged

The time adjustment only checks the parent time in seconds, but it should also check the parent time in milliseconds

## How this works

adds the wall clock <> parent milliseconds check

## How this was tested

no test (will be added with a upcoming refactor)

## Need to be documented?

no

## Need to update RELEASES.md?

no
