### PR TITLE
build: use `avalanchego@master` instead of branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           go-version-file: "go.mod"
       - name: Run e2e tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@3f91f67b9b4c0a99e75c572bae7a67334e73a289
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@84e9aebcfbc04602865f4c0a3e8b46a27409a3f5
         with:
           run: ./scripts/run_task.sh test-e2e-ci
           prometheus_url: ${{ secrets.PROMETHEUS_URL || '' }}
@@ -132,7 +132,7 @@ jobs:
           ref: ${{ github.event.inputs.avalanchegoBranch }}
           path: avalanchego
       - name: Run Warp E2E Tests
-        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@3f91f67b9b4c0a99e75c572bae7a67334e73a289
+        uses: ava-labs/avalanchego/.github/actions/run-monitored-tmpnet-cmd@84e9aebcfbc04602865f4c0a3e8b46a27409a3f5
         with:
           run: ./scripts/run_task.sh test-e2e-warp-ci
           artifact_prefix: warp

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.24.7
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1
-	github.com/ava-labs/avalanchego v1.13.6-0.20251002202053-3f91f67b9b4c
+	github.com/ava-labs/avalanchego v1.13.6-0.20251003124629-84e9aebcfbc0
 	github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12
 	github.com/ava-labs/libevm v1.13.15-0.20251002164226-35926db4d661
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
-github.com/ava-labs/avalanchego v1.13.6-0.20251002202053-3f91f67b9b4c h1:8E/BAkU307FEnPlnu7thcirlB0Chu2VK0kEgMV/gFg0=
-github.com/ava-labs/avalanchego v1.13.6-0.20251002202053-3f91f67b9b4c/go.mod h1:rvv45JMX5tKYOvq1kWVq2D7raPpZ96aIg7wsajl+3fU=
+github.com/ava-labs/avalanchego v1.13.6-0.20251003124629-84e9aebcfbc0 h1:B3ti+6P0r7V6BZw5PG7nP7hZ4AJj/1tSsmOOAwnonhs=
+github.com/ava-labs/avalanchego v1.13.6-0.20251003124629-84e9aebcfbc0/go.mod h1:yplWYV/FzAZeYAhy0yOj8wjJA1PCdTPxQf8Wzpwg6DY=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12 h1:aMcrLbpJ/dyu2kZDf/Di/4JIWsUcYPyTDKymiHpejt0=
 github.com/ava-labs/firewood-go-ethhash/ffi v0.0.12/go.mod h1:cq89ua3iiZ5wPBALTEQS5eG8DIZcs7ov6OiL4YR1BVY=
 github.com/ava-labs/libevm v1.13.15-0.20251002164226-35926db4d661 h1:lt4yQE1HMvxWrdD5RFj+h9kWUsZK2rmNohvkeQsbG9M=


### PR DESCRIPTION
## Why this should be merged

We're currently using a commit from a branch, as a temporary workaround to the circular dependency.

## How this works

Bump `avalanchego` version to latest on `master` (i.e. the merge commit of said branch).

## How this was tested

Existing tests.

## Need to be documented?

No

## Need to update RELEASES.md?

No