### PR TITLE
move test helper

### DIFF
--- a/params/extras/extrastest/test_rules.go
+++ b/params/extras/extrastest/test_rules.go
@@ -1,0 +1,19 @@
+package extrastest
+
+import (
+	"fmt"
+
+	"github.com/ava-labs/avalanchego/upgrade/upgradetest"
+	"github.com/ava-labs/coreth/params"
+	"github.com/ava-labs/coreth/params/extras"
+	"github.com/ava-labs/coreth/params/paramstest"
+	"github.com/ava-labs/libevm/common"
+)
+
+func ForkToRules(fork upgradetest.Fork) *extras.Rules {
+	chainConfig, ok := paramstest.ForkToChainConfig[fork]
+	if !ok {
+		panic(fmt.Sprintf("unknown fork: %s", fork))
+	}
+	return params.GetRulesExtra(chainConfig.Rules(common.Big0, params.IsMergeTODO, 0))
+}

--- a/plugin/evm/atomic/vm/export_tx_test.go
+++ b/plugin/evm/atomic/vm/export_tx_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/coreth/core/extstate"
+	"github.com/ava-labs/coreth/params/extras/extrastest"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/coreth/plugin/evm/vmtest"
 	"github.com/ava-labs/coreth/utils"
@@ -862,7 +863,7 @@ func TestExportTxSemanticVerify(t *testing.T) {
 			tx := &atomic.Tx{UnsignedAtomicTx: test.tx}
 			require.NoError(t, tx.Sign(atomic.Codec, test.signers))
 
-			rules := vmtest.ForkToRules(test.fork)
+			rules := extrastest.ForkToRules(test.fork)
 			backend := NewVerifierBackend(vm, *rules)
 
 			err := backend.SemanticVerify(tx, parent, vmtest.InitialBaseFee)
@@ -1053,7 +1054,7 @@ func TestExportTxVerify(t *testing.T) {
 				return (*atomic.UnsignedExportTx)(nil)
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrNilTx.Error(),
 		},
 		"valid export tx": {
@@ -1061,7 +1062,7 @@ func TestExportTxVerify(t *testing.T) {
 				return exportTx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "",
 		},
 		"valid export tx banff": {
@@ -1069,7 +1070,7 @@ func TestExportTxVerify(t *testing.T) {
 				return exportTx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: "",
 		},
 		"incorrect networkID": {
@@ -1079,7 +1080,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongNetworkID.Error(),
 		},
 		"incorrect blockchainID": {
@@ -1089,7 +1090,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongChainID.Error(),
 		},
 		"incorrect destination chain": {
@@ -1099,7 +1100,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongChainID.Error(), // TODO make this error more specific to destination not just chainID
 		},
 		"no exported outputs": {
@@ -1109,7 +1110,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrNoExportOutputs.Error(),
 		},
 		"unsorted outputs": {
@@ -1122,7 +1123,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrOutputsNotSorted.Error(),
 		},
 		"invalid exported output": {
@@ -1132,7 +1133,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "nil transferable output is not valid",
 		},
 		"unsorted EVM inputs before AP1": {
@@ -1145,7 +1146,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "",
 		},
 		"unsorted EVM inputs after AP1": {
@@ -1158,7 +1159,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase1),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase1),
 			expectedErr: atomic.ErrInputsNotSortedUnique.Error(),
 		},
 		"EVM input with amount 0": {
@@ -1175,7 +1176,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrNoValueInput.Error(),
 		},
 		"non-unique EVM input before AP1": {
@@ -1185,7 +1186,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "",
 		},
 		"non-unique EVM input after AP1": {
@@ -1195,7 +1196,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase1),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase1),
 			expectedErr: atomic.ErrInputsNotSortedUnique.Error(),
 		},
 		"non-AVAX input Apricot Phase 6": {
@@ -1212,7 +1213,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase6),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase6),
 			expectedErr: "",
 		},
 		"non-AVAX output Apricot Phase 6": {
@@ -1234,7 +1235,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase6),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase6),
 			expectedErr: "",
 		},
 		"non-AVAX input Banff": {
@@ -1251,7 +1252,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: atomic.ErrExportNonAVAXInputBanff.Error(),
 		},
 		"non-AVAX output Banff": {
@@ -1273,7 +1274,7 @@ func TestExportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: atomic.ErrExportNonAVAXOutputBanff.Error(),
 		},
 	}

--- a/plugin/evm/atomic/vm/import_tx_test.go
+++ b/plugin/evm/atomic/vm/import_tx_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/ava-labs/coreth/core/extstate"
+	"github.com/ava-labs/coreth/params/extras/extrastest"
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap0"
 	"github.com/ava-labs/coreth/plugin/evm/vmtest"
