### PR TITLE
test: run sync tests in parallel

### DIFF
--- a/sync/blocksync/syncer_test.go
+++ b/sync/blocksync/syncer_test.go
@@ -109,6 +109,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			env := newTestEnvironment(t, tt.numBlocks)
 			require.NoError(t, env.prePopulateBlocks(tt.prePopulateBlocks))
 
@@ -128,6 +129,7 @@ func TestBlockSyncer_ParameterizedTests(t *testing.T) {
 }
 
 func TestBlockSyncer_ContextCancellation(t *testing.T) {
+	t.Parallel()
 	env := newTestEnvironment(t, 10)
 	syncer, err := env.createSyncer(5, 3)
 	require.NoError(t, err)

--- a/sync/handlers/block_request_test.go
+++ b/sync/handlers/block_request_test.go
@@ -151,6 +151,7 @@ func TestBlockRequestHandler(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			executeBlockRequestTest(t, test, blocks)
 		})
 	}
@@ -208,12 +209,14 @@ func TestBlockRequestHandlerLargeBlocks(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
 			executeBlockRequestTest(t, test, blocks)
 		})
 	}
 }
 
 func TestBlockRequestHandlerCtxExpires(t *testing.T) {
+	t.Parallel()
 	gspec := &core.Genesis{
 		Config: params.TestChainConfig,
 	}

--- a/sync/statesync/code_queue_test.go
+++ b/sync/statesync/code_queue_test.go
@@ -78,6 +78,7 @@ func TestCodeQueue(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			defer goleak.VerifyNone(t, goleak.IgnoreCurrent())
 
 			db := rawdb.NewMemoryDatabase()

--- a/sync/statesync/code_syncer_test.go
+++ b/sync/statesync/code_syncer_test.go
@@ -96,6 +96,7 @@ func testCodeSyncer(t *testing.T, test codeSyncerTest) {
 }
 
 func TestCodeSyncerSingleCodeHash(t *testing.T) {
+	t.Parallel()
 	codeBytes := utils.RandomBytes(100)
 	codeHash := crypto.Keccak256Hash(codeBytes)
 	testCodeSyncer(t, codeSyncerTest{
@@ -105,6 +106,7 @@ func TestCodeSyncerSingleCodeHash(t *testing.T) {
 }
 
 func TestCodeSyncerManyCodeHashes(t *testing.T) {
+	t.Parallel()
 	numCodeSlices := 5000
 	codeHashes := make([]common.Hash, 0, numCodeSlices)
 	codeByteSlices := make([][]byte, 0, numCodeSlices)
@@ -123,6 +125,7 @@ func TestCodeSyncerManyCodeHashes(t *testing.T) {
 }
 
 func TestCodeSyncerRequestErrors(t *testing.T) {
+	t.Parallel()
 	codeBytes := utils.RandomBytes(100)
 	codeHash := crypto.Keccak256Hash(codeBytes)
 	err := errors.New("dummy error")
@@ -137,6 +140,7 @@ func TestCodeSyncerRequestErrors(t *testing.T) {
 }
 
 func TestCodeSyncerAddsInProgressCodeHashes(t *testing.T) {
+	t.Parallel()
 	codeBytes := utils.RandomBytes(100)
 	codeHash := crypto.Keccak256Hash(codeBytes)
 	clientDB := rawdb.NewMemoryDatabase()
@@ -149,6 +153,7 @@ func TestCodeSyncerAddsInProgressCodeHashes(t *testing.T) {
 }
 
 func TestCodeSyncerAddsMoreInProgressThanQueueSize(t *testing.T) {
+	t.Parallel()
 	numCodeSlices := 100
 	codeHashes := make([]common.Hash, 0, numCodeSlices)
 	codeByteSlices := make([][]byte, 0, numCodeSlices)

--- a/sync/statesync/sync_test.go
+++ b/sync/statesync/sync_test.go
@@ -194,12 +194,14 @@ func TestSimpleSyncCases(t *testing.T) {
 	}
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			testSync(t, test)
 		})
 	}
 }
 
 func TestCancelSync(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -243,6 +245,7 @@ func (i *interruptLeafsIntercept) getLeafsIntercept(request message.LeafsRequest
 }
 
 func TestResumeSyncAccountsTrieInterrupted(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -270,6 +273,7 @@ func TestResumeSyncAccountsTrieInterrupted(t *testing.T) {
 }
 
 func TestResumeSyncLargeStorageTrieInterrupted(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -303,6 +307,7 @@ func TestResumeSyncLargeStorageTrieInterrupted(t *testing.T) {
 }
 
 func TestResumeSyncToNewRootAfterLargeStorageTrieInterrupted(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -345,6 +350,7 @@ func TestResumeSyncToNewRootAfterLargeStorageTrieInterrupted(t *testing.T) {
 }
 
 func TestResumeSyncLargeStorageTrieWithConsecutiveDuplicatesInterrupted(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -378,6 +384,7 @@ func TestResumeSyncLargeStorageTrieWithConsecutiveDuplicatesInterrupted(t *testi
 }
 
 func TestResumeSyncLargeStorageTrieWithSpreadOutDuplicatesInterrupted(t *testing.T) {
+	t.Parallel()
 	r := rand.New(rand.NewSource(1))
 	serverDB := rawdb.NewMemoryDatabase()
 	serverTrieDB := triedb.NewDatabase(serverDB, nil)
@@ -473,6 +480,7 @@ func TestResyncNewRootAfterDeletes(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
+			t.Parallel()
 			testSyncerSyncsToNewRoot(t, test.deleteBetweenSyncs)
 		})
 	}


### PR DESCRIPTION
## Why this should be merged

The timeout in avalanchego for tests is much lower, so we should be more efficient in using runtime to prevent timeouts. These sync tests take a long time, and running them in parallel should be expected.

## How this works

Run tests in parallel. There's some test helpers that need to be re-instantiated or reset after each test, so these tests could be further improved. However, as this code will soon be deprecated, it's likely not helpful.

## How this was tested

Existing UT

## Need to be documented?

No

## Need to update RELEASES.md?

No
