### PR TITLE
refactor(test): replace custom test context helper with standard context pattern

### DIFF
--- a/plugin/evm/atomic/vm/tx_gossip_test.go
+++ b/plugin/evm/atomic/vm/tx_gossip_test.go
@@ -39,7 +39,7 @@ import (
 
 func TestAtomicTxGossip(t *testing.T) {
 	require := require.New(t)
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
@@ -189,7 +189,7 @@ func TestAtomicTxGossip(t *testing.T) {
 // Tests that a tx is gossiped when it is issued
 func TestAtomicTxPushGossipOutbound(t *testing.T) {
 	require := require.New(t)
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)
@@ -259,7 +259,7 @@ func TestAtomicTxPushGossipOutbound(t *testing.T) {
 // Tests that a tx is gossiped when it is issued and valid
 func TestAtomicTxPushGossipInboundValid(t *testing.T) {
 	require := require.New(t)
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	snowCtx := snowtest.Context(t, snowtest.CChainID)

--- a/plugin/evm/vmsync/registry_test.go
+++ b/plugin/evm/vmsync/registry_test.go
@@ -175,7 +175,7 @@ func TestSyncerRegistry_RunSyncerTasks(t *testing.T) {
 				require.NoError(t, registry.Register(mockSyncer))
 			}
 
-			ctx, cancel := utilstest.NewTestContext(t)
+			ctx, cancel := context.WithCancel(t.Context())
 			t.Cleanup(cancel)
 
 			err := registry.RunSyncerTasks(ctx, newTestClientSummary(t))
@@ -193,7 +193,7 @@ func TestSyncerRegistry_ConcurrentStart(t *testing.T) {
 
 	registry := NewSyncerRegistry()
 
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	const numBarrierSyncers = 5
@@ -223,7 +223,7 @@ func TestSyncerRegistry_ErrorPropagatesAndCancelsOthers(t *testing.T) {
 
 	registry := NewSyncerRegistry()
 
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	// Error syncer
@@ -268,7 +268,7 @@ func TestSyncerRegistry_FirstErrorWinsAcrossMany(t *testing.T) {
 
 	registry := NewSyncerRegistry()
 
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	const numErrorSyncers = 3
@@ -301,7 +301,7 @@ func TestSyncerRegistry_NoSyncersRegistered(t *testing.T) {
 	t.Parallel()
 
 	registry := NewSyncerRegistry()
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	require.NoError(t, registry.RunSyncerTasks(ctx, newTestClientSummary(t)))

--- a/plugin/evm/vmtest/test_vm.go
+++ b/plugin/evm/vmtest/test_vm.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/extension"
-	"github.com/ava-labs/coreth/utils/utilstest"
 
 	avalancheatomic "github.com/ava-labs/avalanchego/chains/atomic"
 	commoneng "github.com/ava-labs/avalanchego/snow/engine/common"
@@ -74,7 +73,7 @@ func SetupTestVM(t *testing.T, vm commoneng.VM, config TestVMConfig) *TestVMSuit
 	configJSON, err := OverrideSchemeConfig(scheme, config.ConfigJSON)
 	require.NoError(t, err)
 
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
 
 	err = vm.Initialize(

--- a/sync/statesync/code_syncer_test.go
+++ b/sync/statesync/code_syncer_test.go
@@ -4,6 +4,7 @@
 package statesync
 
 import (
+	"context"
 	"errors"
 	"testing"
 
@@ -18,7 +19,6 @@ import (
 	"github.com/ava-labs/coreth/plugin/evm/customrawdb"
 	"github.com/ava-labs/coreth/plugin/evm/message"
 	"github.com/ava-labs/coreth/sync/handlers"
-	"github.com/ava-labs/coreth/utils/utilstest"
 
 	statesyncclient "github.com/ava-labs/coreth/sync/client"
 	handlerstats "github.com/ava-labs/coreth/sync/handlers/stats"
@@ -78,7 +78,7 @@ func testCodeSyncer(t *testing.T, test codeSyncerTest) {
 		}
 	}()
 
-	ctx, cancel := utilstest.NewTestContext(t)
+	ctx, cancel := context.WithCancel(t.Context())
 	t.Cleanup(cancel)
 
 	// Run the sync and handle expected error.

--- a/utils/utilstest/context.go
+++ b/utils/utilstest/context.go
@@ -12,14 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func NewTestContext(t *testing.T) (context.Context, context.CancelFunc) {
-	t.Helper()
-	if d, ok := t.Deadline(); ok {
-		return context.WithDeadline(t.Context(), d)
-	}
-	return context.WithTimeout(t.Context(), 30*time.Second)
-}
-
 func WaitGroupWithContext(t *testing.T, ctx context.Context, wg *sync.WaitGroup) {
 	t.Helper()
 	done := make(chan struct{})


### PR DESCRIPTION
## Why this should be merged

## How this works

Remove `NewTestContext` helper function from `utilstest` package and replace all usages with the standard `context.WithCancel(t.Context())` pattern.

This simplifies test code by using the built-in `testing.T` context directly instead of wrapping it with custom timeout/deadline logic.

## How this was tested

existing UT

## Need to be documented?
no

## Need to update RELEASES.md?
no

resolves #1412

Signed-off-by: Tsvetan Dimitrov (tsvetan.dimitrov23@gmail.com)