### PR TITLE
ci: Fix flakes file

### DIFF
--- a/scripts/known_flakes.txt
+++ b/scripts/known_flakes.txt
@@ -1,4 +1,5 @@
 TestClientCancelWebsocket
+TestClientWebsocketLargeMessage
 TestGolangBindings
 TestMempoolAtmTxsAppGossipHandlingDiscardedTx
 TestMempoolEthTxsAppGossipHandling
@@ -7,5 +8,4 @@ TestResyncNewRootAfterDeletes
 TestTransactionSkipIndexing
 TestUpdatedKeyfileContents
 TestWaitDeployedCornerCases
-TestClientWebsocketLargeMessage
 TestWebsocketLargeRead


### PR DESCRIPTION
## Why this should be merged

This is used by `comm`, which expects the file to be sorted. Otherwise, when a test fails, you get something like this:

```
FAIL
comm: file 2 is not in sorted order
comm: input is not in sorted order
```

## How this works

Alphabet

## How this was tested

Wasn't tested

## Need to be documented?

No

## Need to update RELEASES.md?

No