### PR TITLE
Remove secondary validator override

### DIFF
--- a/plugin/evm/vm.go
+++ b/plugin/evm/vm.go
@@ -1077,7 +1077,7 @@ func (vm *VM) CreateHandlers(context.Context) (map[string]http.Handler, error) {
 		warpSDKClient := vm.Network.NewClient(p2p.SignatureRequestHandlerID)
 		signatureAggregator := acp118.NewSignatureAggregator(vm.ctx.Log, warpSDKClient)
 
-		if err := handler.RegisterName("warp", warp.NewAPI(vm.ctx, vm.warpBackend, signatureAggregator, vm.requirePrimaryNetworkSigners)); err != nil {
+		if err := handler.RegisterName("warp", warp.NewAPI(vm.ctx, vm.warpBackend, signatureAggregator)); err != nil {
 			return nil, err
 		}
 		enabledAPIs = append(enabledAPIs, "warp")
@@ -1109,24 +1109,6 @@ func (vm *VM) chainConfigExtra() *extras.ChainConfig {
 func (vm *VM) rules(number *big.Int, time uint64) extras.Rules {
 	ethrules := vm.chainConfig.Rules(number, params.IsMergeTODO, time)
 	return *params.GetRulesExtra(ethrules)
-}
-
-// currentRules returns the chain rules for the current block.
-func (vm *VM) currentRules() extras.Rules {
-	header := vm.eth.APIBackend.CurrentHeader()
-	return vm.rules(header.Number, header.Time)
-}
-
-// requirePrimaryNetworkSigners returns true if warp messages from the primary
-// network must be signed by the primary network validators.
-// This is necessary when the subnet is not validating the primary network.
-func (vm *VM) requirePrimaryNetworkSigners() bool {
-	switch c := vm.currentRules().Precompiles[warpcontract.ContractAddress].(type) {
-	case *warpcontract.Config:
-		return c.RequirePrimaryNetworkSigners
-	default: // includes nil due to non-presence
-		return false
-	}
 }
 
 func (vm *VM) startContinuousProfiler() {

--- a/warp/service.go
+++ b/warp/service.go
@@ -23,18 +23,16 @@ var errNoValidators = errors.New("cannot aggregate signatures from subnet with n
 
 // API introduces snowman specific functionality to the evm
 type API struct {
-	chainContext                 *snow.Context
-	backend                      Backend
-	signatureAggregator          *acp118.SignatureAggregator
-	requirePrimaryNetworkSigners func() bool
+	chainContext        *snow.Context
+	backend             Backend
+	signatureAggregator *acp118.SignatureAggregator
 }
 
-func NewAPI(chainCtx *snow.Context, backend Backend, signatureAggregator *acp118.SignatureAggregator, requirePrimaryNetworkSigners func() bool) *API {
+func NewAPI(chainCtx *snow.Context, backend Backend, signatureAggregator *acp118.SignatureAggregator) *API {
 	return &API{
-		backend:                      backend,
-		chainContext:                 chainCtx,
-		signatureAggregator:          signatureAggregator,
-		requirePrimaryNetworkSigners: requirePrimaryNetworkSigners,
+		backend:             backend,
+		chainContext:        chainCtx,
+		signatureAggregator: signatureAggregator,
 	}
 }
 

--- a/warp/service.go
+++ b/warp/service.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ava-labs/libevm/log"
 
 	warpprecompile "github.com/ava-labs/coreth/precompile/contracts/warp"
-	warpValidators "github.com/ava-labs/coreth/warp/validators"
 )
 
 var errNoValidators = errors.New("cannot aggregate signatures from subnet with no validators")
@@ -108,8 +107,7 @@ func (a *API) aggregateSignatures(ctx context.Context, unsignedMessage *warp.Uns
 		return nil, err
 	}
 
-	state := warpValidators.NewState(validatorState, a.chainContext.SubnetID, a.chainContext.ChainID, a.requirePrimaryNetworkSigners())
-	validatorSet, err := warp.GetCanonicalValidatorSetFromSubnetID(ctx, state, pChainHeight, subnetID)
+	validatorSet, err := warp.GetCanonicalValidatorSetFromSubnetID(ctx, validatorState, pChainHeight, subnetID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get validator set: %w", err)
 	}


### PR DESCRIPTION
## Why this should be merged

Currently `warp_getMessageAggregateSignature` and `warp_getBlockAggregateSignature` incorrectly override the `subnetID` twice.

Specifically, the intended behavior is:
- If the `subnetID` is not overridden, use this chain's validator set
  - This is the "normal" case as this chain is sending the message.
- If the `subnetID` is overridden, use the validator set requested by the caller
  - This allows the C-chain's APIs to be used to generate a signature for a subnet which is using their own validator set to verify the message.

This is almost what the logic does currently, but there is a weird edge case. If the `subnetID` is overridden to use the primary network's validator set and this chain has enabled the optimization to use the local validator set for the primary network, then the `subnetID` is overridden for a second time and the chain's validator set will be used.

We should not override the `subnetID` based on this chain's configuration. If the caller overrides the `subnetID`, that override should be honored.

This edge case has likely never been hit, because no one would reasonably override the validator set to the primary network, as that would just make the message more expensive to issue.

## How this works

Removes the second override along with the resulting dead code.

## How this was tested

Existing CI still passes. I think this API is planned on being removed at some point in favor of the standalone relayer implementation, so I didn't add a regression test here.

## Need to be documented?

No.

## Need to update RELEASES.md?

Probably not? I doubt anyone has hit this.