### PR TITLE
deps: bump go to version `1.24.9` 

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@
   - Add `minDelayExcess` (uint64) to block header for Granite upgrade.
   - Add minimum block building delays to conform the block builder to ACP-226 requirements.
   - Add minimum delay verification.
-- Update go version to 1.24.8
+- Update go version to 1.24.9
 
 ## [v0.15.3](https://github.com/ava-labs/coreth/releases/tag/v0.15.3)
 

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ module github.com/ava-labs/coreth
 //
 // - If updating between minor versions (e.g. 1.24.x -> 1.25.x):
 //   - Consider updating the version of golangci-lint (see tools/go.mod)
-go 1.24.8
+go 1.24.9
 
 require (
 	github.com/VictoriaMetrics/fastcache v1.12.1

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ava-labs/coreth/tools
 
-go 1.24.8
+go 1.24.9
 
 tool (
 	github.com/fjl/gencodec

--- a/tools/legacy-golangci-lint.mod
+++ b/tools/legacy-golangci-lint.mod
@@ -11,7 +11,7 @@ module github.com/ava-labs/coreth/tools/legacy-golangci-lint
 // go tool -modfile=tools/legacy-golangci-lint.mod golangci-lint [args]
 //
 
-go 1.24.8
+go 1.24.9
 
 tool github.com/golangci/golangci-lint/cmd/golangci-lint
 


### PR DESCRIPTION
## Why this should be merged
This resolves security vulnerabilities present in go 1.24.8