### PR TITLE
test: Skip rpc tests that timeout

### DIFF
--- a/rpc/websocket_test.go
+++ b/rpc/websocket_test.go
@@ -132,7 +132,7 @@ func TestWebsocketLargeCall(t *testing.T) {
 // This test times out occasionally due to context timeout differences with go-ethereum.
 // These differences are not critical, so this test can simply be skipped.
 func TestWebsocketLargeRead(t *testing.T) {
-	t.SkipNow()
+	t.Skip("Flaky")
 
 	var (
 		srv     = newTestServer()


### PR DESCRIPTION
## Why this should be merged

This test often times out and panics, causing CI to fail. There is no considerable difference from ethereum in the production code, and the test is the same.

Closes #1382

## How this works

Calls `t.SkipNow()` to avoid execution

## How this was tested

Existing UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
