### PR TITLE
ci: Missing test import lint

### DIFF
--- a/plugin/evm/atomic/vm/tx_gossip_test.go
+++ b/plugin/evm/atomic/vm/tx_gossip_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/atomic"
 	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/coreth/plugin/evm/vmtest"
-	"github.com/ava-labs/coreth/utils"
 	"github.com/ava-labs/coreth/utils/utilstest"
 
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
@@ -45,7 +44,7 @@ func TestAtomicTxGossip(t *testing.T) {
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	snowCtx.AVAXAssetID = ids.GenerateTestID()
-	validatorState := utils.NewTestValidatorState()
+	validatorState := utilstest.NewTestValidatorState()
 	snowCtx.ValidatorState = validatorState
 	memory := avalancheatomic.NewMemory(memdb.New())
 	snowCtx.SharedMemory = memory.NewSharedMemory(snowCtx.ChainID)
@@ -195,7 +194,7 @@ func TestAtomicTxPushGossipOutbound(t *testing.T) {
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	snowCtx.AVAXAssetID = ids.GenerateTestID()
-	validatorState := utils.NewTestValidatorState()
+	validatorState := utilstest.NewTestValidatorState()
 	snowCtx.ValidatorState = validatorState
 	memory := avalancheatomic.NewMemory(memdb.New())
 	snowCtx.SharedMemory = memory.NewSharedMemory(snowCtx.ChainID)
@@ -265,7 +264,7 @@ func TestAtomicTxPushGossipInboundValid(t *testing.T) {
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
 	snowCtx.AVAXAssetID = ids.GenerateTestID()
-	validatorState := utils.NewTestValidatorState()
+	validatorState := utilstest.NewTestValidatorState()
 	snowCtx.ValidatorState = validatorState
 	memory := avalancheatomic.NewMemory(memdb.New())
 	snowCtx.SharedMemory = memory.NewSharedMemory(snowCtx.ChainID)

--- a/plugin/evm/tx_gossip_test.go
+++ b/plugin/evm/tx_gossip_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/config"
 	"github.com/ava-labs/coreth/plugin/evm/upgrade/ap0"
 	"github.com/ava-labs/coreth/plugin/evm/vmtest"
-	"github.com/ava-labs/coreth/utils"
+	"github.com/ava-labs/coreth/utils/utilstest"
 
 	agoUtils "github.com/ava-labs/avalanchego/utils"
 )
@@ -40,7 +40,7 @@ func TestEthTxGossip(t *testing.T) {
 	require := require.New(t)
 	ctx := t.Context()
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
-	validatorState := utils.NewTestValidatorState()
+	validatorState := utilstest.NewTestValidatorState()
 	snowCtx.ValidatorState = validatorState
 
 	pk, err := secp256k1.NewPrivateKey()

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -119,8 +119,8 @@ function test_import_testing_only_in_tests {
 
   IMPORT_TESTING=$(echo "${NON_TEST_GO_FILES}" | xargs grep -lP '^\s*(import\s+)?"testing"')
   IMPORT_TESTIFY=$(echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/stretchr/testify')
-  IMPORT_FROM_TESTS=$(echo "${NON_TEST_GO_FILES}" | xargs grep -l '"github.com/ava-labs/coreth/tests/')
-  IMPORT_TEST_PKG=$(echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/coreth/.*?test"')
+  IMPORT_FROM_TESTS=$(echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/(?:avalanchego|coreth)/tests/')
+  IMPORT_TEST_PKG=$(echo "${NON_TEST_GO_FILES}" | xargs grep -lP '"github.com/ava-labs/(?:avalanchego|coreth)/.*?test"')
 
   # TODO(arr4n): send a PR to add support for build tags in `mockgen` and then enable this.
   # IMPORT_GOMOCK=$( echo "${NON_TEST_GO_FILES}" | xargs grep -l '"go.uber.org/mock');

--- a/utils/utilstest/snow.go
+++ b/utils/utilstest/snow.go
@@ -1,7 +1,7 @@
 // Copyright (C) 2019-2025, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
-package utils
+package utilstest
 
 import (
 	"context"


### PR DESCRIPTION
## Why this should be merged

When I was migrating the linters for a monorepo, I noticed a small test import mistake.

## How this works

Disallows avalanchego testing imports in non-test packages

## How this was tested

CI

## Need to be documented?

No

## Need to update RELEASES.md?

No
