### PR TITLE
Remove `libevm/psuedo` import

### DIFF
--- a/plugin/evm/customtypes/state_account_ext.go
+++ b/plugin/evm/customtypes/state_account_ext.go
@@ -1,8 +1,9 @@
+// Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
+// See the file LICENSE for licensing terms.
+
 package customtypes
 
-import (
-	ethtypes "github.com/ava-labs/libevm/core/types"
-)
+import ethtypes "github.com/ava-labs/libevm/core/types"
 
 type isMultiCoin bool
 


### PR DESCRIPTION
## Why this should be merged
This libevm import is not allowed and should not be used. 

## How this was tested
Existing UT

## Need to be documented?
No

## Need to update RELEASES.md?
No
