### PR TITLE
remove unused GetChainConfig from the precompile interface

### DIFF
--- a/params/hooks_libevm.go
+++ b/params/hooks_libevm.go
@@ -191,10 +191,6 @@ func (a accessibleState) GetBlockContext() contract.BlockContext {
 	return a.blockContext
 }
 
-func (a accessibleState) GetChainConfig() precompileconfig.ChainConfig {
-	return GetExtra(a.env.ChainConfig())
-}
-
 func (a accessibleState) GetRules() precompileconfig.Rules {
 	chainConfigExtra := GetExtra(a.GetPrecompileEnv().ChainConfig())
 	return chainConfigExtra.GetAvalancheRules(a.GetBlockContext().Timestamp())

--- a/precompile/contract/interfaces.go
+++ b/precompile/contract/interfaces.go
@@ -58,7 +58,6 @@ type AccessibleState interface {
 	GetStateDB() StateDB
 	GetBlockContext() BlockContext
 	GetSnowContext() *snow.Context
-	GetChainConfig() precompileconfig.ChainConfig
 	GetPrecompileEnv() vm.PrecompileEnvironment
 	GetRules() precompileconfig.Rules
 }

--- a/precompile/contract/mocks.go
+++ b/precompile/contract/mocks.go
@@ -320,20 +320,6 @@ func (mr *MockAccessibleStateMockRecorder) GetBlockContext() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockContext", reflect.TypeOf((*MockAccessibleState)(nil).GetBlockContext))
 }
 
-// GetChainConfig mocks base method.
-func (m *MockAccessibleState) GetChainConfig() precompileconfig.ChainConfig {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetChainConfig")
-	ret0, _ := ret[0].(precompileconfig.ChainConfig)
-	return ret0
-}
-
-// GetChainConfig indicates an expected call of GetChainConfig.
-func (mr *MockAccessibleStateMockRecorder) GetChainConfig() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetChainConfig", reflect.TypeOf((*MockAccessibleState)(nil).GetChainConfig))
-}
-
 // GetPrecompileEnv mocks base method.
 func (m *MockAccessibleState) GetPrecompileEnv() vm.PrecompileEnvironment {
 	m.ctrl.T.Helper()

--- a/precompile/precompiletest/test_precompile.go
+++ b/precompile/precompiletest/test_precompile.go
@@ -116,7 +116,6 @@ func (test PrecompileTest) setup(t testing.TB, module modules.Module, state *tes
 	accessibleState.EXPECT().GetStateDB().Return(state).AnyTimes()
 	accessibleState.EXPECT().GetBlockContext().Return(blockContext).AnyTimes()
 	accessibleState.EXPECT().GetSnowContext().Return(snowContext).AnyTimes()
-	accessibleState.EXPECT().GetChainConfig().Return(chainConfig).AnyTimes()
 	accessibleState.EXPECT().GetRules().Return(test.Rules).AnyTimes()
 
 	if test.Config != nil {


### PR DESCRIPTION
## Why this should be merged

After addition of `GetRules` in accessible state ([here](https://github.com/ava-labs/coreth/pull/1306)) we no longer require `GetChainConfig` as we can directly pass the rules. It's not used even in Coreth, but Subnet-EVM. In both repos we should no longer require this and use `GetRules` instead 

## How this works

removes unused interface function

## How this was tested

existing tests

## Need to be documented?

no
## Need to update RELEASES.md?

 no
