### PR TITLE
fix: block hash when overriding to block n+1

### DIFF
--- a/eth/tracers/api.go
+++ b/eth/tracers/api.go
@@ -33,6 +33,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"os"
 	"runtime"
 	"sync"
@@ -959,10 +960,22 @@ func (api *API) TraceCall(ctx context.Context, args ethapi.TransactionArgs, bloc
 	}
 	defer release()
 
-	vmctx := core.NewEVMBlockContext(block.Header(), api.chainContext(ctx), nil)
+	h := block.Header()
+	vmctx := core.NewEVMBlockContext(h, api.chainContext(ctx), nil)
 
 	// Apply the customization rules if required.
 	if config != nil {
+		if config.BlockOverrides != nil && config.BlockOverrides.Number.ToInt().Uint64() == h.Number.Uint64()+1 {
+			// Overriding the block number to n+1 is a common way for wallets to
+			// simulate transactions, however without the following fix, a contract
+			// can assert it is being simulated by checking if blockhash(n) == 0x0 and
+			// can behave differently during the simulation. (#32175 for more info)
+			// --
+			// Modify the parent hash and number so that downstream, blockContext's
+			// GetHash function can correctly return n.
+			h.ParentHash = h.Hash()
+			h.Number.Add(h.Number, big.NewInt(1))
+		}
 		originalTime := block.Time()
 		config.BlockOverrides.Apply(&vmctx)
 		// Apply all relevant upgrades from [originalTime] to the block time set in the override.

--- a/eth/tracers/api_test.go
+++ b/eth/tracers/api_test.go
@@ -930,6 +930,25 @@ func testTracingWithOverrides(t *testing.T, scheme string) {
 			},
 			want: `{"gas":25288,"failed":false,"returnValue":"0000000000000000000000000000000000000000000000000000000000000055"}`,
 		},
+		{ // Override blocknumber with block n+1 and query a blockhash (resolves issue #32175)
+			blockNumber: rpc.LatestBlockNumber,
+			call: ethapi.TransactionArgs{
+				From: &accounts[0].addr,
+				Input: newRPCBytes([]byte{
+					byte(vm.PUSH1), byte(genBlocks),
+					byte(vm.BLOCKHASH),
+					byte(vm.PUSH1), 0x00,
+					byte(vm.MSTORE),
+					byte(vm.PUSH1), 0x20,
+					byte(vm.PUSH1), 0x00,
+					byte(vm.RETURN),
+				}),
+			},
+			config: &TraceCallConfig{
+				BlockOverrides: &ethapi.BlockOverrides{Number: (*hexutil.Big)(big.NewInt(int64(genBlocks + 1)))},
+			},
+			want: fmt.Sprintf(`{"gas":59592,"failed":false,"returnValue":"%x"}`, backend.chain.GetHeaderByNumber(uint64(genBlocks)).Hash()),
+		},
 	}
 	for i, tc := range testSuite {
 		result, err := api.TraceCall(context.Background(), tc.call, rpc.BlockNumberOrHash{BlockNumber: &tc.blockNumber}, tc.config)


### PR DESCRIPTION
## Why this should be merged

Addresses ethereum/go-ethereum#32175 in which the `BLOCKHASH` op code returns `0x00` when simulating a transaction at block `HEAD+1`.

## How this works

Sets the parent block hash based on code from ethereum/go-ethereum#32183. A cherry-pick wasn't viable due to conflicts.

## How this was tested

UT from the above PR, which failed before adding the fix.

## Need to be documented?

Yes

## Need to update RELEASES.md?

Yes