@@ -132,7 +133,7 @@ func TestImportTxVerify(t *testing.T) {
 				return importTx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrNilTx.Error(),
 		},
 		"valid import tx": {
@@ -140,7 +141,7 @@ func TestImportTxVerify(t *testing.T) {
 				return importTx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "", // Expect this transaction to be valid in Apricot Phase 0
 		},
 		"valid import tx banff": {
@@ -148,7 +149,7 @@ func TestImportTxVerify(t *testing.T) {
 				return importTx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: "", // Expect this transaction to be valid in Banff
 		},
 		"invalid network ID": {
@@ -158,7 +159,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongNetworkID.Error(),
 		},
 		"invalid blockchain ID": {
@@ -168,7 +169,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongChainID.Error(),
 		},
 		"P-chain source before AP5": {
@@ -178,7 +179,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrWrongChainID.Error(),
 		},
 		"P-chain source after AP5": {
@@ -188,7 +189,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:   ctx,
-			rules: vmtest.ForkToRules(upgradetest.ApricotPhase5),
+			rules: extrastest.ForkToRules(upgradetest.ApricotPhase5),
 		},
 		"invalid source chain ID": {
 			generate: func() atomic.UnsignedAtomicTx {
@@ -197,7 +198,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase5),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase5),
 			expectedErr: atomic.ErrWrongChainID.Error(),
 		},
 		"no inputs": {
@@ -207,7 +208,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrNoImportInputs.Error(),
 		},
 		"inputs sorted incorrectly": {
@@ -220,7 +221,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: atomic.ErrInputsNotSortedUnique.Error(),
 		},
 		"invalid input": {
@@ -233,7 +234,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "atomic input failed verification",
 		},
 		"unsorted outputs phase 0 passes verification": {
@@ -246,7 +247,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "",
 		},
 		"non-unique outputs phase 0 passes verification": {
@@ -259,7 +260,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "",
 		},
 		"unsorted outputs phase 1 fails verification": {
@@ -272,7 +273,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase1),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase1),
 			expectedErr: atomic.ErrOutputsNotSorted.Error(),
 		},
 		"non-unique outputs phase 1 passes verification": {
@@ -285,7 +286,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase1),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase1),
 			expectedErr: "",
 		},
 		"outputs not sorted and unique phase 2 fails verification": {
@@ -298,7 +299,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase2),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase2),
 			expectedErr: atomic.ErrOutputsNotSortedUnique.Error(),
 		},
 		"outputs not sorted phase 2 fails verification": {
@@ -311,7 +312,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase2),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase2),
 			expectedErr: atomic.ErrOutputsNotSortedUnique.Error(),
 		},
 		"invalid EVMOutput fails verification": {
@@ -327,7 +328,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.NoUpgrades),
+			rules:       extrastest.ForkToRules(upgradetest.NoUpgrades),
 			expectedErr: "EVM Output failed verification",
 		},
 		"no outputs apricot phase 3": {
@@ -337,7 +338,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase3),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase3),
 			expectedErr: atomic.ErrNoEVMOutputs.Error(),
 		},
 		"non-AVAX input Apricot Phase 6": {
@@ -361,7 +362,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase6),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase6),
 			expectedErr: "",
 		},
 		"non-AVAX output Apricot Phase 6": {
@@ -377,7 +378,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.ApricotPhase6),
+			rules:       extrastest.ForkToRules(upgradetest.ApricotPhase6),
 			expectedErr: "",
 		},
 		"non-AVAX input Banff": {
@@ -401,7 +402,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: atomic.ErrImportNonAVAXInputBanff.Error(),
 		},
 		"non-AVAX output Banff": {
@@ -417,7 +418,7 @@ func TestImportTxVerify(t *testing.T) {
 				return &tx
 			},
 			ctx:         ctx,
-			rules:       vmtest.ForkToRules(upgradetest.Banff),
+			rules:       extrastest.ForkToRules(upgradetest.Banff),
 			expectedErr: atomic.ErrImportNonAVAXOutputBanff.Error(),
 		},
 	}

--- a/plugin/evm/vmtest/genesis.go
+++ b/plugin/evm/vmtest/genesis.go
@@ -4,7 +4,6 @@ package vmtest
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -21,7 +20,6 @@ import (
 
 	"github.com/ava-labs/coreth/core"
 	"github.com/ava-labs/coreth/params"
-	"github.com/ava-labs/coreth/params/extras"
 	"github.com/ava-labs/coreth/params/paramstest"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap3"
 
@@ -126,12 +124,4 @@ func SetupGenesis(
 	prefixedDB := prefixdb.New([]byte{1}, baseDB)
 	genesisJSON := GenesisJSON(paramstest.ForkToChainConfig[fork])
 	return ctx, prefixedDB, []byte(genesisJSON), atomicMemory
-}
-
-func ForkToRules(fork upgradetest.Fork) *extras.Rules {
-	chainConfig, ok := paramstest.ForkToChainConfig[fork]
-	if !ok {
-		panic(fmt.Sprintf("unknown fork: %s", fork))
-	}
-	return params.GetRulesExtra(chainConfig.Rules(common.Big0, params.IsMergeTODO, 0))
 }


### PR DESCRIPTION
## Why this should be merged

This should belong to `extrastest` so it can be used in other packages.

## How this works

Moves the helper to new `extrastest` package

## How this was tested

UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
