### PR TITLE
fix: one missing time

### DIFF
--- a/core/txpool/blobpool/blobpool.go
+++ b/core/txpool/blobpool/blobpool.go
@@ -845,7 +845,7 @@ func (p *BlobPool) Reset(oldHead, newHead *types.Header) {
 	baseFeeBig, err := customheader.EstimateNextBaseFee(
 		params.GetExtra(p.chain.Config()),
 		p.head,
-		uint64(time.Now().Unix()),
+		uint64(time.Now().UnixMilli()),
 	)
 	if err != nil {
 		log.Error("Failed to estimate next base fee to reset blobpool fees", "err", err)


### PR DESCRIPTION
## Why this should be merged

One instance still used unix seconds. This updates it to seconds. See ava-labs/subnet-evm#1804

## How this works

Millisecond timestamps

## How this was tested

Existing UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
