### PR TITLE
chore: remove deprecated genesis types

### DIFF
--- a/core/blockchain_test.go
+++ b/core/blockchain_test.go
@@ -1043,7 +1043,7 @@ func TestEIP3651(t *testing.T) {
 		gspec   = &Genesis{
 			Config:    params.TestChainConfig,
 			Timestamp: uint64(upgrade.InitiallyActiveTime.Unix()),
-			Alloc: GenesisAlloc{
+			Alloc: types.GenesisAlloc{
 				addr1: {Balance: funds},
 				addr2: {Balance: funds},
 				// The address 0xAAAA sloads 0x00 and 0x01

--- a/core/genesis.go
+++ b/core/genesis.go
@@ -59,12 +59,6 @@ import (
 
 var errGenesisNoConfig = errors.New("genesis has no chain configuration")
 
-// Deprecated: use types.Account instead.
-type GenesisAccount = types.Account
-
-// Deprecated: use types.GenesisAlloc instead.
-type GenesisAlloc = types.GenesisAlloc
-
 // Genesis specifies the header fields, state of a genesis block. It also defines hard
 // fork switch-over blocks through the chain configuration.
 type Genesis struct {


### PR DESCRIPTION
## Why this should be merged
These types are explicitly deprecated and just serve as a type alias. 

## How this was tested
Existing UTs

## Need to be documented?
No

## Need to update RELEASES.md?
No
