### PR TITLE
docs: add archival note

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
-# Coreth and the C-Chain
-
-## THIS REPOSITORY HAS MOVED
+# THIS REPOSITORY HAS MOVED
 
 > **⚠️ WARNING: Do not depend on this repository. It has been deprecated.**
 
 Coreth has been moved entirely to the [AvalancheGo](https://github.com/ava-labs/avalanchego/tree/master/graft/coreth), and this repository is no longer under active development. To open issues, pull requests, and discussions, do so in [AvalancheGo](https://github.com/ava-labs/avalanchego). For the latest releases, see the [AvalancheGo release page](https://github.com/ava-labs/avalanchego/releases).
 
-----
+# Coreth and the C-Chain
 
 [Avalanche](https://www.avax.network/) is a network composed of multiple blockchains.
 Each blockchain is an instance of a Virtual Machine (VM), much like an object in an object-oriented language is an instance of a class.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,13 @@
 # Coreth and the C-Chain
 
+## THIS REPOSITORY HAS MOVED
+
+> **⚠️ WARNING: Do not depend on this repository. It has been archived.**
+
+Coreth has been moved entirely to the [AvalancheGo](https://github.com/ava-labs/avalanchego/tree/master/graft/coreth), and this repository is no longer under active development. To open issues, pull requests, and discussions, do so in [AvalancheGo](https://github.com/ava-labs/avalanchego). For the latest releases, see the [AvalancheGo release page](https://github.com/ava-labs/avalanchego).
+
+----
+
 [Avalanche](https://www.avax.network/) is a network composed of multiple blockchains.
 Each blockchain is an instance of a Virtual Machine (VM), much like an object in an object-oriented language is an instance of a class.
 That is, the VM defines the behavior of the blockchain.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 > **⚠️ WARNING: Do not depend on this repository. It has been archived.**
 
-Coreth has been moved entirely to the [AvalancheGo](https://github.com/ava-labs/avalanchego/tree/master/graft/coreth), and this repository is no longer under active development. To open issues, pull requests, and discussions, do so in [AvalancheGo](https://github.com/ava-labs/avalanchego). For the latest releases, see the [AvalancheGo release page](https://github.com/ava-labs/avalanchego).
+Coreth has been moved entirely to the [AvalancheGo](https://github.com/ava-labs/avalanchego/tree/master/graft/coreth), and this repository is no longer under active development. To open issues, pull requests, and discussions, do so in [AvalancheGo](https://github.com/ava-labs/avalanchego). For the latest releases, see the [AvalancheGo release page](https://github.com/ava-labs/avalanchego/releases).
 
 ----
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## THIS REPOSITORY HAS MOVED
 
-> **⚠️ WARNING: Do not depend on this repository. It has been archived.**
+> **⚠️ WARNING: Do not depend on this repository. It has been deprecated.**
 
 Coreth has been moved entirely to the [AvalancheGo](https://github.com/ava-labs/avalanchego/tree/master/graft/coreth), and this repository is no longer under active development. To open issues, pull requests, and discussions, do so in [AvalancheGo](https://github.com/ava-labs/avalanchego). For the latest releases, see the [AvalancheGo release page](https://github.com/ava-labs/avalanchego/releases).
 


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->
## Why this should be merged

This should be the last PR merged into coreth, to redirect users to the new location in AvalancheGo. 

