### PR TITLE
Add warp test to verify equivalent gas consumed

### DIFF
--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -619,7 +619,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 	noValidators := precompiletest.PredicateTest{
 		Config: NewConfig(utils.NewUint64(0), 0, false),
 		PredicateContext: &precompileconfig.PredicateContext{
-			SnowCtx: createSnowCtx(t, nil),
+			SnowCtx: createSnowCtx(t, nil /*=validators*/), // No validators in state
 			ProposerVMBlockCtx: &block.Context{
 				PChainHeight: 1,
 			},
@@ -635,7 +635,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 			SnowCtx: createSnowCtx(t, []validatorRange{
 				{
 					start:     0,
-					end:       100,
+					end:       2, // Generate two validators each with max weight to force overflow
 					weight:    math.MaxUint64,
 					publicKey: true,
 				},

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -613,16 +613,19 @@ func TestWarpSignatureWeightsNonDefaultQuorumNumerator(t *testing.T) {
 }
 
 func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
-	pred := createPredicate(0)
-	expectedGas := GasCostPerSignatureVerification + uint64(len(pred))*GasCostPerWarpMessageChunk
-
+	var (
+		config            = NewConfig(utils.NewUint64(0), 0, false)
+		proposervmContext = &block.Context{
+			PChainHeight: 1,
+		}
+		pred        = createPredicate(0)
+		expectedGas = GasCostPerSignatureVerification + uint64(len(pred))*GasCostPerWarpMessageChunk
+	)
 	noValidators := precompiletest.PredicateTest{
-		Config: NewConfig(utils.NewUint64(0), 0, false),
+		Config: config,
 		PredicateContext: &precompileconfig.PredicateContext{
-			SnowCtx: createSnowCtx(t, nil /*=validators*/), // No validators in state
-			ProposerVMBlockCtx: &block.Context{
-				PChainHeight: 1,
-			},
+			SnowCtx:            createSnowCtx(t, nil /*=validators*/), // No validators in state
+			ProposerVMBlockCtx: proposervmContext,
 		},
 		Predicate:   pred,
 		Gas:         expectedGas,
@@ -630,7 +633,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 		ExpectedErr: bls.ErrNoPublicKeys,
 	}
 	weightOverflow := precompiletest.PredicateTest{
-		Config: NewConfig(utils.NewUint64(0), 0, false),
+		Config: config,
 		PredicateContext: &precompileconfig.PredicateContext{
 			SnowCtx: createSnowCtx(t, []validatorRange{
 				{
@@ -640,9 +643,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 					publicKey: true,
 				},
 			}),
-			ProposerVMBlockCtx: &block.Context{
-				PChainHeight: 1,
-			},
+			ProposerVMBlockCtx: proposervmContext,
 		},
 		Predicate:   pred,
 		Gas:         expectedGas,

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/ava-labs/avalanchego/utils/crypto/bls/signer/localsigner"
 	"github.com/ava-labs/avalanchego/utils/set"
 	"github.com/ava-labs/avalanchego/vms/evm/predicate"
-	"github.com/ava-labs/avalanchego/vms/platformvm/warp"
 	"github.com/ava-labs/avalanchego/vms/platformvm/warp/payload"
 	"github.com/ava-labs/libevm/common"
 	"github.com/stretchr/testify/require"
@@ -647,7 +646,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 		Predicate:   pred,
 		Gas:         GasCostPerSignatureVerification + uint64(len(pred))*GasCostPerWarpMessageChunk, // Gas cost should be equal to [TestWarpNoValidators]
 		GasErr:      nil,
-		ExpectedErr: warp.ErrWeightOverflow,
+		ExpectedErr: avalancheWarp.ErrWeightOverflow,
 	}
 	precompiletest.RunPredicateTests(t, map[string]precompiletest.PredicateTest{
 		"no_validators":   noValidators,

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -644,7 +644,7 @@ func TestWarpNoValidatorsAndOverflowUseSameGas(t *testing.T) {
 			},
 		},
 		Predicate:   pred,
-		Gas:         GasCostPerSignatureVerification + uint64(len(pred))*GasCostPerWarpMessageChunk, // Gas cost should be equal to [TestWarpNoValidators]
+		Gas:         expectedGas,
 		GasErr:      nil,
 		ExpectedErr: avalancheWarp.ErrWeightOverflow,
 	}

--- a/precompile/contracts/warp/predicate_test.go
+++ b/precompile/contracts/warp/predicate_test.go
@@ -153,7 +153,8 @@ func createWarpMessage(numKeys int) *avalancheWarp.Message {
 		}
 		sig = aggregateSignature
 	} else {
-		// populate with a random signature
+		// Parsing an unpopulated signature fails, so instead we populate a
+		// random signature.
 		sk, err := localsigner.New()
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
## Why this should be merged

As part of ACP-181, we will be caching all validator sets at the current epoch height.

As part of this we will be changing the canonical representation of a validator set with a total weight that overflows uint64 to be the empty set rather than erroring during construction.

This adds an equivalence test to ensure this a not a breaking change.

## How this works

Adds a test which verifies that the gas consumed is equal for both cases (and that both cases error).

## How this was tested

It is a test

## Need to be documented?

no

## Need to update RELEASES.md?

no